### PR TITLE
Ensure trailing slash in <SourceRoot>

### DIFF
--- a/DeterministicBuild.targets
+++ b/DeterministicBuild.targets
@@ -9,7 +9,7 @@ https://github.com/dotnet/sourcelink/issues/572 -->
     <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)"/>
   </ItemGroup>
   <ItemGroup>
-    <SourceRoot Include="$(NuGetPackageRoot)" />
+    <SourceRoot Include="$([MSBuild]::EnsureTrailingSlash($(NuGetPackageRoot)))" Condition="'$(NuGetPackageRoot)' != ''" />
   </ItemGroup>
 
   <Target Name="CoverletGetPathMap"

--- a/Documentation/DeterministicBuild.md
+++ b/Documentation/DeterministicBuild.md
@@ -47,7 +47,7 @@ https://github.com/dotnet/sourcelink/issues/572 -->
     <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)"/>
   </ItemGroup>
   <ItemGroup>
-    <SourceRoot Include="$(NuGetPackageRoot)" />
+    <SourceRoot Include="$([MSBuild]::EnsureTrailingSlash($(NuGetPackageRoot)))" Condition="'$(NuGetPackageRoot)' != ''" />
   </ItemGroup>
 
   <Target Name="CoverletGetPathMap"

--- a/Documentation/Examples/MSBuild/DeterministicBuild/DeterministicBuild.targets
+++ b/Documentation/Examples/MSBuild/DeterministicBuild/DeterministicBuild.targets
@@ -9,7 +9,7 @@ https://github.com/dotnet/sourcelink/issues/572 -->
     <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)"/>
   </ItemGroup>
   <ItemGroup>
-    <SourceRoot Include="$(NuGetPackageRoot)" />
+    <SourceRoot Include="$([MSBuild]::EnsureTrailingSlash($(NuGetPackageRoot)))" Condition="'$(NuGetPackageRoot)' != ''" />
   </ItemGroup>
 
   <Target Name="CoverletGetPathMap"

--- a/Documentation/Examples/VSTest/DeterministicBuild/DeterministicBuild.targets
+++ b/Documentation/Examples/VSTest/DeterministicBuild/DeterministicBuild.targets
@@ -9,7 +9,7 @@ https://github.com/dotnet/sourcelink/issues/572 -->
     <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)"/>
   </ItemGroup>
   <ItemGroup>
-    <SourceRoot Include="$(NuGetPackageRoot)" />
+    <SourceRoot Include="$([MSBuild]::EnsureTrailingSlash($(NuGetPackageRoot)))" Condition="'$(NuGetPackageRoot)' != ''" />
   </ItemGroup>
 
   <Target Name="CoverletGetPathMap"


### PR DESCRIPTION
$(NuGetPackageRoot) may not end in a trailing slash, but SourceRoot must end in a trailing slash.

Without a trailing slash, builds produce an error like:
> /opt/dotnet/6.0.100/sdk/6.0.100/Roslyn/Microsoft.Managed.Core.targets(236,5): error : SourceRoot paths are required to end with a slash or backslash: '/var/nuget'

This is the source for the task that generates the exception:
https://github.com/dotnet/roslyn/blob/315c2e149ba7889b0937d872274c33fcbfe9af5f/src/Compilers/Core/MSBuildTask/MapSourceRoots.cs#L113

This has caused issues in consuming projects:
https://github.com/NuGet/Home/issues/9431#issuecomment-637162855
https://github.community/t/nugetpackageroot-should-end-in-slash/138118