### PR TITLE
Fix multi-line lambda coverage regression

### DIFF
--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -405,8 +405,8 @@ namespace Coverlet.Core
                     {
                         if (hitCandidate != hitCandidateToCompare && !hitCandidateToCompare.isBranch)
                         {
-                            if (hitCandidateToCompare.start >= hitCandidate.start &&
-                               hitCandidateToCompare.end <= hitCandidate.end)
+                            if (hitCandidateToCompare.start > hitCandidate.start &&
+                               hitCandidateToCompare.end < hitCandidate.end)
                             {
                                 for (int i = hitCandidateToCompare.start;
                                      i <= (hitCandidateToCompare.end == 0 ? hitCandidateToCompare.start : hitCandidateToCompare.end);

--- a/test/coverlet.core.tests/Coverage/CoverageTests.Lambda.cs
+++ b/test/coverlet.core.tests/Coverage/CoverageTests.Lambda.cs
@@ -122,7 +122,6 @@ namespace Coverlet.Core.Tests
                 }, new string[] { path });
 
                 TestInstrumentationHelper.GetCoverageResult(path)
-                .GenerateReport(show: true)
                 .Document("Instrumentation.Lambda.cs")
                 .AssertLinesCoveredFromTo(BuildConfiguration.Debug, 110, 119)
                 .AssertLinesCoveredFromTo(BuildConfiguration.Debug, 122, 124)

--- a/test/coverlet.core.tests/Coverage/CoverageTests.Lambda.cs
+++ b/test/coverlet.core.tests/Coverage/CoverageTests.Lambda.cs
@@ -127,7 +127,7 @@ namespace Coverlet.Core.Tests
                 .AssertLinesCoveredFromTo(BuildConfiguration.Debug, 122, 124)
                 .AssertLinesCoveredFromTo(BuildConfiguration.Debug, 127, 129)
                 .AssertLinesCoveredFromTo(BuildConfiguration.Debug, 131, 131)
-                .AssertLinesCovered((110, 1), (111, 2), (112, 2), (113, 2), (114, 2), (115, 2), (116, 2), (117, 2), (118, 2), (119, 1),
+                .AssertLinesCovered(BuildConfiguration.Debug, (110, 1), (111, 2), (112, 2), (113, 2), (114, 2), (115, 2), (116, 2), (117, 2), (118, 2), (119, 1),
                                     (122, 2), (123, 2), (124, 2),
                                     (127, 2), (128, 2), (129, 2),
                                     (131, 4));

--- a/test/coverlet.core.tests/Coverage/CoverageTests.Lambda.cs
+++ b/test/coverlet.core.tests/Coverage/CoverageTests.Lambda.cs
@@ -102,5 +102,41 @@ namespace Coverlet.Core.Tests
                 File.Delete(path);
             }
         }
+
+        [Fact]
+        public void Issue_1056()
+        {
+            string path = Path.GetTempFileName();
+            try
+            {
+                FunctionExecutor.RunAsync(async (string[] pathSerialize) =>
+                {
+                    CoveragePrepareResult coveragePrepareResult = await TestInstrumentationHelper.Run<Issue_1056>(instance =>
+                    {
+                        instance.T1();
+                        return Task.CompletedTask;
+                    },
+                    persistPrepareResultToFile: pathSerialize[0]);
+
+                    return 0;
+                }, new string[] { path });
+
+                TestInstrumentationHelper.GetCoverageResult(path)
+                .GenerateReport(show: true)
+                .Document("Instrumentation.Lambda.cs")
+                .AssertLinesCoveredFromTo(BuildConfiguration.Debug, 110, 119)
+                .AssertLinesCoveredFromTo(BuildConfiguration.Debug, 122, 124)
+                .AssertLinesCoveredFromTo(BuildConfiguration.Debug, 127, 129)
+                .AssertLinesCoveredFromTo(BuildConfiguration.Debug, 131, 131)
+                .AssertLinesCovered((110, 1), (111, 2), (112, 2), (113, 2), (114, 2), (115, 2), (116, 2), (117, 2), (118, 2), (119, 1),
+                                    (122, 2), (123, 2), (124, 2),
+                                    (127, 2), (128, 2), (129, 2),
+                                    (131, 4));
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
     }
 }

--- a/test/coverlet.core.tests/Coverage/CoverageTests.Lambda.cs
+++ b/test/coverlet.core.tests/Coverage/CoverageTests.Lambda.cs
@@ -109,7 +109,7 @@ namespace Coverlet.Core.Tests
             string path = Path.GetTempFileName();
             try
             {
-                FunctionExecutor.RunAsync(async (string[] pathSerialize) =>
+                FunctionExecutor.Run(async (string[] pathSerialize) =>
                 {
                     CoveragePrepareResult coveragePrepareResult = await TestInstrumentationHelper.Run<Issue_1056>(instance =>
                     {

--- a/test/coverlet.core.tests/Coverage/InstrumenterHelper.Assertions.cs
+++ b/test/coverlet.core.tests/Coverage/InstrumenterHelper.Assertions.cs
@@ -246,6 +246,11 @@ namespace Coverlet.Core.Tests
             return document;
         }
 
+        public static Document AssertLinesCoveredFromTo(this Document document, int from, int to)
+        {
+            return AssertLinesCoveredFromTo(document, BuildConfiguration.Debug | BuildConfiguration.Release, from, to);
+        }
+
         public static Document AssertLinesCoveredFromTo(this Document document, BuildConfiguration configuration, int from, int to)
         {
             if (document is null)

--- a/test/coverlet.core.tests/Samples/Instrumentation.Lambda.cs
+++ b/test/coverlet.core.tests/Samples/Instrumentation.Lambda.cs
@@ -103,4 +103,31 @@ namespace Coverlet.Core.Samples.Tests
             return sum;
         }
     }
+
+    public class Issue_1056
+    {
+        public void T1()
+        {
+            Do(x => WriteLine(x.GetType().Name));
+            Do(x => WriteLine(x
+                .GetType()
+                .Name));
+            Do2(x => x.GetType().Name.Length);
+            Do2(x => x.GetType()
+                .Name
+                .Length);
+        }
+
+        private static void Do(System.Action<object> action)
+        {
+            action(new object());
+        }
+
+        private static object Do2(System.Func<object, object> func)
+        {
+            return func(new object());
+        }
+
+        public void WriteLine(string str) { }
+    }
 }


### PR DESCRIPTION
closes https://github.com/coverlet-coverage/coverlet/issues/1056

Before

![before](https://user-images.githubusercontent.com/7894084/104836560-f3a28400-58ae-11eb-9558-cad56745a770.JPG)

After

![image](https://user-images.githubusercontent.com/7894084/104836581-20ef3200-58af-11eb-94c3-bf2ef9cbb450.png)

cc: @ulrichb @daveMueller 
