### PR TITLE
Wrong branch coverage for async methods .NET Standard 1.x 

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
+-Wrong branch coverage for async methods .NET Standard 1.x [#1376](https://github.com/coverlet-coverage/coverlet/issues/1376) 
 -Allign published nuget package version to github release version [#1413](https://github.com/coverlet-coverage/coverlet/issues/1413)  
 -Sync nuget and github release versions [#1122](https://github.com/coverlet-coverage/coverlet/issues/1122)  
 

--- a/src/coverlet.core/Symbols/CecilSymbolHelper.cs
+++ b/src/coverlet.core/Symbols/CecilSymbolHelper.cs
@@ -199,6 +199,7 @@ namespace Coverlet.Core.Symbols
                         operand.DeclaringType.Scope.Name == "System.Runtime" ||
                         operand.DeclaringType.Scope.Name == "netstandard" ||
                         operand.DeclaringType.Scope.Name == "mscorlib" ||
+                        operand.DeclaringType.Scope.Name == "System.Threading.Tasks" ||
                         operand.DeclaringType.Scope.Name == "System.Threading.Tasks.Extensions"
                     )
                )


### PR DESCRIPTION
closes #1376 