### PR TITLE
Remove workaround for deterministic build for sdk ge 3.1.100

### DIFF
--- a/Documentation/DeterministicBuild.md
+++ b/Documentation/DeterministicBuild.md
@@ -13,6 +13,10 @@ If for instance we build same project on different machine we'll have different 
 As explained above, to improve the level of security of generated artifacts (suppose for instance DLLs inside the nuget package), we need to apply some signature (signing with certificate) and validate before usage to avoid possible security issues like tampering.  
 Finally thanks to deterministic CI builds (with the `ContinuousIntegrationBuild` property set to `true`) plus signature we can validate artifacts and be sure that binary was build from a specific sources (because there is no hard-coded variables metadata like paths from different build machines).
 
+**Deterministic build is supported without any workaround since version 3.1.100 of .NET Core SDK**
+
+## Workaround only for .NET Core SDK < 3.1.100
+
 At the moment deterministic build works thanks to Roslyn compiler that emits deterministic metadata if `DeterministicSourcePaths` is enabled. Take a look here for more information https://github.com/dotnet/sourcelink/tree/master/docs#deterministicsourcepaths.  
 To allow coverlet to correctly do his work we need to provide information to translate deterministic path to real local path for every project referenced by tests project.  
 The current workaround is to add on top of your repo a `Directory.Build.targets` with inside a simple snippet with custom `target` that supports coverlet resolution algorithm.

--- a/src/coverlet.collector/build/netstandard1.0/coverlet.collector.targets
+++ b/src/coverlet.collector/build/netstandard1.0/coverlet.collector.targets
@@ -22,9 +22,17 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     </PropertyGroup>
   </Target>
 
+  <PropertyGroup>
+    <_CoverletSdkNETCoreSdkVersion>$(NETCoreSdkVersion)</_CoverletSdkNETCoreSdkVersion>
+    <_CoverletSdkNETCoreSdkVersion Condition="$(_CoverletSdkNETCoreSdkVersion.Contains('-'))">$(_CoverletSdkNETCoreSdkVersion.Split('-')[0])</_CoverletSdkNETCoreSdkVersion>
+    <_CoverletSdkMinVersionWithDependencyTarget>3.1.300</_CoverletSdkMinVersionWithDependencyTarget>
+    <_CoverletSourceRootTargetName>CoverletGetPathMap</_CoverletSourceRootTargetName>
+    <_CoverletSourceRootTargetName Condition="'$([System.Version]::Parse($(_CoverletSdkNETCoreSdkVersion)).CompareTo($([System.Version]::Parse($(_CoverletSdkMinVersionWithDependencyTarget)))))' &gt;= '0' ">InitializeSourceRootMappedPaths</_CoverletSourceRootTargetName>
+  </PropertyGroup>
+
   <Target Name="ReferencedPathMaps" BeforeTargets="CoreCompile" DependsOnTargets="ResolveProjectReferences" >
     <MSBuild Projects="@(AnnotatedProjects->'%(FullPath)')"
-             Targets="CoverletGetPathMap"             
+             Targets="$(_CoverletSourceRootTargetName)"
              Properties="TargetFramework=%(AnnotatedProjects.NearestTargetFramework)"
              SkipNonexistentTargets="true">
       <Output TaskParameter="TargetOutputs"

--- a/src/coverlet.msbuild.tasks/coverlet.msbuild.targets
+++ b/src/coverlet.msbuild.tasks/coverlet.msbuild.targets
@@ -3,9 +3,17 @@
   <UsingTask TaskName="Coverlet.MSbuild.Tasks.InstrumentationTask" AssemblyFile="$(CoverletToolsPath)coverlet.msbuild.tasks.dll"/>
   <UsingTask TaskName="Coverlet.MSbuild.Tasks.CoverageResultTask" AssemblyFile="$(CoverletToolsPath)coverlet.msbuild.tasks.dll"/>
 
+  <PropertyGroup>
+    <_CoverletSdkNETCoreSdkVersion>$(NETCoreSdkVersion)</_CoverletSdkNETCoreSdkVersion>
+    <_CoverletSdkNETCoreSdkVersion Condition="$(_CoverletSdkNETCoreSdkVersion.Contains('-'))">$(_CoverletSdkNETCoreSdkVersion.Split('-')[0])</_CoverletSdkNETCoreSdkVersion>
+    <_CoverletSdkMinVersionWithDependencyTarget>3.1.300</_CoverletSdkMinVersionWithDependencyTarget>
+    <_CoverletSourceRootTargetName>CoverletGetPathMap</_CoverletSourceRootTargetName>
+    <_CoverletSourceRootTargetName Condition="'$([System.Version]::Parse($(_CoverletSdkNETCoreSdkVersion)).CompareTo($([System.Version]::Parse($(_CoverletSdkMinVersionWithDependencyTarget)))))' &gt;= '0' ">InitializeSourceRootMappedPaths</_CoverletSourceRootTargetName>
+  </PropertyGroup>
+
   <Target Name="ReferencedPathMaps" BeforeTargets="CoreCompile" DependsOnTargets="ResolveProjectReferences" >
     <MSBuild Projects="@(AnnotatedProjects->'%(FullPath)')"
-             Targets="CoverletGetPathMap"
+             Targets="$(_CoverletSourceRootTargetName)"
              Properties="TargetFramework=%(AnnotatedProjects.NearestTargetFramework)"
              SkipNonexistentTargets="true">
       <Output TaskParameter="TargetOutputs"
@@ -39,7 +47,7 @@
       SingleHit="$(SingleHit)"
       MergeWith="$(MergeWith)"
       UseSourceLink="$(UseSourceLink)"
-      SkipAutoProps="$(SkipAutoProps)" 
+      SkipAutoProps="$(SkipAutoProps)"
       DoesNotReturnAttribute="$(DoesNotReturnAttribute)">
       <Output TaskParameter="InstrumenterState" PropertyName="InstrumenterState"/>
     </Coverlet.MSbuild.Tasks.InstrumentationTask>


### PR DESCRIPTION
Closes https://github.com/coverlet-coverage/coverlet/issues/900

cc: @clairernovotny can you review pls?

I took idea from your code https://github.com/novotnyllc/MSBuildSdkExtras/blob/0a872cc69d447b272cf798497de34f1a66c43362/Source/MSBuild.Sdk.Extras/Build/Core.props#L41
I tried with simple `DependsOnTargets` but if it doesn't exists it will fail and also I should have replicated some code, let me know if you agree with this implementation.
Did also manual check and seems to work.

