### PR TITLE
Add VSMac extension to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,14 @@ If you're using [Cake Build](https://cakebuild.net) for your build script you ca
 
 ## Visual Studio Add-In
 
-If you're using Visual Studio, you can use the [Fine Code Coverage](https://marketplace.visualstudio.com/items?itemName=FortuneNgwenya.FineCodeCoverage) extension to visualize coverlet output inside Visual Studio while you code.
-Visualization is updated when you run unit tests in inside Visual Studio.
+If you want to visualize coverlet output inside Visual Studio while you code, you can use the following addins depending on your platform.
+
+### Windows
+If you're using Visual Studio on Windows, you can use the [Fine Code Coverage](https://marketplace.visualstudio.com/items?itemName=FortuneNgwenya.FineCodeCoverage) extension.
+Visualization is updated when you run unit tests inside Visual Studio.
+
+### Mac OS
+If you're using Visual Studio for Mac, you can use the [VSMac-CodeCoverage](https://github.com/ademanuele/VSMac-CodeCoverage) extension.
 
 ## Consume nightly build
 


### PR DESCRIPTION
Hi 👋 

I really like what you have done with coverlet.
Its a great tool and its my goto for coverage on all my projects.

I have been developing a Visual Studio for Mac extension for visualising code coverage which uses coverlet for gathering coverage. The extension is now fairly usable (it only started off as a proof of concept) and was thinking if you would consider adding it to the README here as I see you already reference a Windows alternative.