### PR TITLE
Avoid double flush hit files for collectors

### DIFF
--- a/Documentation/Examples/VSTest/HelloWorld/XUnitTestProject1/XUnitTestProject1.csproj
+++ b/Documentation/Examples/VSTest/HelloWorld/XUnitTestProject1/XUnitTestProject1.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0">
+    <PackageReference Include="coverlet.collector" Version="1.2.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/coverlet.collector/InProcDataCollection/CoverletInProcDataCollector.cs
+++ b/src/coverlet.collector/InProcDataCollection/CoverletInProcDataCollector.cs
@@ -56,6 +56,7 @@ namespace Coverlet.Collector.DataCollection
                     _eqtTrace.Verbose($"Calling ModuleTrackerTemplate.UnloadModule for '{injectedInstrumentationClass.Assembly.FullName}'");
                     var unloadModule = injectedInstrumentationClass.GetMethod(nameof(ModuleTrackerTemplate.UnloadModule), new[] { typeof(object), typeof(EventArgs) });
                     unloadModule.Invoke(null, new[] { null, EventArgs.Empty });
+                    injectedInstrumentationClass.GetField("FlushHitFile", BindingFlags.Static | BindingFlags.Public).SetValue(null, false);
                     _eqtTrace.Verbose($"Called ModuleTrackerTemplate.UnloadModule for '{injectedInstrumentationClass.Assembly.FullName}'");
                 }
                 catch (Exception ex)

--- a/src/coverlet.collector/InProcDataCollection/CoverletInProcDataCollector.cs
+++ b/src/coverlet.collector/InProcDataCollection/CoverletInProcDataCollector.cs
@@ -55,7 +55,7 @@ namespace Coverlet.Collector.DataCollection
                 {
                     _eqtTrace.Verbose($"Calling ModuleTrackerTemplate.UnloadModule for '{injectedInstrumentationClass.Assembly.FullName}'");
                     var unloadModule = injectedInstrumentationClass.GetMethod(nameof(ModuleTrackerTemplate.UnloadModule), new[] { typeof(object), typeof(EventArgs) });
-                    unloadModule.Invoke(null, new[] { null, EventArgs.Empty });
+                    unloadModule.Invoke(null, new[] { (object)this, EventArgs.Empty });
                     injectedInstrumentationClass.GetField("FlushHitFile", BindingFlags.Static | BindingFlags.Public).SetValue(null, false);
                     _eqtTrace.Verbose($"Called ModuleTrackerTemplate.UnloadModule for '{injectedInstrumentationClass.Assembly.FullName}'");
                 }

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -34,6 +34,7 @@ namespace Coverlet.Core.Instrumentation
         private FieldDefinition _customTrackerHitsArray;
         private FieldDefinition _customTrackerHitsFilePath;
         private FieldDefinition _customTrackerSingleHit;
+        private FieldDefinition _customTrackerFlushHitFile;
         private ILProcessor _customTrackerClassConstructorIl;
         private TypeDefinition _customTrackerTypeDef;
         private MethodReference _customTrackerRegisterUnloadEventsMethod;
@@ -243,6 +244,8 @@ namespace Coverlet.Core.Instrumentation
                     _customTrackerClassConstructorIl.InsertBefore(lastInstr, Instruction.Create(OpCodes.Stsfld, _customTrackerHitsFilePath));
                     _customTrackerClassConstructorIl.InsertBefore(lastInstr, Instruction.Create(_singleHit ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0));
                     _customTrackerClassConstructorIl.InsertBefore(lastInstr, Instruction.Create(OpCodes.Stsfld, _customTrackerSingleHit));
