### PR TITLE
Allow standalone coverlet usage for integration/end-to-end tests using .NET tool driver

### DIFF
--- a/Documentation/GlobalTool.md
+++ b/Documentation/GlobalTool.md
@@ -9,12 +9,12 @@ coverlet --help
 The current options are (output of `coverlet --help`):
 
 ```bash
-Cross platform .NET Core code coverage tool 1.0.0.0
+Cross platform .NET Core code coverage tool 3.0.0.0
 
-Usage: coverlet [arguments] [options]
+Usage: coverlet [options] <<ASSEMBLY> or <APP DIR>>
 
 Arguments:
-  <ASSEMBLY>  Path to the test assembly.
+  <ASSEMBLY> or <APP DIR>      Path to the test assembly or application directory.
 
 Options:
   -h|--help                    Show help information
@@ -23,21 +23,21 @@ Options:
   -a|--targetargs              Arguments to be passed to the test runner.
   -o|--output                  Output of the generated coverage report
   -v|--verbosity               Sets the verbosity level of the command. Allowed values are quiet, minimal, normal, detailed.
-  -f|--format                  Format of the generated coverage report[multiple value].
+  -f|--format                  Format of the generated coverage report.
   --threshold                  Exits with error if the coverage % is below value.
-  --threshold-type             Coverage type to apply the threshold to[multiple value].
+  --threshold-type             Coverage type to apply the threshold to.
   --threshold-stat             Coverage statistic used to enforce the threshold value.
-  --exclude                    Filter expressions to exclude specific modules and types[multiple value].
-  --include                    Filter expressions to include specific modules and types[multiple value].
-  --include-directory          Include directories containing additional assemblies to be instrumented[multiple value].
-  --exclude-by-file            Glob patterns specifying source files to exclude[multiple value].
-  --exclude-by-attribute       Attributes to exclude from code coverage[multiple value].
+  --exclude                    Filter expressions to exclude specific modules and types.
+  --include                    Filter expressions to include only specific modules and types.
+  --exclude-by-file            Glob patterns specifying source files to exclude.
+  --include-directory          Include directories containing additional assemblies to be instrumented.
+  --exclude-by-attribute       Attributes to exclude from code coverage.
   --include-test-assembly      Specifies whether to report code coverage of the test assembly.
-  --single-hit                 Specifies whether to limit code coverage hit reporting to a single hit for each location.
+  --single-hit                 Specifies whether to limit code coverage hit reporting to a single hit for each location
+  --skipautoprops              Neither track nor record auto-implemented properties.
   --merge-with                 Path to existing coverage result to merge.
   --use-source-link            Specifies whether to use SourceLink URIs in place of file system paths.
-  --skipautoprops              Neither track nor record auto-implemented properties.
-  --does-not-return-attribute  Attributes that mark methods that do not return[multiple value].
+  --does-not-return-attribute  Attributes that mark methods that do not return.
 ```
 
 NB. For a [multiple value] options you have to specify values multiple times i.e.
@@ -59,6 +59,22 @@ coverlet /path/to/test-assembly.dll --target "dotnet" --targetargs "test /path/t
 After the above command is run, a `coverage.json` file containing the results will be generated in the directory the `coverlet` command was run. A summary of the results will also be displayed in the terminal.
 
 _Note: The `--no-build` flag is specified so that the `/path/to/test-assembly.dll` isn't rebuilt_
+
+## Code Coverage for integration tests and end-to-end tests.
+
+Sometimes there are tests that doesn't use classic tests framework like XUnit/NUnit and so on.  
+For instance suppose to have some integration end-to-end tests where you do some calls to a backend web site with Selenium and at the end do assertions on database data. In this use case there is no test engine involved but simple script to startup tests and do evaluation at the end. 
+To gather the coverage for this kind of tests you can use Coverlet .NET tool and startup tests through our driver.  
+For instance suppose to have a folder `/application` where you've built your project and where there is the app entry point `myapp` file.
+You can use our tool to startup the app and gather live coverage:
+bash
+```
+coverlet "/application" --target "/application/myapp"
+```
+Coverlet will instrument all assemblies inside de `application` folder and after it will start the `myapp` application. Finally at shutdown of your app it will generate the coverage report. You can use all parameters available to customize the report generation.  
+
+**CAVEAT: today  Coverlet relies on `AppDomain.CurrentDomain.ProcessExit` and `AppDomain.CurrentDomain.DomainUnload` to register coverage hits on file system for the accounting, due to this you need to ensure a gracefully process shutdown. If you'll kill the process you won't get correct coverage report.**
+
 
 ## Coverage Output
 

--- a/Documentation/GlobalTool.md
+++ b/Documentation/GlobalTool.md
@@ -11,10 +11,10 @@ The current options are (output of `coverlet --help`):
 ```bash
 Cross platform .NET Core code coverage tool 3.0.0.0
 
-Usage: coverlet [options] <<ASSEMBLY> or <APP DIR>>
+Usage: coverlet [arguments] [options]
 
 Arguments:
-  <ASSEMBLY> or <APP DIR>      Path to the test assembly or application directory.
+  <ASSEMBLY|DIRECTORY>         Path to the test assembly or application directory.
 
 Options:
   -h|--help                    Show help information
@@ -62,19 +62,17 @@ _Note: The `--no-build` flag is specified so that the `/path/to/test-assembly.dl
 
 ## Code Coverage for integration tests and end-to-end tests.
 
-Sometimes there are tests that doesn't use classic tests framework like XUnit/NUnit and so on.  
-For instance suppose to have some integration end-to-end tests where you do some calls to a backend web site with Selenium and at the end do assertions on database data. In this use case there is no test engine involved but simple script to startup tests and do evaluation at the end. 
-To gather the coverage for this kind of tests you can use Coverlet .NET tool and startup tests through our driver.  
-For instance suppose to have a folder `/application` where you've built your project and where there is the app entry point `myapp` file.
-You can use our tool to startup the app and gather live coverage:
-bash
-```
-coverlet "/application" --target "/application/myapp"
-```
-Coverlet will instrument all assemblies inside de `application` folder and after it will start the `myapp` application. Finally at shutdown of your app it will generate the coverage report. You can use all parameters available to customize the report generation.  
+Sometimes, there are tests that doesn't use regular unit test frameworks like xunit. You may find yourself in a situation where your tests are driven by a custom executable/script, which when run, could do anything from making API calls to driving Selenium.
 
-**CAVEAT: today  Coverlet relies on `AppDomain.CurrentDomain.ProcessExit` and `AppDomain.CurrentDomain.DomainUnload` to register coverage hits on file system for the accounting, due to this you need to ensure a gracefully process shutdown. If you'll kill the process you won't get correct coverage report.**
+As an example, suppose you have a folder `/integrationtest` which contains said executable (lets call it `runner.exe`) and everything it needs to successfully execute. You can use our tool to startup the executable and gather live coverage:
 
+```bash
+coverlet "/integrationtest" --target "/application/runner.exe"
+```
+
+Coverlet will first instrument all .NET assemblies within the `integrationtests` folder, after which it will execute `runner.exe`. Finally, at shutdown of your `runner.exe`, it will generate the coverage report. You can use all parameters available to customize the report generation. Coverage results will be generated once `runner.exe` exits. You can use all parameters available to customize the report generation.
+
+_Note: Today, Coverlet relies on `AppDomain.CurrentDomain.ProcessExit` and `AppDomain.CurrentDomain.DomainUnload` to record hits to the filesystem, as a result, you need to ensure a graceful process shutdown. Forcefully, killing the process will result in an incomplete coverage report._
 
 ## Coverage Output
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Coverlet can be used through three different *drivers*
 
 * VSTest engine integration
 * MSBuild task integration
-* As a .NET Global tool(used also for integration test, end-to-end tests)
+* As a .NET Global tool (supports standalone integration tests)
 
 Coverlet supports only SDK-style projects https://docs.microsoft.com/en-us/visualstudio/msbuild/how-to-use-project-sdk?view=vs-2019  
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Coverlet can be used through three different *drivers*
 
 * VSTest engine integration
 * MSBuild task integration
-* As a .NET Global tool  
+* As a .NET Global tool(used also for integration test, end-to-end tests)
 
 Coverlet supports only SDK-style projects https://docs.microsoft.com/en-us/visualstudio/msbuild/how-to-use-project-sdk?view=vs-2019  
 

--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -44,7 +44,7 @@ namespace Coverlet.Console
             app.VersionOption("-v|--version", GetAssemblyVersion());
             int exitCode = (int)CommandExitCodes.Success;
 
