### PR TITLE
Ability to force-instrument modules without corresponding source files

### DIFF
--- a/src/coverlet.collector/DataCollection/CoverageWrapper.cs
+++ b/src/coverlet.collector/DataCollection/CoverageWrapper.cs
@@ -33,7 +33,8 @@ namespace Coverlet.Collector.DataCollection
                 UseSourceLink = settings.UseSourceLink,
                 SkipAutoProps = settings.SkipAutoProps,
                 DoesNotReturnAttributes = settings.DoesNotReturnAttributes,
-                DeterministicReport = settings.DeterministicReport
+                DeterministicReport = settings.DeterministicReport,
+                ForceInstrumentModules = settings.ForceInstrumentModules
             };
 
             return new Coverage(

--- a/src/coverlet.collector/DataCollection/CoverletSettings.cs
+++ b/src/coverlet.collector/DataCollection/CoverletSettings.cs
@@ -81,6 +81,11 @@ namespace Coverlet.Collector.DataCollection
         /// </summary>
         public bool DeterministicReport { get; set; }
 
+        /// <summary>
+        /// Modules that should be instrumented even without existing source files
+        /// </summary>
+        public string[] ForceInstrumentModules { get; set; }
+
         public override string ToString()
         {
             var builder = new StringBuilder();
@@ -98,6 +103,7 @@ namespace Coverlet.Collector.DataCollection
             builder.AppendFormat("SkipAutoProps: '{0}'", SkipAutoProps);
             builder.AppendFormat("DoesNotReturnAttributes: '{0}'", string.Join(",", DoesNotReturnAttributes ?? Enumerable.Empty<string>()));
             builder.AppendFormat("DeterministicReport: '{0}'", DeterministicReport);
+            builder.AppendFormat("ForceInstrumentModules: '{0}'", string.Join(",", ForceInstrumentModules ?? Enumerable.Empty<string>()));
 
             return builder.ToString();
         }

--- a/src/coverlet.collector/DataCollection/CoverletSettingsParser.cs
+++ b/src/coverlet.collector/DataCollection/CoverletSettingsParser.cs
@@ -48,6 +48,7 @@ namespace Coverlet.Collector.DataCollection
                 coverletSettings.SkipAutoProps = ParseSkipAutoProps(configurationElement);
                 coverletSettings.DoesNotReturnAttributes = ParseDoesNotReturnAttributes(configurationElement);
                 coverletSettings.DeterministicReport = ParseDeterministicReport(configurationElement);
+                coverletSettings.ForceInstrumentModules = ParseForceInstrument(configurationElement);
             }
 
             coverletSettings.ReportFormats = ParseReportFormats(configurationElement);
@@ -161,6 +162,17 @@ namespace Coverlet.Collector.DataCollection
         private static string[] ParseExcludeAttributes(XmlElement configurationElement)
         {
             XmlElement excludeAttributesElement = configurationElement[CoverletConstants.ExcludeAttributesElementName];
+            return SplitElement(excludeAttributesElement);
+        }
+
+        /// <summary>
+        /// Parse modules forced to be instrumented
+        /// </summary>
+        /// <param name="configurationElement">Configuration element</param>
+        /// <returns>Modules forced to be instrumented</returns>
+        private static string[] ParseForceInstrument(XmlElement configurationElement)
+        {
+            XmlElement excludeAttributesElement = configurationElement[CoverletConstants.ForceInstrumentElementName];
             return SplitElement(excludeAttributesElement);
         }
 

--- a/src/coverlet.collector/Utilities/CoverletConstants.cs
+++ b/src/coverlet.collector/Utilities/CoverletConstants.cs
@@ -26,5 +26,6 @@ namespace Coverlet.Collector.Utilities
         public const string SkipAutoProps = "SkipAutoProps";
         public const string DoesNotReturnAttributesElementName = "DoesNotReturnAttribute";
         public const string DeterministicReport = "DeterministicReport";
+        public const string ForceInstrumentElementName = "ForceInstrument";
     }
 }

--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -70,6 +70,7 @@ namespace Coverlet.Console
             CommandOption mergeWith = app.Option("--merge-with", "Path to existing coverage result to merge.", CommandOptionType.SingleValue);
             CommandOption useSourceLink = app.Option("--use-source-link", "Specifies whether to use SourceLink URIs in place of file system paths.", CommandOptionType.NoValue);
             CommandOption doesNotReturnAttributes = app.Option("--does-not-return-attribute", "Attributes that mark methods that do not return.", CommandOptionType.MultipleValue);