+                    _customTrackerClassConstructorIl.InsertBefore(lastInstr, Instruction.Create(OpCodes.Ldc_I4_1));
+                    _customTrackerClassConstructorIl.InsertBefore(lastInstr, Instruction.Create(OpCodes.Stsfld, _customTrackerFlushHitFile));
 
                     if (containsAppContext)
                     {
@@ -294,6 +297,8 @@ namespace Coverlet.Core.Instrumentation
                         _customTrackerHitsFilePath = fieldClone;
                     else if (fieldClone.Name == nameof(ModuleTrackerTemplate.SingleHit))
                         _customTrackerSingleHit = fieldClone;
+                    else if (fieldClone.Name == nameof(ModuleTrackerTemplate.FlushHitFile))
+                        _customTrackerFlushHitFile = fieldClone;
                 }
 
                 foreach (MethodDefinition methodDef in moduleTrackerTemplate.Methods)

--- a/src/coverlet.core/Instrumentation/ModuleTrackerTemplate.cs
+++ b/src/coverlet.core/Instrumentation/ModuleTrackerTemplate.cs
@@ -127,8 +127,7 @@ namespace Coverlet.Core.Instrumentation
 
                                 if (hitsLength != hitsArray.Length)
                                 {
-                                    throw new InvalidOperationException(
-                                        $"{HitsFilePath} has {hitsLength} entries but on memory {nameof(HitsArray)} has {hitsArray.Length}");
+                                    throw new InvalidOperationException($"{HitsFilePath} has {hitsLength} entries but on memory {nameof(HitsArray)} has {hitsArray.Length}");
                                 }
 
                                 for (int i = 0; i < hitsLength; ++i)

--- a/src/coverlet.core/Instrumentation/ModuleTrackerTemplate.cs
+++ b/src/coverlet.core/Instrumentation/ModuleTrackerTemplate.cs
@@ -92,7 +92,7 @@ namespace Coverlet.Core.Instrumentation
                 {
                     try
                     {
-                        WriteLog($"Unload called for '{Assembly.GetExecutingAssembly().Location}' by '{sender}'");
+                        WriteLog($"Unload called for '{Assembly.GetExecutingAssembly().Location}' by '{sender ?? "null"}'");
                         WriteLog($"Flushing hit file '{HitsFilePath}'");
 
                         bool failedToCreateNewHitsFile = false;
@@ -185,7 +185,7 @@ namespace Coverlet.Core.Instrumentation
                     }
                 }
 
-                File.AppendAllText(logFile, $"Hits flushed file path {HitsFilePath} location '{Assembly.GetExecutingAssembly().Location}' by '{sender}'");
+                File.AppendAllText(logFile, $"Hits flushed file path {HitsFilePath} location '{Assembly.GetExecutingAssembly().Location}' by '{sender ?? "null"}'");
             }
         }
 

--- a/src/coverlet.core/Instrumentation/ModuleTrackerTemplate.cs
+++ b/src/coverlet.core/Instrumentation/ModuleTrackerTemplate.cs
@@ -85,13 +85,13 @@ namespace Coverlet.Core.Instrumentation
                     mutex.WaitOne();
                 }
 
