### PR TITLE
Handle PDB location when project build externally

### DIFF
--- a/src/coverlet.core/Abstractions/ISourceRootTranslator.cs
+++ b/src/coverlet.core/Abstractions/ISourceRootTranslator.cs
@@ -8,6 +8,7 @@ namespace Coverlet.Core.Abstractions
 {
     internal interface ISourceRootTranslator
     {
+        bool AddMappingInCache(string originalFileName, string targetFileName);
         string ResolveFilePath(string originalFileName);
         string ResolveDeterministicPath(string originalFileName);
         IReadOnlyList<SourceRootMapping> ResolvePathRoot(string pathRoot);

--- a/src/coverlet.core/Helpers/InstrumentationHelper.cs
+++ b/src/coverlet.core/Helpers/InstrumentationHelper.cs
@@ -90,7 +90,8 @@ namespace Coverlet.Core.Helpers
                 if (entry.Type == DebugDirectoryEntryType.CodeView)
                 {
                     CodeViewDebugDirectoryData codeViewData = peReader.ReadCodeViewDebugDirectoryData(entry);
-                    if (_sourceRootTranslator.ResolveFilePath(codeViewData.Path) == $"{Path.GetFileNameWithoutExtension(module)}.pdb")
+                    string modulePdbFileName = $"{Path.GetFileNameWithoutExtension(module)}.pdb";
+                    if (_sourceRootTranslator.ResolveFilePath(codeViewData.Path) == modulePdbFileName)
                     {
                         // PDB is embedded
                         embedded = true;
@@ -104,7 +105,7 @@ namespace Coverlet.Core.Helpers
                         return true;
                     }
 
-                    string localPdbFileName = Path.Combine(Path.GetDirectoryName(module), Path.GetFileName(codeViewData.Path));
+                    string localPdbFileName = Path.Combine(Path.GetDirectoryName(module), modulePdbFileName);
                     if (_fileSystem.Exists(localPdbFileName))
                     {
                         // local PDB is located within same folder as module

--- a/src/coverlet.core/Helpers/InstrumentationHelper.cs
+++ b/src/coverlet.core/Helpers/InstrumentationHelper.cs
@@ -97,7 +97,24 @@ namespace Coverlet.Core.Helpers
                         return true;
                     }
 
-                    return _fileSystem.Exists(_sourceRootTranslator.ResolveFilePath(codeViewData.Path));
+                    if (_fileSystem.Exists(_sourceRootTranslator.ResolveFilePath(codeViewData.Path)))
+                    {
+                        // local PDB is located within original build location
+                        embedded = false;
+                        return true;
+                    }
+
+                    string localPdbFileName = Path.Combine(Path.GetDirectoryName(module), Path.GetFileName(codeViewData.Path));
+                    if (_fileSystem.Exists(localPdbFileName))
+                    {
+                        // local PDB is located within same folder as module
+                        embedded = false;
+
+                        // mapping need to be registered in _sourceRootTranslator to use that discovery
+                        _sourceRootTranslator.AddMappingInCache(codeViewData.Path, localPdbFileName);
+
+                        return true;
+                    }
                 }
             }
 

--- a/src/coverlet.core/Helpers/SourceRootTranslator.cs
+++ b/src/coverlet.core/Helpers/SourceRootTranslator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+
 using Coverlet.Core.Abstractions;
 
 namespace Coverlet.Core.Helpers
@@ -106,6 +107,17 @@ namespace Coverlet.Core.Helpers
             }
 
             return mapping;
+        }
+
+        public bool AddMappingInCache(string originalFileName, string targetFileName)
+        {
+            if (_resolutionCacheFiles != null && _resolutionCacheFiles.ContainsKey(originalFileName))
+            {
+                return false;
+            }
+
+             (_resolutionCacheFiles ??= new Dictionary<string, string>()).Add(originalFileName, targetFileName);
+            return true;
         }
 
         public IReadOnlyList<SourceRootMapping> ResolvePathRoot(string pathRoot)

--- a/src/coverlet.core/Helpers/SourceRootTranslator.cs
+++ b/src/coverlet.core/Helpers/SourceRootTranslator.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-
 using Coverlet.Core.Abstractions;
 
 namespace Coverlet.Core.Helpers

--- a/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
+++ b/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
@@ -36,7 +36,7 @@ namespace Coverlet.Core.Helpers.Tests
         [Fact]
         public void EmbeddedPortablePDPHasLocalSource_DocumentDoesNotExist_ReturnsFalse()
         {
-            var fileSystem = new Mock<FileSystem> { CallBase = true };
+            var fileSystem = new Mock<FileSystem> {CallBase = true};
             fileSystem.Setup(x => x.Exists(It.IsAny<string>())).Returns(false);
 
             var instrumentationHelper =
@@ -64,7 +64,13 @@ namespace Coverlet.Core.Helpers.Tests
         public void TestHasPdbOfExternalAssembly()
         {
             string testAssemblyLocation = GetType().Assembly.Location;
-            string externalAssemblyFileName = Path.Combine(Path.GetDirectoryName(testAssemblyLocation), "TestAssets", "75d9f96508d74def860a568f426ea4a4.dll");
+
+            string externalAssemblyFileName = Path.Combine(
+                Path.GetDirectoryName(testAssemblyLocation),
+                "TestAssets",
+                "75d9f96508d74def860a568f426ea4a4.dll"
+            );
+
             Assert.True(_instrumentationHelper.HasPdb(externalAssemblyFileName, out bool embeddedPdb));
             Assert.False(embeddedPdb);
         }

--- a/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
+++ b/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
@@ -36,7 +36,7 @@ namespace Coverlet.Core.Helpers.Tests
         [Fact]
         public void EmbeddedPortablePDPHasLocalSource_DocumentDoesNotExist_ReturnsFalse()
         {
-            var fileSystem = new Mock<FileSystem> {CallBase = true};
+            var fileSystem = new Mock<FileSystem> { CallBase = true };
             fileSystem.Setup(x => x.Exists(It.IsAny<string>())).Returns(false);
 
             var instrumentationHelper =
@@ -54,9 +54,18 @@ namespace Coverlet.Core.Helpers.Tests
         }
 
         [Fact]
-        public void TestHasPdb()
+        public void TestHasPdbOfLocalAssembly()
         {
             Assert.True(_instrumentationHelper.HasPdb(typeof(InstrumentationHelperTests).Assembly.Location, out bool embeddedPdb));
+            Assert.False(embeddedPdb);
+        }
+
+        [Fact]
+        public void TestHasPdbOfExternalAssembly()
+        {
+            string testAssemblyLocation = GetType().Assembly.Location;
+            string externalAssemblyFileName = Path.Combine(Path.GetDirectoryName(testAssemblyLocation), "TestAssets", "75d9f96508d74def860a568f426ea4a4.dll");
+            Assert.True(_instrumentationHelper.HasPdb(externalAssemblyFileName, out bool embeddedPdb));
             Assert.False(embeddedPdb);
         }
 


### PR DESCRIPTION
The PR is to handle discovery of PDB files for project build externally (Cloud build, Cluster build, Remote build).
Therefore the path mostly will not match with original build location and the PDB file should be detected by looking in the same directory as module file.

The issue is reproduced with new unit test.

The PR solves the issue #1353 