### PR TITLE
Add ThresholdAct option to MSBuild task

### DIFF
--- a/Documentation/MSBuildIntegration.md
+++ b/Documentation/MSBuildIntegration.md
@@ -105,12 +105,12 @@ The following command will compare the threshold value with the overall total co
 dotnet test /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line /p:ThresholdStat=total
 ```
 
-You can also specify what action to take when the the coverage is below the threshold value using the `/p:ThresholdAct` option. the accepted values are:
+You can also specify what action to take when the the coverage is below the threshold value using the `/p:ThresholdAct` option. The accepted values are:
 
 * `fail`: which fails the build and is the default option
-* `warning`: which will not stop the build and only gives warning
+* `warning`: which will not stop the build and only gives a warning console message
 
-The following will give give a warning (but let's the build to continue) when the threshold value is below 80:
+The following will give a warning (but let's the build to continue) when the threshold value is below 80:
 
 ```bash
 dotnet test /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdAct=warning

--- a/Documentation/MSBuildIntegration.md
+++ b/Documentation/MSBuildIntegration.md
@@ -105,6 +105,17 @@ The following command will compare the threshold value with the overall total co
 dotnet test /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line /p:ThresholdStat=total
 ```
 
+You can also specify what action to take when the the coverage is below the threshold value using the `/p:ThresholdAct` option. the accepted values are:
+
+* `fail`: which fails the build and is the default option
+* `warning`: which will not stop the build and only gives warning
+
+The following will give give a warning (but let's the build to continue) when the threshold value is below 80:
+
+```bash
+dotnet test /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdAct=warning
+```
+
 ## Excluding From Coverage
 
 ### Attributes

--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -205,10 +205,10 @@ namespace Coverlet.Console
                 {
                     exitCode += (int)CommandExitCodes.TestFailed;
                 }
+
                 thresholdTypeFlags = result.GetThresholdTypesBelowThreshold(summary, dThreshold, thresholdTypeFlags, dThresholdStat);
                 if (thresholdTypeFlags != ThresholdTypeFlags.None)
                 {
-                    exitCode += (int)CommandExitCodes.CoverageBelowThreshold;
                     var exceptionMessageBuilder = new StringBuilder();
                     if ((thresholdTypeFlags & ThresholdTypeFlags.Line) != ThresholdTypeFlags.None)
                     {
@@ -225,12 +225,16 @@ namespace Coverlet.Console
                         exceptionMessageBuilder.AppendLine($"The {dThresholdStat.ToString().ToLower()} method coverage is below the specified {dThreshold}");
                     }
 
-                    if (dThresholdAct == ThresholdAction.Fail)
+                    switch (dThresholdAct)
                     {
-                        throw new Exception(exceptionMessageBuilder.ToString());
+                        case ThresholdAction.Warning:
+                            logger.LogWarning(exceptionMessageBuilder.ToString());
+                            break;
+                        case ThresholdAction.Fail:
+                        default:
+                            exitCode += (int)CommandExitCodes.CoverageBelowThreshold;
+                            throw new Exception(exceptionMessageBuilder.ToString());
                     }
-
-                    logger.LogWarning(exceptionMessageBuilder.ToString());
                 }
 
                 return exitCode;

--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -37,6 +37,7 @@ namespace Coverlet.Console
             CommandOption threshold = app.Option("--threshold", "Exits with error if the coverage % is below value.", CommandOptionType.SingleValue);
             CommandOption thresholdTypes = app.Option("--threshold-type", "Coverage type to apply the threshold to.", CommandOptionType.MultipleValue);
             CommandOption thresholdStat = app.Option("--threshold-stat", "Coverage statistic used to enforce the threshold value.", CommandOptionType.SingleValue);
+            CommandOption thresholdAct = app.Option("--threshold-act", "The action to take when coverage is below the threshold value. Defaults to fail the build", CommandOptionType.SingleValue);
             CommandOption excludeFilters = app.Option("--exclude", "Filter expressions to exclude specific modules and types.", CommandOptionType.MultipleValue);
             CommandOption includeFilters = app.Option("--include", "Filter expressions to include only specific modules and types.", CommandOptionType.MultipleValue);
             CommandOption excludedSourceFiles = app.Option("--exclude-by-file", "Glob patterns specifying source files to exclude.", CommandOptionType.MultipleValue);
@@ -105,6 +106,7 @@ namespace Coverlet.Console
                 var dThreshold = threshold.HasValue() ? double.Parse(threshold.Value()) : 0;
                 var dThresholdTypes = thresholdTypes.HasValue() ? thresholdTypes.Values : new List<string>(new string[] { "line", "branch", "method" });
                 var dThresholdStat = thresholdStat.HasValue() ? Enum.Parse<ThresholdStatistic>(thresholdStat.Value(), true) : Enum.Parse<ThresholdStatistic>("minimum", true);
+                var dThresholdAct = thresholdAct.HasValue() ? Enum.Parse<ThresholdAction>(thresholdAct.Value(), true) : Enum.Parse<ThresholdAction>("fail", true);
 
                 logger.LogInformation("\nCalculating coverage result...");
 
@@ -223,7 +225,12 @@ namespace Coverlet.Console
                         exceptionMessageBuilder.AppendLine($"The {dThresholdStat.ToString().ToLower()} method coverage is below the specified {dThreshold}");
                     }
 
-                    throw new Exception(exceptionMessageBuilder.ToString());
+                    if (dThresholdAct == ThresholdAction.Fail)
+                    {
+                        throw new Exception(exceptionMessageBuilder.ToString());
+                    }
+
+                    logger.LogWarning(exceptionMessageBuilder.ToString());
                 }
 
                 return exitCode;

--- a/src/coverlet.core/Enums/ThresholdAction.cs
+++ b/src/coverlet.core/Enums/ThresholdAction.cs
@@ -1,0 +1,8 @@
+﻿namespace Coverlet.Core.Enums
+{
+    internal enum ThresholdAction
+    {
+        Fail,
+        Warning
+    }
+}

--- a/src/coverlet.msbuild.tasks/CoverageResultTask.cs
+++ b/src/coverlet.msbuild.tasks/CoverageResultTask.cs
@@ -248,12 +248,15 @@ namespace Coverlet.MSbuild.Tasks
                         exceptionMessageBuilder.AppendLine($"The {thresholdStat.ToString().ToLower()} method coverage is below the specified {_threshold}");
                     }
 
-                    if(thresholdAct == ThresholdAction.Fail)
+                    switch (thresholdAct)
                     {
-                        throw new Exception(exceptionMessageBuilder.ToString());
+                        case ThresholdAction.Warning:
+                            _logger.LogWarning(exceptionMessageBuilder.ToString());
+                            break;
+                        case ThresholdAction.Fail:
+                        default:
+                            throw new Exception(exceptionMessageBuilder.ToString());
                     }
-
-                    _logger.LogWarning(exceptionMessageBuilder.ToString());
                 }
             }
             catch (Exception ex)

--- a/src/coverlet.msbuild.tasks/coverlet.msbuild.props
+++ b/src/coverlet.msbuild.tasks/coverlet.msbuild.props
@@ -15,6 +15,7 @@
     <Threshold Condition="$(Threshold) == ''">0</Threshold>
     <ThresholdType Condition="$(ThresholdType) == ''">line,branch,method</ThresholdType>
     <ThresholdStat Condition="$(ThresholdStat) == ''">minimum</ThresholdStat>
+    <ThresholdAct Condition="$(ThresholdAct) == ''">fail</ThresholdAct>
   </PropertyGroup>
   <PropertyGroup>
     <CoverletToolsPath Condition=" '$(CoverletToolsPath)' == '' ">$(MSBuildThisFileDirectory)</CoverletToolsPath>

--- a/src/coverlet.msbuild.tasks/coverlet.msbuild.targets
+++ b/src/coverlet.msbuild.tasks/coverlet.msbuild.targets
@@ -39,6 +39,7 @@
       Threshold="$(Threshold)"
       ThresholdType="$(ThresholdType)"
       ThresholdStat="$(ThresholdStat)"
+      ThresholdAct="$(ThresholdAct)"
       InstrumenterState="$(InstrumenterState)"
       CoverletMultiTargetFrameworksCurrentTFM="$(_coverletMultiTargetFrameworksCurrentTFM)" />
   </Target>


### PR DESCRIPTION
- This will enable the option to choose if the build should fail when
  the coverage is below the threshold or just give a warning about it