### PR TITLE
Coverage for awaiting ValueTasks

### DIFF
--- a/src/coverlet.core/Symbols/CecilSymbolHelper.cs
+++ b/src/coverlet.core/Symbols/CecilSymbolHelper.cs
@@ -172,6 +172,7 @@ namespace Coverlet.Core.Symbols
                     operand.Name == "get_IsCompleted" &&
                     (
                         operand.DeclaringType.FullName.StartsWith("System.Runtime.CompilerServices.TaskAwaiter") ||
+                        operand.DeclaringType.FullName.StartsWith("System.Runtime.CompilerServices.ValueTaskAwaiter") ||
                         operand.DeclaringType.FullName.StartsWith("System.Runtime.CompilerServices.ConfiguredTaskAwaitable") ||
                         operand.DeclaringType.FullName.StartsWith("System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable")
                     )

--- a/test/coverlet.core.tests/Coverage/CoverageTests.AsyncAwaitValueTask.cs
+++ b/test/coverlet.core.tests/Coverage/CoverageTests.AsyncAwaitValueTask.cs
@@ -1,0 +1,70 @@
+using System.IO;
+using System.Threading.Tasks;
+
+using Coverlet.Core.Samples.Tests;
+using Coverlet.Tests.Xunit.Extensions;
+using Xunit;
+
+namespace Coverlet.Core.Tests
+{
+    public partial class CoverageTests
+    {
+        [Fact]
+        public void AsyncAwaitWithValueTask()
+        {
+            string path = Path.GetTempFileName();
+            try
+            {
+                FunctionExecutor.Run(async (string[] pathSerialize) =>
+                {
+                    CoveragePrepareResult coveragePrepareResult = await TestInstrumentationHelper.Run<AsyncAwaitValueTask>(instance =>
+                    {
+                        instance.SyncExecution();
+
+                        int res = ((ValueTask<int>)instance.AsyncExecution(true)).ConfigureAwait(false).GetAwaiter().GetResult();
+                        res = ((ValueTask<int>)instance.AsyncExecution(1)).ConfigureAwait(false).GetAwaiter().GetResult();
+                        res = ((ValueTask<int>)instance.AsyncExecution(2)).ConfigureAwait(false).GetAwaiter().GetResult();
+                        res = ((ValueTask<int>)instance.AsyncExecution(3)).ConfigureAwait(false).GetAwaiter().GetResult();
+                        res = ((ValueTask<int>)instance.ConfigureAwait()).ConfigureAwait(false).GetAwaiter().GetResult();
+                        res = ((Task<int>)instance.WrappingValueTaskAsTask()).ConfigureAwait(false).GetAwaiter().GetResult();
+
+                        return Task.CompletedTask;
+                    }, persistPrepareResultToFile: pathSerialize[0]);
+                    return 0;
+                }, new string[] { path });
+
+                TestInstrumentationHelper.GetCoverageResult(path)
+                .Document("Instrumentation.AsyncAwaitValueTask.cs")
+                .AssertLinesCovered(BuildConfiguration.Debug,
+                                    // AsyncExecution(bool)
+                                    (12, 1), (13, 1), (15, 1), (16, 1), (18, 1), (19, 1), (21, 1), (23, 1), (24, 0), (25, 0), (26, 0), (28, 1), (29, 1),
+                                    // Async
+                                    (32, 10), (33, 10), (34, 10), (35, 10), (36, 10),
+                                    // AsyncExecution(int)
+                                    (39, 3), (40, 3), (42, 3), (43, 3), (45, 3), (46, 3),
+                                    (49, 1), (50, 1), (51, 1), (54, 1), (55, 1), (56, 1), (59, 1), (60, 1), (62, 1),
+                                    (65, 0), (66, 0), (67, 0), (68, 0), (71, 0),
+                                    // SyncExecution
+                                    (77, 1), (78, 1), (79, 1),
+                                    // Sync
+                                    (82, 1), (83, 1), (84, 1),
+                                    // ConfigureAwait
+                                    (87, 1), (88, 1), (90, 1), (91, 1), (93, 1), (94, 1), (95, 1),
+                                    // WrappingValueTaskAsTask
+                                    (98, 1), (99, 1), (101, 1), (102, 1), (104, 1), (106, 1), (107, 1)
+                                    )
+                .AssertBranchesCovered(BuildConfiguration.Debug,
+                                       // AsyncExecution(bool) if statement
+                                       (23, 0, 0), (23, 1, 1),
+                                       // AsyncExecution(int) switch statement
+                                       (46, 0, 3), (46, 1, 1), (46, 2, 1), (46, 3, 1), (46, 4, 0)
+                                       )
+                .ExpectedTotalNumberOfBranches(BuildConfiguration.Debug, 2);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/test/coverlet.core.tests/Coverage/CoverageTests.AsyncAwaitValueTask.cs
+++ b/test/coverlet.core.tests/Coverage/CoverageTests.AsyncAwaitValueTask.cs
@@ -17,18 +17,16 @@ namespace Coverlet.Core.Tests
             {
                 FunctionExecutor.Run(async (string[] pathSerialize) =>
                 {
-                    CoveragePrepareResult coveragePrepareResult = await TestInstrumentationHelper.Run<AsyncAwaitValueTask>(instance =>
+                    CoveragePrepareResult coveragePrepareResult = await TestInstrumentationHelper.Run<AsyncAwaitValueTask>(async instance =>
                     {
                         instance.SyncExecution();
 
-                        int res = ((ValueTask<int>)instance.AsyncExecution(true)).ConfigureAwait(false).GetAwaiter().GetResult();
-                        res = ((ValueTask<int>)instance.AsyncExecution(1)).ConfigureAwait(false).GetAwaiter().GetResult();
-                        res = ((ValueTask<int>)instance.AsyncExecution(2)).ConfigureAwait(false).GetAwaiter().GetResult();
-                        res = ((ValueTask<int>)instance.AsyncExecution(3)).ConfigureAwait(false).GetAwaiter().GetResult();
-                        res = ((ValueTask<int>)instance.ConfigureAwait()).ConfigureAwait(false).GetAwaiter().GetResult();
+                        int res = await ((ValueTask<int>)instance.AsyncExecution(true)).ConfigureAwait(false);
+                        res = await ((ValueTask<int>)instance.AsyncExecution(1)).ConfigureAwait(false);
+                        res = await ((ValueTask<int>)instance.AsyncExecution(2)).ConfigureAwait(false);
+                        res = await ((ValueTask<int>)instance.AsyncExecution(3)).ConfigureAwait(false);
+                        res = await ((ValueTask<int>)instance.ConfigureAwait()).ConfigureAwait(false);
                         res = ((Task<int>)instance.WrappingValueTaskAsTask()).ConfigureAwait(false).GetAwaiter().GetResult();
-
-                        return Task.CompletedTask;
                     }, persistPrepareResultToFile: pathSerialize[0]);
                     return 0;
                 }, new string[] { path });

--- a/test/coverlet.core.tests/Samples/Instrumentation.AsyncAwaitValueTask.cs
+++ b/test/coverlet.core.tests/Samples/Instrumentation.AsyncAwaitValueTask.cs
@@ -1,0 +1,109 @@
+// Remember to use full name because adding new using directives change line numbers
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Coverlet.Core.Samples.Tests
+{
+    public class AsyncAwaitValueTask
+    {
+        async public ValueTask<int> AsyncExecution(bool skipLast)
+        {
+            var bytes = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+
+            var stream = new MemoryStream(bytes);
+            stream.Position = 0;
+
+            int res = 0;
+            res += await Async(stream);
+
+            res += await Async(stream);
+
+            if (!skipLast)
+            {
+                res += await Async(stream);
+            }
+
+            return res;
+        }
+
+        async public ValueTask<int> Async(System.IO.MemoryStream stream)
+        {
+            var buffer = new byte[4];
+            await stream.ReadAsync(buffer.AsMemory());      // This overload of ReadAsync() returns a ValueTask<int>
+            return buffer[0] + buffer[1] + buffer[2] + buffer[3];
+        }
+
+        async public ValueTask<int> AsyncExecution(int val)
+        {
+            var bytes = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 };
+
+            var stream = new MemoryStream(bytes);
+            stream.Position = 0;
+
+            int res = 0;
+            switch (val)
+            {
+                case 1:
+                    {
+                        res += await Async(stream);
+                        break;
+                    }
+                case 2:
+                    {
+                        res += await Async(stream) + await Async(stream);
+                        break;
+                    }
+                case 3:
+                    {
+                        res += await Async(stream) + await Async(stream) +
+                               await Async(stream);
+                        break;
+                    }
+                case 4:
+                    {
+                        res += await Async(stream) + await Async(stream) +
+                               await Async(stream) + await Async(stream);
+                        break;
+                    }
+                default:
+                    break;
+            }
+            return res;
+        }
+
+        async public ValueTask SyncExecution()
+        {
+            await Sync();
+        }
+
+        public ValueTask Sync()
+        {
+            return default(ValueTask);
+        }
+
+        async public ValueTask<int> ConfigureAwait()
+        {
+            var bytes = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+
+            var stream = new MemoryStream(bytes);
+            stream.Position = 0;
+
+            await Async(stream).ConfigureAwait(false);
+            return 42;
+        }
+
+        async public Task<int> WrappingValueTaskAsTask()
+        {
+            var bytes = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+
+            var stream = new MemoryStream(bytes);
+            stream.Position = 0;
+
+            var task = Async(stream).AsTask();
+
+            return await task;
+        }
+    }
+}

--- a/test/coverlet.core.tests/Samples/Samples.cs
+++ b/test/coverlet.core.tests/Samples/Samples.cs
@@ -189,6 +189,14 @@ namespace Coverlet.Core.Samples.Tests
         }
     }
 
+    public class AsyncAwaitValueTaskStateMachine
+    {
+        async public ValueTask AsyncAwait()
+        {
+            await default(ValueTask);
+        }
+    }
+
     [ExcludeFromCoverage]
     public class ClassExcludedByCoverletCodeCoverageAttr
     {

--- a/test/coverlet.core.tests/Symbols/CecilSymbolHelperTests.cs
+++ b/test/coverlet.core.tests/Symbols/CecilSymbolHelperTests.cs
@@ -295,6 +295,22 @@ namespace Coverlet.Core.Symbols.Tests
         }
 
         [Fact]
+        public void GetBranchPoints_IgnoresBranchesIn_AsyncAwaitValueTaskStateMachine()
+        {
+            // arrange
+            var nestedName = typeof(AsyncAwaitValueTaskStateMachine).GetNestedTypes(BindingFlags.NonPublic).First().Name;
+            var type = _module.Types.FirstOrDefault(x => x.FullName == typeof(AsyncAwaitValueTaskStateMachine).FullName);
+            var nestedType = type.NestedTypes.FirstOrDefault(x => x.FullName.EndsWith(nestedName));
+            var method = nestedType.Methods.First(x => x.FullName.EndsWith("::MoveNext()"));
+
+            // act
+            var points = _cecilSymbolHelper.GetBranchPoints(method);
+
+            // assert
+            Assert.Empty(points);
+        }
+
+        [Fact]
         public void GetBranchPoints_ExceptionFilter()
         {
             // arrange


### PR DESCRIPTION
For issue #907, first, I added a failing unit test, in two parts:

* A new AsyncAwaitValueTaskStateMachine class in Samples.cs
  in coverlet.core.tests/Samples, in line with the existing
  AsyncAwaitStateMachine class, but returning a completed
  ValueTask instead of a completed Task.

* A new test in CecilSymbolHelperTests.cs in
  coverlet.core.tests/Symbols that expects the "await" in
  that sample class not to have a branch in it.

After it failed, I updated CecilSymbolHelper to include
get_IsCompleted from System.Runtime.CompilerServices.ValueTaskAwaiter,
as suggested by @a-jackson in issue #907.  The test passed.

One open question is whether it might be worth adding a
ValueTask-based analogue for the Instrumentation.AsyncAwait.cs
samples.