### PR TITLE
Updating coverlet collector to use GetPropertyValue and if its missing fallback to GetProperties 

### DIFF
--- a/src/coverlet.collector/DataCollection/CoverletCoverageCollector.cs
+++ b/src/coverlet.collector/DataCollection/CoverletCoverageCollector.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Xml;
 using Coverlet.Collector.Utilities;
 using Coverlet.Collector.Utilities.Interfaces;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection;
 
 namespace Coverlet.Collector.DataCollection
@@ -201,7 +202,25 @@ namespace Coverlet.Collector.DataCollection
         /// <returns></returns>
         private static IEnumerable<string> GetPropertyValueWrapper(SessionStartEventArgs sessionStartEventArgs)
         {
-            return sessionStartEventArgs.GetPropertyValue<IEnumerable<string>>(CoverletConstants.TestSourcesPropertyName);
+            try
+            {
+                return sessionStartEventArgs.GetPropertyValue<IEnumerable<string>>(CoverletConstants.TestSourcesPropertyName);
+            }
+            catch (MissingMethodException)
+            {
+                using (var enumProperties = sessionStartEventArgs.GetProperties())
+                {
+                    while (enumProperties.MoveNext())
+                    {
+                        if (enumProperties.Current.Key == CoverletConstants.TestSourcesPropertyName &&
+                            enumProperties.Current.Value is IEnumerable<string> propertyValue)
+                        {
+                            return propertyValue;
+                        }
+                    }
+                }
+                throw;
+            }
         }
     }
 }

--- a/src/coverlet.collector/DataCollection/CoverletCoverageCollector.cs
+++ b/src/coverlet.collector/DataCollection/CoverletCoverageCollector.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Xml;
 using Coverlet.Collector.Utilities;
 using Coverlet.Collector.Utilities.Interfaces;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection;
 
 namespace Coverlet.Collector.DataCollection


### PR DESCRIPTION
To test https://github.com/tonerdo/coverlet/issues/748

Fallback to get the test source property when the GetPropertyValue<T> method is not found.

If the GetProperties method is also not found, a missingMethodException will also be raised.
If the GetProperties method doesn't return the property, we rethrow the exception.

I've tested both methods return the TestSources property when run using .NET Core SDK 2.2.400.

This is a speculative fix to see if GetProperties method exists for .NET Core SDK 2.1.400.