### PR TITLE
A couple of code quality fixes

### DIFF
--- a/src/coverlet.core/Helpers/SourceRootTranslator.cs
+++ b/src/coverlet.core/Helpers/SourceRootTranslator.cs
@@ -40,7 +40,7 @@ namespace Coverlet.Core.Helpers
             {
                 throw new FileNotFoundException("Module test path not found", moduleTestPath);
             }
-            _sourceRootMapping = LoadSourceRootMapping(Path.GetDirectoryName(moduleTestPath)) ?? new Dictionary<string, List<SourceRootMapping>>();
+            _sourceRootMapping = LoadSourceRootMapping(Path.GetDirectoryName(moduleTestPath));
         }
 
         private Dictionary<string, List<SourceRootMapping>> LoadSourceRootMapping(string directory)

--- a/src/coverlet.core/Symbols/CecilSymbolHelper.cs
+++ b/src/coverlet.core/Symbols/CecilSymbolHelper.cs
@@ -728,7 +728,7 @@ namespace Coverlet.Core.Symbols
                 Instruction startFilter = exceptionHandler.FilterStart;
                 Instruction endFilter = startFilter;
 
-                while (endFilter.OpCode != OpCodes.Endfilter && endFilter != null)
+                while (endFilter != null && endFilter.OpCode != OpCodes.Endfilter)
                 {
                     endFilter = endFilter.Next;
                 }


### PR DESCRIPTION
1. `endFilter.OpCode` was accessed before verifying that `endFilter` is not null.
2. As far as I see, `LoadSourceRootMapping` always returns a value. I.e. `_sourceRootMapping` can't be null.