### PR TITLE
Skip branches in generated `MoveNext()` for singleton iterators

### DIFF
--- a/src/coverlet.core/Symbols/CecilSymbolHelper.cs
+++ b/src/coverlet.core/Symbols/CecilSymbolHelper.cs
@@ -412,6 +412,11 @@ namespace Coverlet.Core.Symbols
 
             bool isAsyncStateMachineMoveNext = IsMoveNextInsideAsyncStateMachine(methodDefinition);
             bool isMoveNextInsideAsyncStateMachineProlog = isAsyncStateMachineMoveNext && IsMoveNextInsideAsyncStateMachineProlog(methodDefinition);
+
+            // State machine for enumerator uses `brfalse.s`/`beq` or `switch` opcode depending on how many `yield` we have in the method body.
+            // For more than one `yield` a `switch` is emitted so we should only skip the first branch. In case of a single `yield` we need to
+            // skip the first two branches to avoid reporting a phantom branch. The first branch (`brfalse.s`) jumps to the `yield`ed value,
+            // the second one (`beq`) exits the enumeration.
             bool skipFirstBranch = IsMoveNextInsideEnumerator(methodDefinition);
             bool skipSecondBranch = false;
 

--- a/src/coverlet.core/Symbols/CecilSymbolHelper.cs
+++ b/src/coverlet.core/Symbols/CecilSymbolHelper.cs
@@ -413,7 +413,7 @@ namespace Coverlet.Core.Symbols
             bool isAsyncStateMachineMoveNext = IsMoveNextInsideAsyncStateMachine(methodDefinition);
             bool isMoveNextInsideAsyncStateMachineProlog = isAsyncStateMachineMoveNext && IsMoveNextInsideAsyncStateMachineProlog(methodDefinition);
             bool skipFirstBranch = IsMoveNextInsideEnumerator(methodDefinition);
