### PR TITLE
Skip ResolvedFileToPublish list during publish

### DIFF
--- a/src/coverlet.collector/build/netstandard1.0/coverlet.collector.targets
+++ b/src/coverlet.collector/build/netstandard1.0/coverlet.collector.targets
@@ -12,6 +12,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   <Target Name="CopyCoverletDataCollectorFiles" AfterTargets="ComputeFilesToPublish">
     <ItemGroup>
       <CoverletDataCollectorFiles Include="$(MSBuildThisFileDirectory)\*.*" />
+      <CoverletDataCollectorFiles Remove="@(ResolvedFileToPublish->'$(MSBuildThisFileDirectory)%(Filename)%(Extension)')" />
     </ItemGroup>
     <Copy SourceFiles="@(CoverletDataCollectorFiles)" DestinationFolder="$(PublishDir)%(RecursiveDir)" />
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7894084/139463920-a9bad898-40d1-43c4-bca1-e0d802755b64.png)

During publish skip to copy coverlet files if are inside the `ResolvedFileToPublish` list.

fix https://github.com/coverlet-coverage/coverlet/issues/1045
fix https://github.com/coverlet-coverage/coverlet/issues/1226
fix https://github.com/coverlet-coverage/coverlet/issues/1106
fix https://github.com/coverlet-coverage/coverlet/issues/1131

cc: @daveMueller @Haplois 