### PR TITLE
Escape curly braces in file names when logging

### DIFF
--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -107,7 +107,7 @@ namespace Coverlet.Core
 
             Array.ForEach(_excludeFilters ?? Array.Empty<string>(), filter => _logger.LogVerbose($"Excluded module filter '{filter}'"));
             Array.ForEach(_includeFilters ?? Array.Empty<string>(), filter => _logger.LogVerbose($"Included module filter '{filter}'"));
-            Array.ForEach(_excludedSourceFiles ?? Array.Empty<string>(), filter => _logger.LogVerbose($"Excluded source files filter '{filter}'"));
+            Array.ForEach(_excludedSourceFiles ?? Array.Empty<string>(), filter => _logger.LogVerbose($"Excluded source files filter '{FileSystem.EscapeFileName(filter)}'"));
 
             _excludeFilters = _excludeFilters?.Where(f => _instrumentationHelper.IsValidFilterExpression(f)).ToArray();
             _includeFilters = _includeFilters?.Where(f => _instrumentationHelper.IsValidFilterExpression(f)).ToArray();

--- a/src/coverlet.core/Helpers/FileSystem.cs
+++ b/src/coverlet.core/Helpers/FileSystem.cs
@@ -53,5 +53,11 @@ namespace Coverlet.Core.Helpers
         {
             return File.ReadAllLines(path);
         }
+
+        // Escape format characters in file names
+        internal static string EscapeFileName(string fileName)
+        {
+            return fileName?.Replace("{", "{{").Replace("}", "}}");
+        }
     }
 }

--- a/src/coverlet.core/Helpers/SourceRootTranslator.cs
+++ b/src/coverlet.core/Helpers/SourceRootTranslator.cs
@@ -98,7 +98,7 @@ namespace Coverlet.Core.Helpers
                         if (_fileSystem.Exists(pathToCheck = Path.GetFullPath(originalFileName.Replace(mapping.Key, srm.OriginalPath))))
                         {
                             (_resolutionCacheFiles ??= new Dictionary<string, string>()).Add(originalFileName, pathToCheck);
-                            _logger.LogVerbose($"Mapping resolved: '{originalFileName}' -> '{pathToCheck}'");
+                            _logger.LogVerbose($"Mapping resolved: '{FileSystem.EscapeFileName(originalFileName)}' -> '{FileSystem.EscapeFileName(pathToCheck)}'");
                             return pathToCheck;
                         }
                     }

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -9,6 +9,7 @@ using System.Runtime.CompilerServices;
 using Coverlet.Core.Instrumentation.Reachability;
 using Coverlet.Core.Abstractions;
 using Coverlet.Core.Attributes;
+using Coverlet.Core.Helpers;
 using Coverlet.Core.Symbols;
 using Microsoft.Extensions.FileSystemGlobbing;
 using Mono.Cecil;
@@ -110,7 +111,7 @@ namespace Coverlet.Core.Instrumentation
                         }
                         else
                         {
-                            _logger.LogVerbose($"Unable to instrument module: {_module}, embedded pdb without local source files, [{firstNotFoundDocument}]");
+                            _logger.LogVerbose($"Unable to instrument module: {_module}, embedded pdb without local source files, [{FileSystem.EscapeFileName(firstNotFoundDocument)}]");
                             return false;
                         }
                     }
@@ -122,7 +123,7 @@ namespace Coverlet.Core.Instrumentation
                         }
                         else
                         {
-                            _logger.LogVerbose($"Unable to instrument module: {_module}, pdb without local source files, [{firstNotFoundDocument}]");
+                            _logger.LogVerbose($"Unable to instrument module: {_module}, pdb without local source files, [{FileSystem.EscapeFileName(firstNotFoundDocument)}]");
                             return false;
                         }
                     }
@@ -159,7 +160,7 @@ namespace Coverlet.Core.Instrumentation
             {
                 foreach (string sourceFile in _excludedSourceFiles)
                 {
-                    _logger.LogVerbose($"Excluded source file: '{sourceFile}'");
+                    _logger.LogVerbose($"Excluded source file: '{FileSystem.EscapeFileName(sourceFile)}'");
                 }
             }
 

--- a/test/coverlet.core.tests/Helpers/FileSystemTests.cs
+++ b/test/coverlet.core.tests/Helpers/FileSystemTests.cs
@@ -1,0 +1,20 @@
+using Coverlet.Core.Helpers;
+using Xunit;
+
+namespace Coverlet.Core.Helpers.Tests
+{
+    public class FileSystemTests
+    {
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("", "")]
+        [InlineData("filename.cs", "filename.cs")]
+        [InlineData("filename{T}.cs", "filename{{T}}.cs")]
+        public void TestEscapeFileName(string fileName, string expected)
+        {
+            var actual = FileSystem.EscapeFileName(fileName);
+
+            Assert.Equal(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #998