### PR TITLE
Added InstrumentModulesWithoutLocalSources setting 

### DIFF
--- a/src/coverlet.collector/DataCollection/CoverageWrapper.cs
+++ b/src/coverlet.collector/DataCollection/CoverageWrapper.cs
@@ -33,7 +33,8 @@ namespace Coverlet.Collector.DataCollection
                 UseSourceLink = settings.UseSourceLink,
                 SkipAutoProps = settings.SkipAutoProps,
                 DoesNotReturnAttributes = settings.DoesNotReturnAttributes,
-                DeterministicReport = settings.DeterministicReport
+                DeterministicReport = settings.DeterministicReport,
+                InstrumentModulesWithoutLocalSources = settings.InstrumentModulesWithoutLocalSources
             };
 
             return new Coverage(

--- a/src/coverlet.collector/DataCollection/CoverletSettings.cs
+++ b/src/coverlet.collector/DataCollection/CoverletSettings.cs
@@ -81,6 +81,11 @@ namespace Coverlet.Collector.DataCollection
         /// </summary>
         public bool DeterministicReport { get; set; }
 
+        /// <summary>
+        /// Instruments modules even if the sources from the PDBs can't be resolved.
+        /// </summary>
+        public bool InstrumentModulesWithoutLocalSources { get;  set; }
+
         public override string ToString()
         {
             var builder = new StringBuilder();
@@ -98,6 +103,7 @@ namespace Coverlet.Collector.DataCollection
             builder.AppendFormat("SkipAutoProps: '{0}'", SkipAutoProps);
             builder.AppendFormat("DoesNotReturnAttributes: '{0}'", string.Join(",", DoesNotReturnAttributes ?? Enumerable.Empty<string>()));
             builder.AppendFormat("DeterministicReport: '{0}'", DeterministicReport);
+            builder.AppendFormat("InstrumentModulesWithoutLocalSources: '{0}'", InstrumentModulesWithoutLocalSources);
 
             return builder.ToString();
         }

--- a/src/coverlet.collector/DataCollection/CoverletSettingsParser.cs
+++ b/src/coverlet.collector/DataCollection/CoverletSettingsParser.cs
@@ -48,6 +48,7 @@ namespace Coverlet.Collector.DataCollection
                 coverletSettings.SkipAutoProps = ParseSkipAutoProps(configurationElement);
                 coverletSettings.DoesNotReturnAttributes = ParseDoesNotReturnAttributes(configurationElement);
                 coverletSettings.DeterministicReport = ParseDeterministicReport(configurationElement);
+                coverletSettings.InstrumentModulesWithoutLocalSources = ParseInstrumentModulesWithoutLocalSources(configurationElement);
             }
 
             coverletSettings.ReportFormats = ParseReportFormats(configurationElement);
@@ -209,6 +210,18 @@ namespace Coverlet.Collector.DataCollection
             XmlElement deterministicReportElement = configurationElement[CoverletConstants.DeterministicReport];
             bool.TryParse(deterministicReportElement?.InnerText, out bool deterministicReport);
             return deterministicReport;
+        }
+
+        /// <summary>
+        /// Parse InstrumentModulesWithoutLocalSources flag
+        /// </summary>
+        /// <param name="configurationElement">Configuration element</param>
+        /// <returns>InstrumentModulesWithoutLocalSources flag</returns>
+        private static bool ParseInstrumentModulesWithoutLocalSources(XmlElement configurationElement)
+        {
+            XmlElement instrumentModulesWithoutLocalSourcesElement = configurationElement[CoverletConstants.InstrumentModulesWithoutLocalSources];
+            bool.TryParse(instrumentModulesWithoutLocalSourcesElement?.InnerText, out bool instrumentModulesWithoutLocalSources);
+            return instrumentModulesWithoutLocalSources;
         }
 
         /// <summary>

--- a/src/coverlet.collector/Utilities/CoverletConstants.cs
+++ b/src/coverlet.collector/Utilities/CoverletConstants.cs
@@ -26,5 +26,6 @@ namespace Coverlet.Collector.Utilities
         public const string SkipAutoProps = "SkipAutoProps";
         public const string DoesNotReturnAttributesElementName = "DoesNotReturnAttribute";
         public const string DeterministicReport = "DeterministicReport";
+        public const string InstrumentModulesWithoutLocalSources = "InstrumentModulesWithoutLocalSources";
     }
 }

--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -70,6 +70,7 @@ namespace Coverlet.Console
             CommandOption mergeWith = app.Option("--merge-with", "Path to existing coverage result to merge.", CommandOptionType.SingleValue);
             CommandOption useSourceLink = app.Option("--use-source-link", "Specifies whether to use SourceLink URIs in place of file system paths.", CommandOptionType.NoValue);
             CommandOption doesNotReturnAttributes = app.Option("--does-not-return-attribute", "Attributes that mark methods that do not return.", CommandOptionType.MultipleValue);
+            CommandOption instrumentModulesWithoutLocalSources = app.Option("--instrument-modules-without-local-sources", "Specifies whether modules should be instrumented even if the sources from the PDBs can't be found locally.", CommandOptionType.MultipleValue);
 
             app.OnExecute(() =>
             {
@@ -97,7 +98,8 @@ namespace Coverlet.Console
                     MergeWith = mergeWith.Value(),
                     UseSourceLink = useSourceLink.HasValue(),
                     SkipAutoProps = skipAutoProp.HasValue(),
-                    DoesNotReturnAttributes = doesNotReturnAttributes.Values.ToArray()
+                    DoesNotReturnAttributes = doesNotReturnAttributes.Values.ToArray(),
+                    InstrumentModulesWithoutLocalSources = instrumentModulesWithoutLocalSources.HasValue(),
                 };
 
                 ISourceRootTranslator sourceRootTranslator = serviceProvider.GetRequiredService<ISourceRootTranslator>();

--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -70,7 +70,7 @@ namespace Coverlet.Console
             CommandOption mergeWith = app.Option("--merge-with", "Path to existing coverage result to merge.", CommandOptionType.SingleValue);
             CommandOption useSourceLink = app.Option("--use-source-link", "Specifies whether to use SourceLink URIs in place of file system paths.", CommandOptionType.NoValue);
             CommandOption doesNotReturnAttributes = app.Option("--does-not-return-attribute", "Attributes that mark methods that do not return.", CommandOptionType.MultipleValue);
-            CommandOption instrumentModulesWithoutLocalSources = app.Option("--instrument-modules-without-local-sources", "Specifies whether modules should be instrumented even if the sources from the PDBs can't be found locally.", CommandOptionType.MultipleValue);
+            CommandOption instrumentModulesWithoutLocalSources = app.Option("--instrument-modules-without-local-sources", "Specifies whether modules should be instrumented even if the sources from the PDBs can't be found locally.", CommandOptionType.NoValue);
 
             app.OnExecute(() =>
             {

--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -43,6 +43,8 @@ namespace Coverlet.Core
         public bool SkipAutoProps { get; set; }
         [DataMember]
         public bool DeterministicReport { get; set; }
+        [DataMember]
+        public bool InstrumentModulesWithoutLocalSources { get; set; }
     }
 
     internal class Coverage

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -94,6 +94,11 @@ namespace Coverlet.Core.Instrumentation
             {
                 if (_instrumentationHelper.HasPdb(_module, out bool embeddedPdb))
                 {
+                    if (this._parameters.InstrumentModulesWithoutLocalSources)
+                    {
+                        return true;
+                    }
+					
                     if (embeddedPdb)
                     {
                         if (_instrumentationHelper.EmbeddedPortablePdbHasLocalSource(_module, out string firstNotFoundDocument))

--- a/src/coverlet.core/Reporters/CoberturaReporter.cs
+++ b/src/coverlet.core/Reporters/CoberturaReporter.cs
@@ -227,9 +227,6 @@ namespace Coverlet.Core.Reporters
                     return path.Substring(basePath.Length);
                 }
             }
-
-            Debug.Assert(false, "Unexpected, we should find at least one path starts with one pre-build roots list");
-
             return path;
         }
     }

--- a/src/coverlet.msbuild.tasks/InstrumentationTask.cs
+++ b/src/coverlet.msbuild.tasks/InstrumentationTask.cs
@@ -47,6 +47,8 @@ namespace Coverlet.MSbuild.Tasks
 
         public bool DeterministicReport { get; set; }
 
+        public bool InstrumentModulesWithoutLocalSources { get; set; }
+
         [Output]
         public ITaskItem InstrumenterState { get; set; }
 
@@ -99,6 +101,7 @@ namespace Coverlet.MSbuild.Tasks
                     UseSourceLink = UseSourceLink,
                     SkipAutoProps = SkipAutoProps,
                     DeterministicReport = DeterministicReport,
+                    InstrumentModulesWithoutLocalSources = InstrumentModulesWithoutLocalSources,
                     DoesNotReturnAttributes = DoesNotReturnAttribute?.Split(',')
                 };
 


### PR DESCRIPTION
There are already several issues regarding unexpected empty coverage results. 
https://github.com/coverlet-coverage/coverlet/issues/1089
https://github.com/coverlet-coverage/coverlet/issues/1121

We found out, that there's an implicit filter that checks whether a pdb source location can be mapped to a local file. However that logic is not optimal for some use cases, for example when the build and test run happens on a different machines or when the sources are embedded in the assembly. Since the source files are not used anywhere in the whole instrumentation logic except for that filter logic, we added an option to disable that implicit filter. The previous behavior stays the default behavior. With that setting activated, the user has full control over the filtering and can still filter using Include / Exclude to filter out 3rdParty or include only the assemblies he explicitly wants to measure.