+            CommandOption forceInstrumentModules = app.Option("--force-instrument", "Modules that should be instrumented even without existing source files.", CommandOptionType.MultipleValue);
 
             app.OnExecute(() =>
             {
@@ -97,7 +98,8 @@ namespace Coverlet.Console
                     MergeWith = mergeWith.Value(),
                     UseSourceLink = useSourceLink.HasValue(),
                     SkipAutoProps = skipAutoProp.HasValue(),
-                    DoesNotReturnAttributes = doesNotReturnAttributes.Values.ToArray()
+                    DoesNotReturnAttributes = doesNotReturnAttributes.Values.ToArray(),
+                    ForceInstrumentModules = forceInstrumentModules.Values.ToArray(),
                 };
 
                 ISourceRootTranslator sourceRootTranslator = serviceProvider.GetRequiredService<ISourceRootTranslator>();

--- a/src/coverlet.core/Abstractions/IInstrumentationHelper.cs
+++ b/src/coverlet.core/Abstractions/IInstrumentationHelper.cs
@@ -11,6 +11,7 @@ namespace Coverlet.Core.Abstractions
         bool HasPdb(string module, out bool embedded);
         bool IsModuleExcluded(string module, string[] excludeFilters);
         bool IsModuleIncluded(string module, string[] includeFilters);
+        bool IsModuleForcedToBeInstrumented(string module, string[] forcedModules);
         bool IsValidFilterExpression(string filter);
         bool IsTypeExcluded(string module, string type, string[] excludeFilters);
         bool IsTypeIncluded(string module, string type, string[] includeFilters);

--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -43,6 +43,8 @@ namespace Coverlet.Core
         public bool SkipAutoProps { get; set; }
         [DataMember]
         public bool DeterministicReport { get; set; }
+        [DataMember]
+        public string[] ForceInstrumentModules { get; set; }
     }
 
     internal class Coverage

--- a/src/coverlet.core/Helpers/InstrumentationHelper.cs
+++ b/src/coverlet.core/Helpers/InstrumentationHelper.cs
@@ -353,22 +353,19 @@ namespace Coverlet.Core.Helpers
             if (module == null)
                 return false;
 
-            foreach (string filter in includeFilters)
-            {
-                string modulePattern = filter.Substring(1, filter.IndexOf(']') - 1);
+            return IsModuleIncludeFilterMatch(module, includeFilters);
+        }
 
-                if (modulePattern == "*")
-                    return true;
+        public bool IsModuleForcedToBeInstrumented(string module, string[] forcedModules)
+        {
+            if (forcedModules == null || forcedModules.Length == 0)
+                return false;
 
-                modulePattern = WildcardToRegex(modulePattern);
+            module = Path.GetFileNameWithoutExtension(module);
+            if (module == null)
+                return false;
 
-                var regex = new Regex(modulePattern);
-
-                if (regex.IsMatch(module))
-                    return true;
-            }
-
-            return false;
+            return IsModuleIncludeFilterMatch(module, forcedModules);
         }
 
         public bool IsTypeExcluded(string module, string type, string[] excludeFilters)
