### PR TITLE
Mention the actual missing path in exception output when SourceRootTranslator constructor fails.

### DIFF
--- a/src/coverlet.core/Helpers/SourceRootTranslator.cs
+++ b/src/coverlet.core/Helpers/SourceRootTranslator.cs
@@ -38,7 +38,7 @@ namespace Coverlet.Core.Helpers
             }
             if (!_fileSystem.Exists(moduleTestPath))
             {
-                throw new FileNotFoundException("Module test path not found", moduleTestPath);
+                throw new FileNotFoundException($"Module test path '{moduleTestPath}' not found", moduleTestPath);
             }
             _sourceRootMapping = LoadSourceRootMapping(Path.GetDirectoryName(moduleTestPath)) ?? new Dictionary<string, List<SourceRootMapping>>();
         }


### PR DESCRIPTION
When the SourceRootTranslator constructor fails due to a missing file, the actual path is not mentioned. Instead, the output mentiones the csproj file after the error message, misleading the user into thinking that the project file could not be found or accesed:

> C:\Some\Path\nuget\coverlet.msbuild\2.9.0\build\coverlet.msbuild.targets(31,5): error : Module test path not found [C:\Some\Path\AddOn\Tests\UnitTests\UnitTests.csproj]

This patch includes the path of the missing file in the exception message, so the user knows which file actually could not be found:

> C:\Some\Path\nuget\coverlet.msbuild\2.9.2-g4b933871de\build\coverlet.msbuild.targets(31,5): error : Module test path 'C:\Some\Path\AddOn\Tests\UnitTests\bin\Debug\CODESYS.CAS.Connector.UnitTests.dll' not found [C:\Some\Path\AddOn\Tests\UnitTests\UnitTests.csproj]

My guess is that performance is not really negatively affected, as this only happens in a code path where the test execution fails anyways.

I also hope this qualifies as "very small change" according to https://github.com/coverlet-coverage/coverlet/blob/master/CONTRIBUTING.md, so I did not open an issue before the merge request. :-)