-                // Claim the current hits array and reset it to prevent double-counting scenarios.
-                int[] hitsArray = Interlocked.Exchange(ref HitsArray, new int[HitsArray.Length]);
-
                 if (FlushHitFile)
                 {
                     try
                     {
+                        // Claim the current hits array and reset it to prevent double-counting scenarios.
+                        int[] hitsArray = Interlocked.Exchange(ref HitsArray, new int[HitsArray.Length]);
+
                         WriteLog($"Unload called for '{Assembly.GetExecutingAssembly().Location}' by '{sender ?? "null"}'");
                         WriteLog($"Flushing hit file '{HitsFilePath}'");
 

--- a/src/coverlet.core/Instrumentation/ModuleTrackerTemplate.cs
+++ b/src/coverlet.core/Instrumentation/ModuleTrackerTemplate.cs
@@ -21,6 +21,7 @@ namespace Coverlet.Core.Instrumentation
         public static string HitsFilePath;
         public static int[] HitsArray;
         public static bool SingleHit;
+        public static bool FlushHitFile;
         private static readonly bool _enableLog = int.TryParse(Environment.GetEnvironmentVariable("COVERLET_ENABLETRACKERLOG"), out int result) ? result == 1 : false;
 
         static ModuleTrackerTemplate()
@@ -75,6 +76,11 @@ namespace Coverlet.Core.Instrumentation
 
         public static void UnloadModule(object sender, EventArgs e)
         {
+            if (!FlushHitFile)
+            {
+                return;
+            }
+
             try
             {
                 WriteLog($"Unload called for '{Assembly.GetExecutingAssembly().Location}'");

--- a/test/coverlet.core.tests/Coverage/InstrumenterHelper.cs
+++ b/test/coverlet.core.tests/Coverage/InstrumenterHelper.cs
@@ -26,7 +26,7 @@ namespace Coverlet.Core.Tests
         /// caller sample:  TestInstrumentationHelper.GenerateHtmlReport(result, sourceFileFilter: @"+**\Samples\Instrumentation.cs");
         ///                 TestInstrumentationHelper.GenerateHtmlReport(result);
         /// </summary>
-        public static void GenerateHtmlReport(CoverageResult coverageResult, IReporter reporter = null, string sourceFileFilter = "", [CallerMemberName]string directory = "")
+        public static void GenerateHtmlReport(CoverageResult coverageResult, IReporter reporter = null, string sourceFileFilter = "", [CallerMemberName] string directory = "")
         {
             JsonReporter defaultReporter = new JsonReporter();
             reporter ??= new CoberturaReporter();
@@ -289,6 +289,11 @@ namespace Coverlet.Core.Tests
         public static void RunInProcess(this FunctionExecutor executor, Func<string[], Task<int>> func, string[] args)
         {
             Assert.Equal(0, func(args).Result);
+        }
+
+        public static void RunInProcess(this FunctionExecutor executor, Func<Task<int>> func)
+        {
+            Assert.Equal(0, func().Result);
         }
     }
 }

--- a/test/coverlet.core.tests/Instrumentation/ModuleTrackerTemplateTests.cs
+++ b/test/coverlet.core.tests/Instrumentation/ModuleTrackerTemplateTests.cs
@@ -4,7 +4,6 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Coverlet.Core.Instrumentation;
-using Coverlet.Tests.Xunit.Extensions;
 using Xunit;
 
 namespace Coverlet.Core.Tests.Instrumentation

--- a/test/coverlet.core.tests/Instrumentation/ModuleTrackerTemplateTests.cs
+++ b/test/coverlet.core.tests/Instrumentation/ModuleTrackerTemplateTests.cs
@@ -14,6 +14,7 @@ namespace Coverlet.Core.Tests.Instrumentation
         public TrackerContext()
         {
             ModuleTrackerTemplate.HitsFilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            ModuleTrackerTemplate.FlushHitFile = true;
         }
 
         public void Dispose()


### PR DESCRIPTION
Fixes https://github.com/coverlet-coverage/coverlet/issues/736

When collectors was created we didn't take into account the ProcessExit callback. So sometime happens that in proc collector flush and meanwhile out of proc one try to load hits file when process exits of host process re-flush the file and so invalid concurrent access.
This PR add a  boolean field called `FlushHitFile` default `true` that will be set to false after in process collector flush. This new field is used inside `UnloadModule` , in case of collectors usage we won't have double flush due to process exits callback.

In my local test with tracking log enabled works as expected

![image](https://user-images.githubusercontent.com/7894084/81081715-928a7a00-8ef2-11ea-8b42-143061a691d4.png)

Log before

[DummyApp.dll_tracker_flushOnProcessExits.txt](https://github.com/coverlet-coverage/coverlet/files/4581596/DummyApp.dll_tracker_flushOnProcessExits.txt)

Log after 

[DummyApp.dll_tracker_newVersion.txt](https://github.com/coverlet-coverage/coverlet/files/4581598/DummyApp.dll_tracker_newVersion.txt)

This is also compatible with netfx app domains, btw at the moment collectors does not support netfx.

cc: @ViktorHofer @abe545 @tonerdo 