@@ -401,6 +398,29 @@ namespace Coverlet.Core.Helpers
         public void SetLogger(ILogger logger)
         {
             _logger = logger;
+        }
+
+        private static bool IsModuleIncludeFilterMatch(string module, string[] filters)
+        {
+            Debug.Assert(module != null);
+            Debug.Assert(filters != null);
+
+            foreach (string filter in filters)
+            {
+                string modulePattern = filter.Substring(1, filter.IndexOf(']') - 1);
+
+                if (modulePattern == "*")
+                    return true;
+
+                modulePattern = WildcardToRegex(modulePattern);
+
+                var regex = new Regex(modulePattern);
+
+                if (regex.IsMatch(module))
+                    return true;
+            }
+
+            return false;
         }
 
         private static bool IsTypeFilterMatch(string module, string type, string[] filters)

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -92,6 +92,12 @@ namespace Coverlet.Core.Instrumentation
         {
             try
             {
+                if (_instrumentationHelper.IsModuleForcedToBeInstrumented(_module, _parameters.ForceInstrumentModules))
+                {
+                    _logger.LogVerbose($"Module '{_module}' was forced to be instrumented");
+                    return true;
+                }
+
                 if (_instrumentationHelper.HasPdb(_module, out bool embeddedPdb))
                 {
                     if (embeddedPdb)

--- a/src/coverlet.core/Reporters/CoberturaReporter.cs
+++ b/src/coverlet.core/Reporters/CoberturaReporter.cs
@@ -64,7 +64,7 @@ namespace Coverlet.Core.Reporters
                         string fileName;
                         if (!result.Parameters.DeterministicReport)
                         {
-                            fileName = GetRelativePathFromBase(absolutePaths, document.Key, result.Parameters.UseSourceLink);
+                            fileName = GetRelativePathFromBase(absolutePaths, document.Key, result.Parameters);
                         }
                         else
                         {
@@ -213,9 +213,9 @@ namespace Coverlet.Core.Reporters
             });
         }
 
-        private static string GetRelativePathFromBase(IEnumerable<string> basePaths, string path, bool useSourceLink)
+        private static string GetRelativePathFromBase(IEnumerable<string> basePaths, string path, CoverageParameters parameters)
         {
-            if (useSourceLink)
+            if (parameters.UseSourceLink)
             {
                 return path;
             }
@@ -226,6 +226,11 @@ namespace Coverlet.Core.Reporters
                 {
                     return path.Substring(basePath.Length);
                 }
+            }
+
+            if (parameters.ForceInstrumentModules != null && parameters.ForceInstrumentModules.Any())
+            {
+                return path;
             }
 
             Debug.Assert(false, "Unexpected, we should find at least one path starts with one pre-build roots list");

--- a/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
+++ b/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
@@ -137,7 +137,7 @@ namespace Coverlet.Core.Helpers.Tests
         {
             bool result = _instrumentationHelper.IsModuleForcedToBeInstrumented("Module.dll", new string[0]);
 
-            Assert.True(result);
+            Assert.False(result);
         }
 
         [Theory]

--- a/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
+++ b/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
@@ -132,6 +132,14 @@ namespace Coverlet.Core.Helpers.Tests
             Assert.True(result);
         }
 
+        [Fact]
+        public void TestIsModuleForcedToBeInstrumentedWithoutFilter()
+        {
+            bool result = _instrumentationHelper.IsModuleForcedToBeInstrumented("Module.dll", new string[0]);
+
+            Assert.True(result);
+        }
+
         [Theory]
         [InlineData("[Module]mismatch")]
         [InlineData("[Mismatch]*")]
@@ -150,20 +158,31 @@ namespace Coverlet.Core.Helpers.Tests
             Assert.False(result);
         }
 
+        [Fact]
+        public void TestIsModuleForcedToBeInstrumentedWithSingleMismatchFilter()
+        {
+            bool result = _instrumentationHelper.IsModuleForcedToBeInstrumented("Module.dll", new[] { "[Mismatch]*" });
+
+            Assert.False(result);
+        }
+
         [Theory]
         [MemberData(nameof(ValidModuleFilterData))]
-        public void TestIsModuleExcludedAndIncludedWithFilter(string filter)
+        public void TestIsModuleExcludedAndIncludedAndForcedToBeInstrumentedWithFilter(string filter)
         {
             bool result = _instrumentationHelper.IsModuleExcluded("Module.dll", new[] { filter });
             Assert.True(result);
 
             result = _instrumentationHelper.IsModuleIncluded("Module.dll", new[] { filter });
             Assert.True(result);
+
+            result = _instrumentationHelper.IsModuleForcedToBeInstrumented("Module.dll", new[] { filter });
+            Assert.True(result);
         }
 
         [Theory]
         [MemberData(nameof(ValidModuleFilterData))]
-        public void TestIsModuleExcludedAndIncludedWithMatchingAndMismatchingFilter(string filter)
+        public void TestIsModuleExcludedAndIncludedAndForcedToBeInstrumentedWithMatchingAndMismatchingFilter(string filter)
         {
             string[] filters = new[] { "[Mismatch]*", filter, "[Mismatch]*" };
 
@@ -171,6 +190,9 @@ namespace Coverlet.Core.Helpers.Tests
             Assert.True(result);
 
             result = _instrumentationHelper.IsModuleIncluded("Module.dll", filters);
+            Assert.True(result);
+
+            result = _instrumentationHelper.IsModuleForcedToBeInstrumented("Module.dll", new[] { filter });
             Assert.True(result);
         }
 


### PR DESCRIPTION
This PR adds an option to force-instrument modules without pdbs and source files. 
This can be very handy in CI/CD environments where build and test steps are separate. Build steps build test projects and publishes them, and then test step executes coverlet for these binaries without access to source code.

I've added this option to coverlet.console and coverlet.colleror. AFAIU, there is no point in adding it to coverlet.msbuild because we always have access to sources codes there.