### PR TITLE
When collecting coverage data be sure to open the hitfile with read access.

### DIFF
--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -408,7 +408,7 @@ namespace Coverlet.Core
                 }
 
                 var documentsList = result.Documents.Values.ToList();
-                using (var fs = _fileSystem.NewFileStream(result.HitsFilePath, FileMode.Open))
+                using (var fs = _fileSystem.NewFileStream(result.HitsFilePath, FileMode.Open, FileAccess.Read))
                 using (var br = new BinaryReader(fs))
                 {
                     int hitCandidatesCount = br.ReadInt32();
@@ -442,8 +442,15 @@ namespace Coverlet.Core
                     }
                 }
 
-                _instrumentationHelper.DeleteHitsFile(result.HitsFilePath);
-                _logger.LogVerbose($"Hit file '{result.HitsFilePath}' deleted");
+                try
+                {
+                    _instrumentationHelper.DeleteHitsFile(result.HitsFilePath);
+                    _logger.LogVerbose($"Hit file '{result.HitsFilePath}' deleted");
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning($"Unable to remove hit file: {result.HitsFilePath} because : {ex.Message}");
+                }
             }
         }
 


### PR DESCRIPTION
I'm not sure if this warrants an issue, please let me know and I'll open one.

We're starting to use coverlet in the PowerShell project to gather coverage data, but our usage may be outside the norm. We collect coverage via execution of PowerShell script which may be started via `sudo` - so the hit file may have been created by an elevated user. In this environment, opening the hitfile with write privilege fails.  Also, failure to remove the hitfile should not necessarily be fatal (although I have added a warning if the removal fails).

I should have mentioned that I have tested this change and enables us to collect coverage date for PowerShell.