-            bool skipSecondBranch = skipFirstBranch && instructions.All(i => i.OpCode.Code != Code.Switch);
+            bool skipSecondBranch = false;
 
             foreach (Instruction instruction in instructions.Where(instruction => instruction.OpCode.FlowControl == FlowControl.Cond_Branch))
             {
@@ -422,6 +422,7 @@ namespace Coverlet.Core.Symbols
                     if (skipFirstBranch)
                     {
                         skipFirstBranch = false;
+                        skipSecondBranch = instruction.OpCode.Code != Code.Switch;
                         continue;
                     }
 

--- a/src/coverlet.core/Symbols/CecilSymbolHelper.cs
+++ b/src/coverlet.core/Symbols/CecilSymbolHelper.cs
@@ -413,6 +413,7 @@ namespace Coverlet.Core.Symbols
             bool isAsyncStateMachineMoveNext = IsMoveNextInsideAsyncStateMachine(methodDefinition);
             bool isMoveNextInsideAsyncStateMachineProlog = isAsyncStateMachineMoveNext && IsMoveNextInsideAsyncStateMachineProlog(methodDefinition);
             bool skipFirstBranch = IsMoveNextInsideEnumerator(methodDefinition);
+            bool skipSecondBranch = skipFirstBranch && !instructions.Any(i => i.OpCode.Code == Code.Switch);
 
             foreach (Instruction instruction in instructions.Where(instruction => instruction.OpCode.FlowControl == FlowControl.Cond_Branch))
             {
@@ -421,6 +422,12 @@ namespace Coverlet.Core.Symbols
                     if (skipFirstBranch)
                     {
                         skipFirstBranch = false;
+                        continue;
+                    }
+
+                    if (skipSecondBranch)
+                    {
+                        skipSecondBranch = false;
                         continue;
                     }
 

--- a/src/coverlet.core/Symbols/CecilSymbolHelper.cs
+++ b/src/coverlet.core/Symbols/CecilSymbolHelper.cs
@@ -413,7 +413,7 @@ namespace Coverlet.Core.Symbols
             bool isAsyncStateMachineMoveNext = IsMoveNextInsideAsyncStateMachine(methodDefinition);
             bool isMoveNextInsideAsyncStateMachineProlog = isAsyncStateMachineMoveNext && IsMoveNextInsideAsyncStateMachineProlog(methodDefinition);
             bool skipFirstBranch = IsMoveNextInsideEnumerator(methodDefinition);
-            bool skipSecondBranch = skipFirstBranch && !instructions.Any(i => i.OpCode.Code == Code.Switch);
+            bool skipSecondBranch = skipFirstBranch && instructions.All(i => i.OpCode.Code != Code.Switch);
 
             foreach (Instruction instruction in instructions.Where(instruction => instruction.OpCode.FlowControl == FlowControl.Cond_Branch))
             {

--- a/test/coverlet.core.tests/Coverage/CoverageTest.Yield.cs
+++ b/test/coverlet.core.tests/Coverage/CoverageTest.Yield.cs
@@ -12,7 +12,7 @@ namespace Coverlet.Core.Tests
     {
         [ConditionalFact]
         [SkipOnOS(OS.MacOS)]
-        public void Yield_Singleton()
+        public void Yield_Single()
         {
             // We need to pass file name to remote process where it save instrumentation result
             // Similar to msbuild input/output
@@ -26,7 +26,7 @@ namespace Coverlet.Core.Tests
                     CoveragePrepareResult coveragePrepareResult = await TestInstrumentationHelper.Run<Yield>(instance =>
                     {
                         // We call method to trigger coverage hits
-                        _ = instance.One().Single();
+                        foreach(var _ in instance.One());
 
                         // For now we have only async Run helper
                         return Task.CompletedTask;
@@ -46,7 +46,8 @@ namespace Coverlet.Core.Tests
                 // Asserts on doc/lines/branches
                 result.Document("Instrumentation.Yield.cs")
                       // (line, hits)
-                      .AssertLinesCovered((9, 1));
+                      .AssertLinesCovered((9, 1))
+                      .ExpectedTotalNumberOfBranches(0);
             }
             finally
             {
@@ -66,7 +67,7 @@ namespace Coverlet.Core.Tests
                 {
                     CoveragePrepareResult coveragePrepareResult = await TestInstrumentationHelper.Run<Yield>(instance =>
                     {
-                        _ = instance.Two().ToArray();
+                        foreach (var _ in instance.Two());
                         return Task.CompletedTask;
                     }, persistPrepareResultToFile: pathSerialize[0]);
                     return 0;
@@ -74,8 +75,9 @@ namespace Coverlet.Core.Tests
 
                 CoverageResult result = TestInstrumentationHelper.GetCoverageResult(path);
 
-                result.Document("Instrumentation.SelectionStatements.cs")
-                      .AssertLinesCovered((14, 1), (15, 0));
+                result.Document("Instrumentation.Yield.cs")
+                      .AssertLinesCovered((14, 1), (15, 1))
+                      .ExpectedTotalNumberOfBranches(0);
             }
             finally
             {

--- a/test/coverlet.core.tests/Coverage/CoverageTest.Yield.cs
+++ b/test/coverlet.core.tests/Coverage/CoverageTest.Yield.cs
@@ -19,7 +19,7 @@ namespace Coverlet.Core.Tests
                 {
                     CoveragePrepareResult coveragePrepareResult = await TestInstrumentationHelper.Run<Yield>(instance =>
                     {
-                        foreach(var _ in instance.One()) ;
+                        foreach(var _ in instance.One());
 
                         return Task.CompletedTask;
                     }, persistPrepareResultToFile: pathSerialize[0]);
@@ -50,7 +50,7 @@ namespace Coverlet.Core.Tests
                 {
                     CoveragePrepareResult coveragePrepareResult = await TestInstrumentationHelper.Run<Yield>(instance =>
                     {
-                        foreach (var _ in instance.Two()) ;
+                        foreach (var _ in instance.Two());
 
                         return Task.CompletedTask;
                     }, persistPrepareResultToFile: pathSerialize[0]);
@@ -80,7 +80,7 @@ namespace Coverlet.Core.Tests
                 {
                     CoveragePrepareResult coveragePrepareResult = await TestInstrumentationHelper.Run<Yield>(instance =>
                     {
-                        foreach (var _ in instance.OneWithSwitch()) ;
+                        foreach (var _ in instance.OneWithSwitch(2)) ;
 
                         return Task.CompletedTask;
                     }, persistPrepareResultToFile: pathSerialize[0]);
@@ -92,6 +92,7 @@ namespace Coverlet.Core.Tests
 
                 result.Document("Instrumentation.Yield.cs")
                       .Method("System.Boolean Coverlet.Core.Samples.Tests.Yield/<OneWithSwitch>d__2::MoveNext()")
+                      .AssertLinesCovered((30, 1), (31, 1), (37, 1))
                       .ExpectedTotalNumberOfBranches(1);
             }
             finally

--- a/test/coverlet.core.tests/Coverage/CoverageTest.Yield.cs
+++ b/test/coverlet.core.tests/Coverage/CoverageTest.Yield.cs
@@ -152,7 +152,7 @@ namespace Coverlet.Core.Tests
 
                 result.Document("Instrumentation.Yield.cs")
                       .Method("System.Boolean Coverlet.Core.Samples.Tests.Yield/<Enumerable>d__4::MoveNext()")
-                      .AssertLinesCovered((51, 4))
+                      .AssertLinesCovered((48, 1), (49, 11), (50, 4), (51, 4), (52, 4), (53, 1))
                       .ExpectedTotalNumberOfBranches(1);
             }
             finally

--- a/test/coverlet.core.tests/Coverage/CoverageTest.Yield.cs
+++ b/test/coverlet.core.tests/Coverage/CoverageTest.Yield.cs
@@ -92,7 +92,7 @@ namespace Coverlet.Core.Tests
 
                 result.Document("Instrumentation.Yield.cs")
                       .Method("System.Boolean Coverlet.Core.Samples.Tests.Yield/<OneWithSwitch>d__2::MoveNext()")
-                      .AssertLinesCovered((30, 1), (31, 1), (37, 1))
+                      .AssertLinesCovered((21, 1), (30, 1), (31, 1), (37, 1))
                       .ExpectedTotalNumberOfBranches(1);
             }
             finally

--- a/test/coverlet.core.tests/Coverage/CoverageTest.Yield.cs
+++ b/test/coverlet.core.tests/Coverage/CoverageTest.Yield.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 
 using Coverlet.Core.Samples.Tests;
-using Coverlet.Tests.Xunit.Extensions;
 using Tmds.Utils;
 using Xunit;
 
@@ -10,54 +9,37 @@ namespace Coverlet.Core.Tests
 {
     public partial class CoverageTests : ExternalProcessExecutionTest
     {
-        [ConditionalFact]
-        [SkipOnOS(OS.MacOS)]
+        [Fact]
         public void Yield_Single()
         {
-            // We need to pass file name to remote process where it save instrumentation result
-            // Similar to msbuild input/output
             string path = Path.GetTempFileName();
             try
             {
-                // Lambda will run in a custom process to avoid issue with statics and file locking
                 FunctionExecutor.Run(async (string[] pathSerialize) =>
                 {
-                    // Run load and call a delegate passing class as dynamic to simplify method call
                     CoveragePrepareResult coveragePrepareResult = await TestInstrumentationHelper.Run<Yield>(instance =>
                     {
-                        // We call method to trigger coverage hits
                         foreach(var _ in instance.One());
 
-                        // For now we have only async Run helper
                         return Task.CompletedTask;
                     }, persistPrepareResultToFile: pathSerialize[0]);
 
-                    // we return 0 if we return something different assert fail
                     return 0;
                 }, new string[] { path });
 
-                // We retrive and load CoveragePrepareResult and run coverage calculation
-                // Similar to msbuild coverage result task
                 CoverageResult result = TestInstrumentationHelper.GetCoverageResult(path);
 
-                // Generate html report to check
-                // TestInstrumentationHelper.GenerateHtmlReport(result);
-
-                // Asserts on doc/lines/branches
                 result.Document("Instrumentation.Yield.cs")
-                      // (line, hits)
                       .AssertLinesCovered((9, 1))
                       .ExpectedTotalNumberOfBranches(0);
             }
             finally
             {
-                // Cleanup tmp file
                 File.Delete(path);
             }
         }
 
-        [ConditionalFact]
-        [SkipOnOS(OS.MacOS)]
+        [Fact]
         public void Yield_Multiple()
         {
             string path = Path.GetTempFileName();
@@ -68,6 +50,7 @@ namespace Coverlet.Core.Tests
                     CoveragePrepareResult coveragePrepareResult = await TestInstrumentationHelper.Run<Yield>(instance =>
                     {
                         foreach (var _ in instance.Two());
+
                         return Task.CompletedTask;
                     }, persistPrepareResultToFile: pathSerialize[0]);
                     return 0;

--- a/test/coverlet.core.tests/Coverage/CoverageTest.Yield.cs
+++ b/test/coverlet.core.tests/Coverage/CoverageTest.Yield.cs
@@ -19,7 +19,7 @@ namespace Coverlet.Core.Tests
                 {
                     CoveragePrepareResult coveragePrepareResult = await TestInstrumentationHelper.Run<Yield>(instance =>
                     {
-                        foreach(var _ in instance.One());
+                        foreach (var _ in instance.One()) ;
 
                         return Task.CompletedTask;
                     }, persistPrepareResultToFile: pathSerialize[0]);
@@ -50,7 +50,7 @@ namespace Coverlet.Core.Tests
                 {
                     CoveragePrepareResult coveragePrepareResult = await TestInstrumentationHelper.Run<Yield>(instance =>
                     {
-                        foreach (var _ in instance.Two());
+                        foreach (var _ in instance.Two()) ;
 
                         return Task.CompletedTask;
                     }, persistPrepareResultToFile: pathSerialize[0]);
@@ -142,7 +142,6 @@ namespace Coverlet.Core.Tests
                     CoveragePrepareResult coveragePrepareResult = await TestInstrumentationHelper.Run<Yield>(instance =>
                     {
                         foreach (var _ in instance.Enumerable(new[] { "one", "two", "three", "four" })) ;
-
                         return Task.CompletedTask;
                     }, persistPrepareResultToFile: pathSerialize[0]);
                     return 0;
@@ -152,7 +151,7 @@ namespace Coverlet.Core.Tests
 
                 result.Document("Instrumentation.Yield.cs")
                       .Method("System.Boolean Coverlet.Core.Samples.Tests.Yield/<Enumerable>d__4::MoveNext()")
-                      .AssertLinesCovered(BuildConfiguration.Debug, (48, 1), (49, 11), (50, 4), (51, 4), (52, 4), (53, 1))
+                      .AssertLinesCovered(BuildConfiguration.Debug, (48, 1), (49, 1), (50, 4), (51, 5), (52, 1), (54, 4), (55, 4), (56, 4), (57, 1))
                       .ExpectedTotalNumberOfBranches(1);
             }
             finally

--- a/test/coverlet.core.tests/Coverage/CoverageTest.Yield.cs
+++ b/test/coverlet.core.tests/Coverage/CoverageTest.Yield.cs
@@ -41,7 +41,7 @@ namespace Coverlet.Core.Tests
         }
 
         [Fact]
-        public void Yield_Multiple()
+        public void Yield_Two()
         {
             string path = Path.GetTempFileName();
             try
@@ -93,6 +93,66 @@ namespace Coverlet.Core.Tests
                 result.Document("Instrumentation.Yield.cs")
                       .Method("System.Boolean Coverlet.Core.Samples.Tests.Yield/<OneWithSwitch>d__2::MoveNext()")
                       .AssertLinesCovered((30, 1), (31, 1), (37, 1))
+                      .ExpectedTotalNumberOfBranches(1);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void Yield_Three()
+        {
+            string path = Path.GetTempFileName();
+            try
+            {
+                FunctionExecutor.Run(async (string[] pathSerialize) =>
+                {
+                    CoveragePrepareResult coveragePrepareResult = await TestInstrumentationHelper.Run<Yield>(instance =>
+                    {
+                        foreach (var _ in instance.Three()) ;
+
+                        return Task.CompletedTask;
+                    }, persistPrepareResultToFile: pathSerialize[0]);
+                    return 0;
+                }, new string[] { path });
+
+                CoverageResult result = TestInstrumentationHelper.GetCoverageResult(path);
+
+                result.Document("Instrumentation.Yield.cs")
+                      .Method("System.Boolean Coverlet.Core.Samples.Tests.Yield/<Three>d__3::MoveNext()")
+                      .AssertLinesCovered((42, 1), (43, 1), (44, 1))
+                      .ExpectedTotalNumberOfBranches(0);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void Yield_Enumerable()
+        {
+            string path = Path.GetTempFileName();
+            try
+            {
+                FunctionExecutor.Run(async (string[] pathSerialize) =>
+                {
+                    CoveragePrepareResult coveragePrepareResult = await TestInstrumentationHelper.Run<Yield>(instance =>
+                    {
+                        foreach (var _ in instance.Enumerable(new[] { "one", "two", "three", "four" })) ;
+
+                        return Task.CompletedTask;
+                    }, persistPrepareResultToFile: pathSerialize[0]);
+                    return 0;
+                }, new string[] { path });
+
+                CoverageResult result = TestInstrumentationHelper.GetCoverageResult(path);
+
+                result.Document("Instrumentation.Yield.cs")
+                      .Method("System.Boolean Coverlet.Core.Samples.Tests.Yield/<Enumerable>d__4::MoveNext()")
+                      .AssertLinesCovered((51, 4))
                       .ExpectedTotalNumberOfBranches(1);
             }
             finally

--- a/test/coverlet.core.tests/Coverage/CoverageTest.Yield.cs
+++ b/test/coverlet.core.tests/Coverage/CoverageTest.Yield.cs
@@ -1,0 +1,86 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+
+using Coverlet.Core.Samples.Tests;
+using Coverlet.Tests.Xunit.Extensions;
+using Tmds.Utils;
+using Xunit;
+
+namespace Coverlet.Core.Tests
+{
+    public partial class CoverageTests : ExternalProcessExecutionTest
+    {
+        [ConditionalFact]
+        [SkipOnOS(OS.MacOS)]
+        public void Yield_Singleton()
+        {
+            // We need to pass file name to remote process where it save instrumentation result
+            // Similar to msbuild input/output
+            string path = Path.GetTempFileName();
+            try
+            {
+                // Lambda will run in a custom process to avoid issue with statics and file locking
+                FunctionExecutor.Run(async (string[] pathSerialize) =>
+                {
+                    // Run load and call a delegate passing class as dynamic to simplify method call
+                    CoveragePrepareResult coveragePrepareResult = await TestInstrumentationHelper.Run<Yield>(instance =>
+                    {
+                        // We call method to trigger coverage hits
+                        _ = instance.One().Single();
+
+                        // For now we have only async Run helper
+                        return Task.CompletedTask;
+                    }, persistPrepareResultToFile: pathSerialize[0]);
+
+                    // we return 0 if we return something different assert fail
+                    return 0;
+                }, new string[] { path });
+
+                // We retrive and load CoveragePrepareResult and run coverage calculation
+                // Similar to msbuild coverage result task
+                CoverageResult result = TestInstrumentationHelper.GetCoverageResult(path);
+
+                // Generate html report to check
+                // TestInstrumentationHelper.GenerateHtmlReport(result);
+
+                // Asserts on doc/lines/branches
+                result.Document("Instrumentation.Yield.cs")
+                      // (line, hits)
+                      .AssertLinesCovered((9, 1));
+            }
+            finally
+            {
+                // Cleanup tmp file
+                File.Delete(path);
+            }
+        }
+
+        [ConditionalFact]
+        [SkipOnOS(OS.MacOS)]
+        public void Yield_Multiple()
+        {
+            string path = Path.GetTempFileName();
+            try
+            {
+                FunctionExecutor.Run(async (string[] pathSerialize) =>
+                {
+                    CoveragePrepareResult coveragePrepareResult = await TestInstrumentationHelper.Run<Yield>(instance =>
+                    {
+                        _ = instance.Two().ToArray();
+                        return Task.CompletedTask;
+                    }, persistPrepareResultToFile: pathSerialize[0]);
+                    return 0;
+                }, new string[] { path });
+
+                CoverageResult result = TestInstrumentationHelper.GetCoverageResult(path);
+
+                result.Document("Instrumentation.SelectionStatements.cs")
+                      .AssertLinesCovered((14, 1), (15, 0));
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/test/coverlet.core.tests/Coverage/CoverageTest.Yield.cs
+++ b/test/coverlet.core.tests/Coverage/CoverageTest.Yield.cs
@@ -19,7 +19,7 @@ namespace Coverlet.Core.Tests
                 {
                     CoveragePrepareResult coveragePrepareResult = await TestInstrumentationHelper.Run<Yield>(instance =>
                     {
-                        foreach(var _ in instance.One());
+                        foreach(var _ in instance.One()) ;
 
                         return Task.CompletedTask;
                     }, persistPrepareResultToFile: pathSerialize[0]);
@@ -50,7 +50,7 @@ namespace Coverlet.Core.Tests
                 {
                     CoveragePrepareResult coveragePrepareResult = await TestInstrumentationHelper.Run<Yield>(instance =>
                     {
-                        foreach (var _ in instance.Two());
+                        foreach (var _ in instance.Two()) ;
 
                         return Task.CompletedTask;
                     }, persistPrepareResultToFile: pathSerialize[0]);
@@ -80,7 +80,7 @@ namespace Coverlet.Core.Tests
                 {
                     CoveragePrepareResult coveragePrepareResult = await TestInstrumentationHelper.Run<Yield>(instance =>
                     {
-                        foreach (var _ in instance.OneWithSwitch(2)) ;
+                        foreach (var _ in instance.OneWithSwitch()) ;
 
                         return Task.CompletedTask;
                     }, persistPrepareResultToFile: pathSerialize[0]);
@@ -92,7 +92,6 @@ namespace Coverlet.Core.Tests
 
                 result.Document("Instrumentation.Yield.cs")
                       .Method("System.Boolean Coverlet.Core.Samples.Tests.Yield/<OneWithSwitch>d__2::MoveNext()")
-                      .AssertLinesCovered((30, 1), (31, 1), (37, 1))
                       .ExpectedTotalNumberOfBranches(1);
             }
             finally

--- a/test/coverlet.core.tests/Coverage/CoverageTest.Yield.cs
+++ b/test/coverlet.core.tests/Coverage/CoverageTest.Yield.cs
@@ -92,7 +92,8 @@ namespace Coverlet.Core.Tests
 
                 result.Document("Instrumentation.Yield.cs")
                       .Method("System.Boolean Coverlet.Core.Samples.Tests.Yield/<OneWithSwitch>d__2::MoveNext()")
-                      .AssertLinesCovered((21, 1), (30, 1), (31, 1), (37, 1))
+                      .AssertLinesCovered(BuildConfiguration.Debug, (21, 1), (30, 1), (31, 1), (37, 1))
+                      .AssertLinesCovered(BuildConfiguration.Release, (30, 1), (31, 1), (37, 1))
                       .ExpectedTotalNumberOfBranches(1);
             }
             finally
@@ -152,7 +153,8 @@ namespace Coverlet.Core.Tests
 
                 result.Document("Instrumentation.Yield.cs")
                       .Method("System.Boolean Coverlet.Core.Samples.Tests.Yield/<Enumerable>d__4::MoveNext()")
-                      .AssertLinesCovered((48, 1), (49, 11), (50, 4), (51, 4), (52, 4), (53, 1))
+                      .AssertLinesCovered(BuildConfiguration.Debug, (48, 1), (49, 11), (50, 4), (51, 4), (52, 4), (53, 1))
+                      .AssertLinesCovered(BuildConfiguration.Release, (49, 10), (51, 4), (53, 1))
                       .ExpectedTotalNumberOfBranches(1);
             }
             finally

--- a/test/coverlet.core.tests/Coverage/CoverageTest.Yield.cs
+++ b/test/coverlet.core.tests/Coverage/CoverageTest.Yield.cs
@@ -30,6 +30,7 @@ namespace Coverlet.Core.Tests
                 CoverageResult result = TestInstrumentationHelper.GetCoverageResult(path);
 
                 result.Document("Instrumentation.Yield.cs")
+                      .Method("System.Boolean Coverlet.Core.Samples.Tests.Yield/<One>d__0::MoveNext()")
                       .AssertLinesCovered((9, 1))
                       .ExpectedTotalNumberOfBranches(0);
             }
@@ -59,8 +60,40 @@ namespace Coverlet.Core.Tests
                 CoverageResult result = TestInstrumentationHelper.GetCoverageResult(path);
 
                 result.Document("Instrumentation.Yield.cs")
+                      .Method("System.Boolean Coverlet.Core.Samples.Tests.Yield/<Two>d__1::MoveNext()")
                       .AssertLinesCovered((14, 1), (15, 1))
                       .ExpectedTotalNumberOfBranches(0);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void Yield_SingleWithSwitch()
+        {
+            string path = Path.GetTempFileName();
+            try
+            {
+                FunctionExecutor.Run(async (string[] pathSerialize) =>
+                {
+                    CoveragePrepareResult coveragePrepareResult = await TestInstrumentationHelper.Run<Yield>(instance =>
+                    {
+                        foreach (var _ in instance.OneWithSwitch(2)) ;
+
+                        return Task.CompletedTask;
+                    }, persistPrepareResultToFile: pathSerialize[0]);
+
+                    return 0;
+                }, new string[] { path });
+
+                CoverageResult result = TestInstrumentationHelper.GetCoverageResult(path);
+
+                result.Document("Instrumentation.Yield.cs")
+                      .Method("System.Boolean Coverlet.Core.Samples.Tests.Yield/<OneWithSwitch>d__2::MoveNext()")
+                      .AssertLinesCovered((30, 1), (31, 1), (37, 1))
+                      .ExpectedTotalNumberOfBranches(1);
             }
             finally
             {

--- a/test/coverlet.core.tests/Coverage/CoverageTest.Yield.cs
+++ b/test/coverlet.core.tests/Coverage/CoverageTest.Yield.cs
@@ -93,7 +93,6 @@ namespace Coverlet.Core.Tests
                 result.Document("Instrumentation.Yield.cs")
                       .Method("System.Boolean Coverlet.Core.Samples.Tests.Yield/<OneWithSwitch>d__2::MoveNext()")
                       .AssertLinesCovered(BuildConfiguration.Debug, (21, 1), (30, 1), (31, 1), (37, 1))
-                      .AssertLinesCovered(BuildConfiguration.Release, (30, 1), (31, 1), (37, 1))
                       .ExpectedTotalNumberOfBranches(1);
             }
             finally
@@ -154,7 +153,6 @@ namespace Coverlet.Core.Tests
                 result.Document("Instrumentation.Yield.cs")
                       .Method("System.Boolean Coverlet.Core.Samples.Tests.Yield/<Enumerable>d__4::MoveNext()")
                       .AssertLinesCovered(BuildConfiguration.Debug, (48, 1), (49, 11), (50, 4), (51, 4), (52, 4), (53, 1))
-                      .AssertLinesCovered(BuildConfiguration.Release, (49, 10), (51, 4), (53, 1))
                       .ExpectedTotalNumberOfBranches(1);
             }
             finally

--- a/test/coverlet.core.tests/Coverage/CoverageTest.Yield.cs
+++ b/test/coverlet.core.tests/Coverage/CoverageTest.Yield.cs
@@ -142,6 +142,7 @@ namespace Coverlet.Core.Tests
                     CoveragePrepareResult coveragePrepareResult = await TestInstrumentationHelper.Run<Yield>(instance =>
                     {
                         foreach (var _ in instance.Enumerable(new[] { "one", "two", "three", "four" })) ;
+
                         return Task.CompletedTask;
                     }, persistPrepareResultToFile: pathSerialize[0]);
                     return 0;

--- a/test/coverlet.core.tests/Coverage/InstrumenterHelper.Assertions.cs
+++ b/test/coverlet.core.tests/Coverage/InstrumenterHelper.Assertions.cs
@@ -79,6 +79,36 @@ namespace Coverlet.Core.Tests
             throw new XunitException($"Document not found '{docName}'");
         }
 
+        public static Document Method(this Document document, string methodName)
+        {
+            var methodDoc = new Document { Path = document.Path, Index = document.Index };
+
+            if (!document.Lines.Any() && !document.Branches.Any())
+            {
+                return methodDoc;
+            }
+
+            if (document.Lines.Values.All(l => l.Method != methodName) && document.Branches.Values.All(l => l.Method != methodName))
+            {
+                var methods = document.Lines.Values.Select(l => $"'{l.Method}'")
+                    .Concat(document.Branches.Values.Select(b => $"'{b.Method}'"))
+                    .Distinct();
+                throw new XunitException($"Method '{methodName}' not found. Methods in document: {string.Join(", ", methods)}");
+            }
+
+            foreach (var line in document.Lines.Where(l => l.Value.Method == methodName))
+            {
+                methodDoc.Lines[line.Key] = line.Value;
+            }
+
+            foreach (var branch in document.Branches.Where(b => b.Value.Method == methodName))
+            {
+                methodDoc.Branches[branch.Key] = branch.Value;
+            }
+
+            return methodDoc;
+        }
+
         public static Document AssertBranchesCovered(this Document document, params (int line, int ordinal, int hits)[] lines)
         {
             return AssertBranchesCovered(document, BuildConfiguration.Debug | BuildConfiguration.Release, lines);

--- a/test/coverlet.core.tests/Coverage/InstrumenterHelper.Assertions.cs
+++ b/test/coverlet.core.tests/Coverage/InstrumenterHelper.Assertions.cs
@@ -84,6 +84,11 @@ namespace Coverlet.Core.Tests
             return AssertBranchesCovered(document, BuildConfiguration.Debug | BuildConfiguration.Release, lines);
         }
 
+        public static Document ExpectedTotalNumberOfBranches(this Document document, int totalExpectedBranch)
+        {
+            return ExpectedTotalNumberOfBranches(document, BuildConfiguration.Debug | BuildConfiguration.Release, totalExpectedBranch);
+        }
+
         public static Document ExpectedTotalNumberOfBranches(this Document document, BuildConfiguration configuration, int totalExpectedBranch)
         {
             if (document is null)

--- a/test/coverlet.core.tests/Samples/Instrumentation.Yield.cs
+++ b/test/coverlet.core.tests/Samples/Instrumentation.Yield.cs
@@ -1,0 +1,18 @@
+﻿// Remember to use full name because adding new using directives change line numbers
+
+namespace Coverlet.Core.Samples.Tests
+{
+    public class Yield
+    {
+        public System.Collections.Generic.IEnumerable<int> One()
+        {
+            yield return 1;
+        }
+
+        public System.Collections.Generic.IEnumerable<int> Two()
+        {
+            yield return 1;
+            yield return 2;
+        }
+    }
+}

--- a/test/coverlet.core.tests/Samples/Instrumentation.Yield.cs
+++ b/test/coverlet.core.tests/Samples/Instrumentation.Yield.cs
@@ -15,10 +15,10 @@ namespace Coverlet.Core.Samples.Tests
             yield return 2;
         }
 
-        public System.Collections.Generic.IEnumerable<int> OneWithSwitch(int n)
+        public System.Collections.Generic.IEnumerable<int> OneWithSwitch()
         {
             int result;
-            switch (n)
+            switch (new System.Random().Next())
             {
                 case 0:
                     result = 10;

--- a/test/coverlet.core.tests/Samples/Instrumentation.Yield.cs
+++ b/test/coverlet.core.tests/Samples/Instrumentation.Yield.cs
@@ -36,5 +36,20 @@ namespace Coverlet.Core.Samples.Tests
 
             yield return result;
         }
+
+        public System.Collections.Generic.IEnumerable<int> Three()
+        {
+            yield return 1;
+            yield return 2;
+            yield return 3;
+        }
+
+        public System.Collections.Generic.IEnumerable<string> Enumerable(System.Collections.Generic.IList<string> ls)
+        {
+            foreach (var item in ls)
+            {
+                yield return item;
+            }
+        }
     }
 }

--- a/test/coverlet.core.tests/Samples/Instrumentation.Yield.cs
+++ b/test/coverlet.core.tests/Samples/Instrumentation.Yield.cs
@@ -15,10 +15,10 @@ namespace Coverlet.Core.Samples.Tests
             yield return 2;
         }
 
-        public System.Collections.Generic.IEnumerable<int> OneWithSwitch()
+        public System.Collections.Generic.IEnumerable<int> OneWithSwitch(int n)
         {
             int result;
-            switch (new System.Random().Next())
+            switch (n)
             {
                 case 0:
                     result = 10;

--- a/test/coverlet.core.tests/Samples/Instrumentation.Yield.cs
+++ b/test/coverlet.core.tests/Samples/Instrumentation.Yield.cs
@@ -14,5 +14,27 @@ namespace Coverlet.Core.Samples.Tests
             yield return 1;
             yield return 2;
         }
+
+        public System.Collections.Generic.IEnumerable<int> OneWithSwitch(int n)
+        {
+            int result;
+            switch (n)
+            {
+                case 0:
+                    result = 10;
+                    break;
+                case 1:
+                    result = 11;
+                    break;
+                case 2:
+                    result = 12;
+                    break;
+                default:
+                    result = -1;
+                    break;
+            }
+
+            yield return result;
+        }
     }
 }

--- a/test/coverlet.core.tests/Samples/Instrumentation.Yield.cs
+++ b/test/coverlet.core.tests/Samples/Instrumentation.Yield.cs
@@ -46,7 +46,11 @@ namespace Coverlet.Core.Samples.Tests
 
         public System.Collections.Generic.IEnumerable<string> Enumerable(System.Collections.Generic.IList<string> ls)
         {
-            foreach (var item in ls)
+            foreach (
+                    var item
+                    in
+                    ls
+                    )
             {
                 yield return item;
             }

--- a/test/coverlet.core.tests/Samples/Samples.cs
+++ b/test/coverlet.core.tests/Samples/Samples.cs
@@ -172,6 +172,14 @@ namespace Coverlet.Core.Samples.Tests
         }
     }
 
+    public class SingletonIterator
+    {
+        public IEnumerable<string> Fetch()
+        {
+            yield return "one";
+        }
+    }
+
     public class AsyncAwaitStateMachine
     {
         async public Task AsyncAwait()

--- a/test/coverlet.core.tests/Symbols/CecilSymbolHelperTests.cs
+++ b/test/coverlet.core.tests/Symbols/CecilSymbolHelperTests.cs
@@ -259,7 +259,22 @@ namespace Coverlet.Core.Symbols.Tests
 
             // assert
             Assert.Empty(points);
+        }
 
+        [Fact]
+        public void GetBranchPoints_IgnoresBranchesIn_GeneratedMoveNextForSingletonIterator()
+        {
+            // arrange
+            var nestedName = typeof(SingletonIterator).GetNestedTypes(BindingFlags.NonPublic).First().Name;
+            var type = _module.Types.FirstOrDefault(x => x.FullName == typeof(SingletonIterator).FullName);
+            var nestedType = type.NestedTypes.FirstOrDefault(x => x.FullName.EndsWith(nestedName));
+            var method = nestedType.Methods.First(x => x.FullName.EndsWith("::MoveNext()"));
+
+            // act
+            var points = CecilSymbolHelper.GetBranchPoints(method);
+
+            // assert
+            Assert.Empty(points);
         }
 
         [Fact]


### PR DESCRIPTION
This fixes #810 by skipping the two branches inside `MoveNext()` that will be generated when the iterator only `yield`s once.

For instance, the iterator...

```csharp
public class SingletonIterator
{
    public IEnumerable<string> Fetch()
    {
        yield return "one";
    }
}
```

...will result in a generated `MoveNext()` method that has no `switch` instruction, but a `brfalse.s` and a `beq.s` instruction instead:

```msil
<Fetch>d__0.MoveNext:
IL_0000:  ldarg.0     
IL_0001:  ldfld       UserQuery+SingletonIterator+<Fetch>d__0.<>1__state
IL_0006:  stloc.0     
IL_0007:  ldloc.0     
IL_0008:  brfalse.s   IL_0012
IL_000A:  br.s        IL_000C
IL_000C:  ldloc.0     
IL_000D:  ldc.i4.1    
IL_000E:  beq.s       IL_0014
IL_0010:  br.s        IL_0016
IL_0012:  br.s        IL_0018
IL_0014:  br.s        IL_0034
IL_0016:  ldc.i4.0    
IL_0017:  ret         
IL_0018:  ldarg.0     
IL_0019:  ldc.i4.m1   
IL_001A:  stfld       UserQuery+SingletonIterator+<Fetch>d__0.<>1__state
IL_001F:  nop         
IL_0020:  ldarg.0     
IL_0021:  ldstr       "one"
IL_0026:  stfld       UserQuery+SingletonIterator+<Fetch>d__0.<>2__current
IL_002B:  ldarg.0     
IL_002C:  ldc.i4.1    
IL_002D:  stfld       UserQuery+SingletonIterator+<Fetch>d__0.<>1__state
IL_0032:  ldc.i4.1    
IL_0033:  ret         
IL_0034:  ldarg.0     
IL_0035:  ldc.i4.m1   
IL_0036:  stfld       UserQuery+SingletonIterator+<Fetch>d__0.<>1__state
IL_003B:  ldc.i4.0    
IL_003C:  ret 
```