### PR TITLE
Increase retry time during dll restore

### DIFF
--- a/src/coverlet.core/Helpers/InstrumentationHelper.cs
+++ b/src/coverlet.core/Helpers/InstrumentationHelper.cs
@@ -251,8 +251,6 @@ namespace Coverlet.Core.Helpers
 
         public void DeleteHitsFile(string path)
         {
-            // Retry hitting the hits file - retry up to 10 times, since the file could be locked
-            // See: https://github.com/tonerdo/coverlet/issues/25
             var retryStrategy = CreateRetryStrategy();
             _retryHelper.Retry(() => _fileSystem.Delete(path), retryStrategy, RetryAttempts);
         }

--- a/src/coverlet.core/Helpers/InstrumentationHelper.cs
+++ b/src/coverlet.core/Helpers/InstrumentationHelper.cs
@@ -15,6 +15,7 @@ namespace Coverlet.Core.Helpers
 {
     internal class InstrumentationHelper : IInstrumentationHelper
     {
+        private const int RetryAttempts = 12;
         private readonly ConcurrentDictionary<string, string> _backupList = new ConcurrentDictionary<string, string>();
         private readonly IRetryHelper _retryHelper;
         private readonly IFileSystem _fileSystem;
@@ -216,7 +217,7 @@ namespace Coverlet.Core.Helpers
                 _fileSystem.Copy(backupPath, module, true);
                 _fileSystem.Delete(backupPath);
                 _backupList.TryRemove(module, out string _);
-            }, retryStrategy, 10);
+            }, retryStrategy, RetryAttempts);
 
             _retryHelper.Retry(() =>
             {
@@ -227,7 +228,7 @@ namespace Coverlet.Core.Helpers
                     _fileSystem.Delete(backupSymbolPath);
                     _backupList.TryRemove(symbolFile, out string _);
                 }
-            }, retryStrategy, 10);
+            }, retryStrategy, RetryAttempts);
         }
 
         public virtual void RestoreOriginalModules()
@@ -244,7 +245,7 @@ namespace Coverlet.Core.Helpers
                     _fileSystem.Copy(backupPath, key, true);
                     _fileSystem.Delete(backupPath);
                     _backupList.TryRemove(key, out string _);
-                }, retryStrategy, 10);
+                }, retryStrategy, RetryAttempts);
             }
         }
 
@@ -253,7 +254,7 @@ namespace Coverlet.Core.Helpers
             // Retry hitting the hits file - retry up to 10 times, since the file could be locked
             // See: https://github.com/tonerdo/coverlet/issues/25
             var retryStrategy = CreateRetryStrategy();
-            _retryHelper.Retry(() => _fileSystem.Delete(path), retryStrategy, 10);
+            _retryHelper.Retry(() => _fileSystem.Delete(path), retryStrategy, RetryAttempts);
         }
 
         public bool IsValidFilterExpression(string filter)

--- a/test/coverlet.core.tests/Coverage/InstrumenterHelper.cs
+++ b/test/coverlet.core.tests/Coverage/InstrumenterHelper.cs
@@ -178,7 +178,6 @@ namespace Coverlet.Core.Tests
         public T Do<T>(Func<T> action, Func<TimeSpan> backoffStrategy, int maxAttemptCount = 3)
         {
             var exceptions = new List<Exception>();
-
             for (int attempted = 0; attempted < maxAttemptCount; attempted++)
             {
                 try
@@ -191,7 +190,7 @@ namespace Coverlet.Core.Tests
                 }
                 catch (Exception ex)
                 {
-                    if (ex.ToString().Contains("RestoreOriginalModules"))
+                    if (ex.ToString().Contains("RestoreOriginalModules") || ex.ToString().Contains("RestoreOriginalModule"))
                     {
                         // If we're restoring modules mean that process are closing and we cannot override copied test file because is locked so we hide error
                         // to have a correct process exit value


### PR DESCRIPTION
Closes https://github.com/coverlet-coverage/coverlet/issues/857

Increase retry time, old timeout was ~3 sec now ~12.

cc: @AntiPasha 