### PR TITLE
Add `CoverletReport` MSBuild item in the CoverageResultTask MSBuild task

### DIFF
--- a/Documentation/MSBuildIntegration.md
+++ b/Documentation/MSBuildIntegration.md
@@ -44,6 +44,14 @@ To specify a directory where all results will be written to (especially if using
 dotnet test /p:CollectCoverage=true /p:CoverletOutput='./results/'
 ```
 
+The coverlet MSBuild task sets the `CoverletReport` MSBuild item so that you can easily use the produced coverlet reports. For example, using [ReportGenerator](https://github.com/danielpalme/ReportGenerator#usage--command-line-parameters) to generate an html coverage report.
+
+```xml
+<Target Name="GenerateHtmlCoverageReport" AfterTargets="GenerateCoverageResultAfterTest">
+  <ReportGenerator ReportFiles="@(CoverletReport)" TargetDirectory="../html-coverage-report" />
+</Target>
+```
+
 ### TeamCity Output
 
 Coverlet can output basic code coverage statistics using [TeamCity service messages](https://confluence.jetbrains.com/display/TCD18/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-ServiceMessages).

--- a/src/coverlet.msbuild.tasks/ReportWriter.cs
+++ b/src/coverlet.msbuild.tasks/ReportWriter.cs
@@ -20,7 +20,7 @@ namespace Coverlet.MSbuild.Tasks
             => (_coverletMultiTargetFrameworksCurrentTFM, _directory, _output, _reporter, _fileSystem, _console, _result) =
                 (coverletMultiTargetFrameworksCurrentTFM, directory, output, reporter, fileSystem, console, result);
 
-        public void WriteReport()
+        public string WriteReport()
         {
             string filename = Path.GetFileName(_output);
 
@@ -48,6 +48,7 @@ namespace Coverlet.MSbuild.Tasks
             string report = Path.Combine(_directory, filename);
             _console.WriteLine($"  Generating report '{report}'");
             _fileSystem.WriteAllText(report, _reporter.Report(_result));
+            return report;
         }
     }
 }

--- a/src/coverlet.msbuild.tasks/coverlet.msbuild.targets
+++ b/src/coverlet.msbuild.tasks/coverlet.msbuild.targets
@@ -66,7 +66,9 @@
       ThresholdType="$(ThresholdType)"
       ThresholdStat="$(ThresholdStat)"
       InstrumenterState="$(InstrumenterState)"
-      CoverletMultiTargetFrameworksCurrentTFM="$(_coverletMultiTargetFrameworksCurrentTFM)" />
+      CoverletMultiTargetFrameworksCurrentTFM="$(_coverletMultiTargetFrameworksCurrentTFM)">
+      <Output TaskParameter="ReportItems" ItemName="CoverletReport" />
+    </Coverlet.MSbuild.Tasks.CoverageResultTask>
   </Target>
 
   <Target Name="GenerateCoverageResultAfterTest"

--- a/test/coverlet.core.tests/Reporters/Reporters.cs
+++ b/test/coverlet.core.tests/Reporters/Reporters.cs
@@ -30,13 +30,6 @@ namespace Coverlet.Core.Reporters.Tests
         public void Msbuild_ReportWriter(string coverletMultiTargetFrameworksCurrentTFM, string coverletOutput, string reportFormat, string expectedFileName)
         {
             Mock<IFileSystem> fileSystem = new Mock<IFileSystem>();
-            fileSystem.Setup(f => f.WriteAllText(It.IsAny<string>(), It.IsAny<string>()))
-            .Callback((string path, string contents) =>
-            {
-                // Path.Combine depends on OS so we can change only win side to avoid duplication
-                Assert.Equal(path.Replace('/', Path.DirectorySeparatorChar), expectedFileName.Replace('/', Path.DirectorySeparatorChar));
-            });
-
             Mock<IConsole> console = new Mock<IConsole>();
 
             ReportWriter reportWriter = new ReportWriter(
@@ -49,7 +42,9 @@ namespace Coverlet.Core.Reporters.Tests
                 console.Object,
                 new CoverageResult() { Modules = new Modules() });
 
-            reportWriter.WriteReport();
+            var path = reportWriter.WriteReport();
+            // Path.Combine depends on OS so we can change only win side to avoid duplication
+            Assert.Equal(path.Replace('/', Path.DirectorySeparatorChar), expectedFileName.Replace('/', Path.DirectorySeparatorChar));
         }
     }
 }


### PR DESCRIPTION
So that the coverlet reports can be easily used by other MSBuild tasks. For example, using [ReportGenerator](https://github.com/danielpalme/ReportGenerator#usage--command-line-parameters) to generate an html coverage report.

```xml
<Target Name="GenerateHtmlCoverageReport" AfterTargets="GenerateCoverageResultAfterTest">
  <ReportGenerator ReportFiles="@(CoverletReport)" TargetDirectory="../html-coverage-report" />
</Target>
```