-            CommandArgument module = app.Argument("<ASSEMBLY>", "Path to the test assembly.");
+            CommandArgument moduleOrAppDirectory = app.Argument("<ASSEMBLY> or <APP DIR>", "Path to the test assembly or application directory.");
             CommandOption target = app.Option("-t|--target", "Path to the test runner application.", CommandOptionType.SingleValue);
             CommandOption targs = app.Option("-a|--targetargs", "Arguments to be passed to the test runner.", CommandOptionType.SingleValue);
             CommandOption output = app.Option("-o|--output", "Output of the generated coverage report", CommandOptionType.SingleValue);
@@ -67,8 +67,8 @@ namespace Coverlet.Console
 
             app.OnExecute(() =>
             {
-                if (string.IsNullOrEmpty(module.Value) || string.IsNullOrWhiteSpace(module.Value))
-                    throw new CommandParsingException(app, "No test assembly specified.");
+                if (string.IsNullOrEmpty(moduleOrAppDirectory.Value) || string.IsNullOrWhiteSpace(moduleOrAppDirectory.Value))
+                    throw new CommandParsingException(app, "No test assembly or application directory specified.");
 
                 if (!target.HasValue())
                     throw new CommandParsingException(app, "Target must be specified.");
@@ -94,7 +94,7 @@ namespace Coverlet.Console
                     DoesNotReturnAttributes = doesNotReturnAttributes.Values.ToArray()
                 };
 
-                Coverage coverage = new Coverage(module.Value,
+                Coverage coverage = new Coverage(moduleOrAppDirectory.Value,
                                                  parameters,
                                                  logger,
                                                  serviceProvider.GetRequiredService<IInstrumentationHelper>(),

--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -44,7 +44,7 @@ namespace Coverlet.Console
             app.VersionOption("-v|--version", GetAssemblyVersion());
             int exitCode = (int)CommandExitCodes.Success;
 
-            CommandArgument moduleOrAppDirectory = app.Argument("<ASSEMBLY> or <APP DIR>", "Path to the test assembly or application directory.");
+            CommandArgument moduleOrAppDirectory = app.Argument("<ASSEMBLY|DIRECTORY>", "Path to the test assembly or application directory.");
             CommandOption target = app.Option("-t|--target", "Path to the test runner application.", CommandOptionType.SingleValue);
             CommandOption targs = app.Option("-a|--targetargs", "Arguments to be passed to the test runner.", CommandOptionType.SingleValue);
             CommandOption output = app.Option("-o|--output", "Output of the generated coverage report", CommandOptionType.SingleValue);

--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -29,7 +29,7 @@ namespace Coverlet.Core
 
     internal class Coverage
     {
-        private string _module;
+        private string _moduleOrAppDirectory;
         private string _identifier;
         private string[] _includeFilters;
         private string[] _includeDirectories;
@@ -54,7 +54,7 @@ namespace Coverlet.Core
             get { return _identifier; }
         }
 
-        public Coverage(string module,
+        public Coverage(string moduleOrDirectory,
             CoverageParameters parameters,
             ILogger logger,
             IInstrumentationHelper instrumentationHelper,
@@ -62,7 +62,7 @@ namespace Coverlet.Core
             ISourceRootTranslator sourceRootTranslator,
             ICecilSymbolHelper cecilSymbolHelper)
         {
-            _module = module;
+            _moduleOrAppDirectory = moduleOrDirectory;
             _includeFilters = parameters.IncludeFilters;
             _includeDirectories = parameters.IncludeDirectories ?? Array.Empty<string>();
             _excludeFilters = parameters.ExcludeFilters;
@@ -91,7 +91,7 @@ namespace Coverlet.Core
                         ISourceRootTranslator sourceRootTranslator)
         {
             _identifier = prepareResult.Identifier;
-            _module = prepareResult.Module;
+            _moduleOrAppDirectory = prepareResult.ModuleOrDirectory;
             _mergeWith = prepareResult.MergeWith;
             _useSourceLink = prepareResult.UseSourceLink;
             _results = new List<InstrumenterResult>(prepareResult.Results);
@@ -103,7 +103,7 @@ namespace Coverlet.Core
 
         public CoveragePrepareResult PrepareModules()
         {
-            string[] modules = _instrumentationHelper.GetCoverableModules(_module, _includeDirectories, _includeTestAssembly);
+            string[] modules = _instrumentationHelper.GetCoverableModules(_moduleOrAppDirectory, _includeDirectories, _includeTestAssembly);
 
             Array.ForEach(_excludeFilters ?? Array.Empty<string>(), filter => _logger.LogVerbose($"Excluded module filter '{filter}'"));
             Array.ForEach(_includeFilters ?? Array.Empty<string>(), filter => _logger.LogVerbose($"Included module filter '{filter}'"));
@@ -161,7 +161,7 @@ namespace Coverlet.Core
             return new CoveragePrepareResult()
             {
                 Identifier = _identifier,
-                Module = _module,
+                ModuleOrDirectory = _moduleOrAppDirectory,
                 MergeWith = _mergeWith,
                 UseSourceLink = _useSourceLink,
                 Results = _results.ToArray()

--- a/src/coverlet.core/CoveragePrepareResult.cs
+++ b/src/coverlet.core/CoveragePrepareResult.cs
@@ -13,7 +13,7 @@ namespace Coverlet.Core
         [DataMember]
         public string Identifier { get; set; }
         [DataMember]
-        public string Module { get; set; }
+        public string ModuleOrDirectory { get; set; }
         [DataMember]
         public string MergeWith { get; set; }
         [DataMember]

--- a/src/coverlet.core/Helpers/InstrumentationHelper.cs
+++ b/src/coverlet.core/Helpers/InstrumentationHelper.cs
@@ -36,7 +36,9 @@ namespace Coverlet.Core.Helpers
             Debug.Assert(directories != null);
             Debug.Assert(moduleOrAppDirectory != null);
 
-            string moduleDirectory = Path.GetDirectoryName(moduleOrAppDirectory);
+            bool isAppDirectory = !File.Exists(moduleOrAppDirectory) && Directory.Exists(moduleOrAppDirectory);
+
+            string moduleDirectory = isAppDirectory ? moduleOrAppDirectory : Path.GetDirectoryName(moduleOrAppDirectory);
             if (moduleDirectory == string.Empty)
             {
                 moduleDirectory = Directory.GetCurrentDirectory();
@@ -68,7 +70,7 @@ namespace Coverlet.Core.Helpers
             // The module's name must be unique.
             var uniqueModules = new HashSet<string>();
 
-            if (!includeTestAssembly && File.Exists(moduleDirectory))
+            if (!includeTestAssembly && !isAppDirectory)
                 uniqueModules.Add(Path.GetFileName(moduleOrAppDirectory));
 
             return dirs.SelectMany(d => Directory.EnumerateFiles(d))

--- a/src/coverlet.core/Helpers/InstrumentationHelper.cs
+++ b/src/coverlet.core/Helpers/InstrumentationHelper.cs
@@ -31,11 +31,12 @@ namespace Coverlet.Core.Helpers
             _sourceRootTranslator = sourceRootTranslator;
         }
 
-        public string[] GetCoverableModules(string module, string[] directories, bool includeTestAssembly)
+        public string[] GetCoverableModules(string moduleOrAppDirectory, string[] directories, bool includeTestAssembly)
         {
             Debug.Assert(directories != null);
+            Debug.Assert(moduleOrAppDirectory != null);
 
-            string moduleDirectory = Path.GetDirectoryName(module);
+            string moduleDirectory = Path.GetDirectoryName(moduleOrAppDirectory);
             if (moduleDirectory == string.Empty)
             {
                 moduleDirectory = Directory.GetCurrentDirectory();
@@ -67,8 +68,8 @@ namespace Coverlet.Core.Helpers
             // The module's name must be unique.
             var uniqueModules = new HashSet<string>();
 
-            if (!includeTestAssembly)
-                uniqueModules.Add(Path.GetFileName(module));
+            if (!includeTestAssembly && File.Exists(moduleDirectory))
+                uniqueModules.Add(Path.GetFileName(moduleOrAppDirectory));
 
             return dirs.SelectMany(d => Directory.EnumerateFiles(d))
                 .Where(m => IsAssembly(m) && uniqueModules.Add(Path.GetFileName(m)))

--- a/src/coverlet.core/Helpers/InstrumentationHelper.cs
+++ b/src/coverlet.core/Helpers/InstrumentationHelper.cs
@@ -37,8 +37,8 @@ namespace Coverlet.Core.Helpers
             Debug.Assert(moduleOrAppDirectory != null);
 
             bool isAppDirectory = !File.Exists(moduleOrAppDirectory) && Directory.Exists(moduleOrAppDirectory);
-
             string moduleDirectory = isAppDirectory ? moduleOrAppDirectory : Path.GetDirectoryName(moduleOrAppDirectory);
+
             if (moduleDirectory == string.Empty)
             {
                 moduleDirectory = Directory.GetCurrentDirectory();

--- a/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
+++ b/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
@@ -208,9 +208,13 @@ namespace Coverlet.Core.Helpers.Tests
         public void TestIncludeDirectories()
         {
             string module = typeof(InstrumentationHelperTests).Assembly.Location;
-
             DirectoryInfo newDir = Directory.CreateDirectory("TestIncludeDirectories");
+            newDir.Delete(true);
+            newDir.Create();
             DirectoryInfo newDir2 = Directory.CreateDirectory("TestIncludeDirectories2");
+            newDir2.Delete(true);
+            newDir2.Create();
+
             File.Copy(module, Path.Combine(newDir.FullName, Path.GetFileName(module)));
             module = Path.Combine(newDir.FullName, Path.GetFileName(module));
             File.Copy("coverlet.msbuild.tasks.dll", Path.Combine(newDir.FullName, "coverlet.msbuild.tasks.dll"));
@@ -224,6 +228,12 @@ namespace Coverlet.Core.Helpers.Tests
             Assert.Equal(2, moreThanOneDirectory.Length);
             Assert.Equal("coverlet.msbuild.tasks.dll", Path.GetFileName(moreThanOneDirectory[0]));
             Assert.Equal("coverlet.core.dll", Path.GetFileName(moreThanOneDirectory[1]));
+
+            var moreThanOneDirectoryPlusTestAssembly = _instrumentationHelper.GetCoverableModules(module, new string[] { newDir2.FullName }, true);
+            Assert.Equal(3, moreThanOneDirectoryPlusTestAssembly.Length);
+            Assert.Equal("coverlet.core.tests.dll", Path.GetFileName(moreThanOneDirectoryPlusTestAssembly[0]));
+            Assert.Equal("coverlet.msbuild.tasks.dll", Path.GetFileName(moreThanOneDirectoryPlusTestAssembly[1]));
+            Assert.Equal("coverlet.core.dll", Path.GetFileName(moreThanOneDirectoryPlusTestAssembly[2]));
 
             newDir.Delete(true);
             newDir2.Delete(true);

--- a/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
+++ b/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
@@ -224,14 +224,16 @@ namespace Coverlet.Core.Helpers.Tests
             Assert.Single(currentDirModules);
             Assert.Equal("coverlet.msbuild.tasks.dll", Path.GetFileName(currentDirModules[0]));
 
-            var moreThanOneDirectory = _instrumentationHelper.GetCoverableModules(module, new string[] { newDir2.FullName }, false)
+            var moreThanOneDirectory = _instrumentationHelper
+                                       .GetCoverableModules(module, new string[] { newDir2.FullName }, false)
                                        .OrderBy(f => f).ToArray();
 
             Assert.Equal(2, moreThanOneDirectory.Length);
             Assert.Equal("coverlet.msbuild.tasks.dll", Path.GetFileName(moreThanOneDirectory[0]));
             Assert.Equal("coverlet.core.dll", Path.GetFileName(moreThanOneDirectory[1]));
 
-            var moreThanOneDirectoryPlusTestAssembly = _instrumentationHelper.GetCoverableModules(module, new string[] { newDir2.FullName }, true)
+            var moreThanOneDirectoryPlusTestAssembly = _instrumentationHelper
+                                                       .GetCoverableModules(module, new string[] { newDir2.FullName }, true)
                                                        .OrderBy(f => f).ToArray();
 
             Assert.Equal(3, moreThanOneDirectoryPlusTestAssembly.Length);

--- a/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
+++ b/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
@@ -224,12 +224,16 @@ namespace Coverlet.Core.Helpers.Tests
             Assert.Single(currentDirModules);
             Assert.Equal("coverlet.msbuild.tasks.dll", Path.GetFileName(currentDirModules[0]));
 
-            var moreThanOneDirectory = _instrumentationHelper.GetCoverableModules(module, new string[] { newDir2.FullName }, false);
+            var moreThanOneDirectory = _instrumentationHelper.GetCoverableModules(module, new string[] { newDir2.FullName }, false)
+                                       .OrderBy(f => f).ToArray();
+
             Assert.Equal(2, moreThanOneDirectory.Length);
             Assert.Equal("coverlet.msbuild.tasks.dll", Path.GetFileName(moreThanOneDirectory[0]));
             Assert.Equal("coverlet.core.dll", Path.GetFileName(moreThanOneDirectory[1]));
 
-            var moreThanOneDirectoryPlusTestAssembly = _instrumentationHelper.GetCoverableModules(module, new string[] { newDir2.FullName }, true);
+            var moreThanOneDirectoryPlusTestAssembly = _instrumentationHelper.GetCoverableModules(module, new string[] { newDir2.FullName }, true)
+                                                       .OrderBy(f => f).ToArray();
+
             Assert.Equal(3, moreThanOneDirectoryPlusTestAssembly.Length);
             Assert.Equal("coverlet.core.tests.dll", Path.GetFileName(moreThanOneDirectoryPlusTestAssembly[0]));
             Assert.Equal("coverlet.msbuild.tasks.dll", Path.GetFileName(moreThanOneDirectoryPlusTestAssembly[1]));

--- a/test/coverlet.core.tests/Instrumentation/InstrumenterResultTests.cs
+++ b/test/coverlet.core.tests/Instrumentation/InstrumenterResultTests.cs
@@ -29,7 +29,7 @@ namespace Coverlet.Core.Instrumentation.Tests
             CoveragePrepareResult cpr = new CoveragePrepareResult();
             cpr.Identifier = "Identifier";
             cpr.MergeWith = "MergeWith";
-            cpr.Module = "Module";
+            cpr.ModuleOrDirectory = "Module";
             cpr.UseSourceLink = true;
 
             InstrumenterResult ir = new InstrumenterResult();
@@ -99,7 +99,7 @@ namespace Coverlet.Core.Instrumentation.Tests
 
             Assert.Equal(cpr.Identifier, roundTrip.Identifier);
             Assert.Equal(cpr.MergeWith, roundTrip.MergeWith);
-            Assert.Equal(cpr.Module, roundTrip.Module);
+            Assert.Equal(cpr.ModuleOrDirectory, roundTrip.ModuleOrDirectory);
             Assert.Equal(cpr.UseSourceLink, roundTrip.UseSourceLink);
 
             for (int i = 0; i < cpr.Results.Length; i++)

--- a/test/coverlet.integration.template/Program.cs
+++ b/test/coverlet.integration.template/Program.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+using Coverlet.Integration.Template;
+
+namespace HelloWorld
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            DeepThought dt = new DeepThought();
+            dt.AnswerToTheUltimateQuestionOfLifeTheUniverseAndEverything();
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/test/coverlet.integration.template/coverlet.integration.template.csproj
+++ b/test/coverlet.integration.template/coverlet.integration.template.csproj
@@ -5,6 +5,8 @@
     <IsPackable>false</IsPackable>
     <AssemblyName>coverletsamplelib.integration.template</AssemblyName>
     <IsTestProject>false</IsTestProject>
+    <OutputType>Exe</OutputType>
+    <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/coverlet.integration.tests/DotnetTool.cs
+++ b/test/coverlet.integration.tests/DotnetTool.cs
@@ -29,5 +29,20 @@ namespace Coverlet.Integration.Tests
             Assert.Contains("Test Run Successful.", standardOutput);
             AssertCoverage(clonedTemplateProject, standardOutput: standardOutput);
         }
+
+        [ConditionalFact]
+        [SkipOnOS(OS.Linux)]
+        [SkipOnOS(OS.MacOS)]
+        public void StandAlone()
+        {
+            using ClonedTemplateProject clonedTemplateProject = CloneTemplateProject();
+            UpdateNugeConfigtWithLocalPackageFolder(clonedTemplateProject.ProjectRootPath!);
+            string coverletToolCommandPath = InstallTool(clonedTemplateProject.ProjectRootPath!);
+            DotnetCli($"build {clonedTemplateProject.ProjectRootPath}", out string standardOutput, out string standardError);
+            string publishedTestFile = clonedTemplateProject.GetFiles("*" + ClonedTemplateProject.AssemblyName + ".dll").Single(f => !f.Contains("obj"));
+            RunCommand(coverletToolCommandPath, $"\"{Path.GetDirectoryName(publishedTestFile)}\" --target \"dotnet\" --targetargs \"{publishedTestFile}\"  --output \"{clonedTemplateProject.ProjectRootPath}\"\\", out standardOutput, out standardError);
+            Assert.Contains("Hello World!", standardOutput);
+            AssertCoverage(clonedTemplateProject, standardOutput: standardOutput);
+        }
     }
 }


### PR DESCRIPTION
contributes https://github.com/coverlet-coverage/coverlet/issues/781

This is an attempt to support end-to-end coverage scenario.
In this case at the end of tests all generated reports should be moved to a folder and merged with report tools like report generator.

@jakubch1 I know that the workflow you described is a bit different(I call it "cold coverage") but at the moment this is the best we can do.

FYI @AbhitejJohn @pavelhorak