### PR TITLE
Make tests run on all platforms

### DIFF
--- a/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
+++ b/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
@@ -444,9 +444,7 @@ namespace Coverlet.Core.Instrumentation.Tests
             loggerMock.VerifyNoOtherCalls();
         }
 
-        [ConditionalFact]
-        [SkipOnOS(OS.MacOS)]
-        [SkipOnOS(OS.Linux)]
+        [Fact]
         public void SkipPpdbWithoutLocalSource()
         {
             string dllFileName = "75d9f96508d74def860a568f426ea4a4.dll";
@@ -456,7 +454,7 @@ namespace Coverlet.Core.Instrumentation.Tests
             partialMockFileSystem.CallBase = true;
             partialMockFileSystem.Setup(fs => fs.OpenRead(It.IsAny<string>())).Returns((string path) =>
             {
-                if (Path.GetFileName(path) == pdbFileName)
+                if (Path.GetFileName(path.Replace(@"\", @"/")) == pdbFileName)
                 {
                     return File.OpenRead(Path.Combine(Path.Combine(Directory.GetCurrentDirectory(), "TestAssets"), pdbFileName));
                 }
@@ -467,7 +465,7 @@ namespace Coverlet.Core.Instrumentation.Tests
             });
             partialMockFileSystem.Setup(fs => fs.Exists(It.IsAny<string>())).Returns((string path) =>
             {
-                if (Path.GetFileName(path) == pdbFileName)
+                if (Path.GetFileName(path.Replace(@"\", @"/")) == pdbFileName)
                 {
                     return File.Exists(Path.Combine(Path.Combine(Directory.GetCurrentDirectory(), "TestAssets"), pdbFileName));
                 }

--- a/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
+++ b/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Toni Solarin-Sodara
+// Copyright (c) Toni Solarin-Sodara
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -34,9 +34,7 @@ namespace Coverlet.Core.Instrumentation.Tests
             _disposeAction?.Invoke();
         }
 
-        [ConditionalFact]
-        [SkipOnOS(OS.Linux)]
-        [SkipOnOS(OS.MacOS)]
+        [Fact]
         public void TestCoreLibInstrumentation()
         {
             DirectoryInfo directory = Directory.CreateDirectory(Path.Combine(Directory.GetCurrentDirectory(), nameof(TestCoreLibInstrumentation)));
@@ -55,7 +53,7 @@ namespace Coverlet.Core.Instrumentation.Tests
             partialMockFileSystem.CallBase = true;
             partialMockFileSystem.Setup(fs => fs.OpenRead(It.IsAny<string>())).Returns((string path) =>
             {
-                if (Path.GetFileName(path) == files[1])
+                if (Path.GetFileName(path.Replace(@"\", @"/")) == files[1])
                 {
                     return File.OpenRead(Path.Combine(Path.Combine(Directory.GetCurrentDirectory(), "TestAssets"), files[1]));
                 }
@@ -66,7 +64,7 @@ namespace Coverlet.Core.Instrumentation.Tests
             });
             partialMockFileSystem.Setup(fs => fs.Exists(It.IsAny<string>())).Returns((string path) =>
             {
-                if (Path.GetFileName(path) == files[1])
+                if (Path.GetFileName(path.Replace(@"\", @"/")) == files[1])
                 {
                     return File.Exists(Path.Combine(Path.Combine(Directory.GetCurrentDirectory(), "TestAssets"), files[1]));
                 }

--- a/test/coverlet.integration.tests/DotnetTool.cs
+++ b/test/coverlet.integration.tests/DotnetTool.cs
@@ -14,12 +14,10 @@ namespace Coverlet.Integration.Tests
         {
             _ = DotnetCli($"tool install coverlet.console --version {GetPackageVersion("*console*.nupkg")} --tool-path \"{Path.Combine(projectPath, "coverletTool")}\"", out string standardOutput, out _, projectPath);
             Assert.Contains("was successfully installed.", standardOutput);
-            return Path.Combine(projectPath, "coverletTool", "coverlet ");
+            return Path.Combine(projectPath, "coverletTool", "coverlet");
         }
 
-        [ConditionalFact]
-        [SkipOnOS(OS.Linux)]
-        [SkipOnOS(OS.MacOS)]
+        [Fact]
         public void DotnetTool()
         {
             using ClonedTemplateProject clonedTemplateProject = CloneTemplateProject();
@@ -27,14 +25,12 @@ namespace Coverlet.Integration.Tests
             string coverletToolCommandPath = InstallTool(clonedTemplateProject.ProjectRootPath!);
             DotnetCli($"build {clonedTemplateProject.ProjectRootPath}", out string standardOutput, out string standardError);
             string publishedTestFile = clonedTemplateProject.GetFiles("*" + ClonedTemplateProject.AssemblyName + ".dll").Single(f => !f.Contains("obj") && !f.Contains("ref"));
-            RunCommand(coverletToolCommandPath, $"\"{publishedTestFile}\" --target \"dotnet\" --targetargs \"test {Path.Combine(clonedTemplateProject.ProjectRootPath, ClonedTemplateProject.ProjectFileName)} --no-build\"  --include-test-assembly --output \"{clonedTemplateProject.ProjectRootPath}\"\\", out standardOutput, out standardError);
+            RunCommand(coverletToolCommandPath, $"\"{publishedTestFile}\" --target \"dotnet\" --targetargs \"test {Path.Combine(clonedTemplateProject.ProjectRootPath, ClonedTemplateProject.ProjectFileName)} --no-build\"  --include-test-assembly --output \"{clonedTemplateProject.ProjectRootPath}\"{Path.DirectorySeparatorChar}", out standardOutput, out standardError);
             Assert.Contains("Passed!", standardOutput);
             AssertCoverage(clonedTemplateProject, standardOutput: standardOutput);
         }
 
-        [ConditionalFact]
-        [SkipOnOS(OS.Linux)]
-        [SkipOnOS(OS.MacOS)]
+        [Fact]
         public void StandAlone()
         {
             using ClonedTemplateProject clonedTemplateProject = CloneTemplateProject();
@@ -42,7 +38,7 @@ namespace Coverlet.Integration.Tests
             string coverletToolCommandPath = InstallTool(clonedTemplateProject.ProjectRootPath!);
             DotnetCli($"build {clonedTemplateProject.ProjectRootPath}", out string standardOutput, out string standardError);
             string publishedTestFile = clonedTemplateProject.GetFiles("*" + ClonedTemplateProject.AssemblyName + ".dll").Single(f => !f.Contains("obj") && !f.Contains("ref"));
-            RunCommand(coverletToolCommandPath, $"\"{Path.GetDirectoryName(publishedTestFile)}\" --target \"dotnet\" --targetargs \"{publishedTestFile}\"  --output \"{clonedTemplateProject.ProjectRootPath}\"\\", out standardOutput, out standardError);
+            RunCommand(coverletToolCommandPath, $"\"{Path.GetDirectoryName(publishedTestFile)}\" --target \"dotnet\" --targetargs \"{publishedTestFile}\"  --output \"{clonedTemplateProject.ProjectRootPath}\"{Path.DirectorySeparatorChar}", out standardOutput, out standardError);
             Assert.Contains("Hello World!", standardOutput);
             AssertCoverage(clonedTemplateProject, standardOutput: standardOutput);
         }


### PR DESCRIPTION
An extra space in the "coverlet " path and a platform specific directory separator char were the culprits for failing the DotnetGlobalTools tests on Linux and macOS.