### PR TITLE
add space between CLI argument in Globaltool README

### DIFF
--- a/Documentation/GlobalTool.md
+++ b/Documentation/GlobalTool.md
@@ -43,7 +43,7 @@ Options:
 
 NB. For a [multiple value] options you have to specify values multiple times i.e.
 ```
---exclude-by-attribute 'Obsolete' --exclude-by-attribute'GeneratedCode' --exclude-by-attribute 'CompilerGenerated'
+--exclude-by-attribute 'Obsolete' --exclude-by-attribute 'GeneratedCode' --exclude-by-attribute 'CompilerGenerated'
 ```
 For `--merge-with` [check the sample](Examples.md).
 


### PR DESCRIPTION
matches the same argument further down.