### PR TITLE
Replace Newtonsoft.Json package with System.Text.Json

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-reportgenerator-globaltool": {
+      "version": "5.1.24",
+      "commands": [
+        "reportgenerator"
+      ]
+    }
+  }
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -46,6 +46,7 @@
         We can check minimum supported package version here https://github.com/Microsoft/vstest/blob/master/src/Microsoft.TestPlatform.ObjectModel/Microsoft.TestPlatform.ObjectModel.csproj#L34
      -->
     <PackageVersion Include="System.Reflection.Metadata" Version="1.6.0" />
+    <PackageVersion Include="System.Text.Json" Version="7.0.3" />
     <!-- Coverlet.Core.Tests executed in Visual Studio will fail with Tmds.ExecFunction version > 0.4.0 => use "dotnet test"
     System.TypeInitializationException : The type initializer for 'Tmds.Utils.ExecFunction' threw an exception.
     System.NotSupportedException : Application is running as testhost, unable to determine parent 'dotnet' process.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Coverlet
 
-[![Build Status](https://dev.azure.com/tonerdo/coverlet/_apis/build/status/coverlet-coverage.coverlet?branchName=master)](https://dev.azure.com/tonerdo/coverlet/_build/latest?definitionId=5&branchName=master) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/coverlet-coverage/coverlet/blob/master/LICENSE)
+[![Build Status](https://dev.azure.com/tonerdo/coverlet/_apis/build/status/coverlet-coverage.coverlet?branchName=master)](https://dev.azure.com/tonerdo/coverlet/_build/latest?definitionId=5&branchName=master) ![Code%20Coverage](https://img.shields.io/azure-devops/coverage/tonerdo/coverlet/5/master?label=Code%20Coverage) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/coverlet-coverage/coverlet/blob/master/LICENSE)
 
 | Driver  |  Current version  | Downloads  |
 |---|---|---|
@@ -170,8 +170,8 @@ Author and owner
 
 Co-maintainers
 
-* [David Müller](https://github.com/daveMueller)  
-* [Bert](https://github.com/Bertk)  
+* [David Müller](https://github.com/daveMueller)
+* [Bert](https://github.com/Bertk)
 * [Peter Liljenberg](https://github.com/petli)
 * [Marco Rossignoli](https://github.com/MarcoRossignoli)
 

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -2,7 +2,7 @@ trigger:
   branches:
     include: ["master", "*_validate"]
   paths:
-    exclude: [".github", "doc", "*.md"]
+    exclude: [".github", "Documentation", "*.md"]
 
 jobs:
 - job: Windows

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -30,6 +30,6 @@ steps:
 - template: publish-coverage-results.yml
   parameters:
     reports: $(Build.SourcesDirectory)/**/coverage.opencover.xml
-    condition: and(succeeded(), eq(variables['_BuildConfig'], 'Debug'))
+    condition: and(succeeded(), eq(variables['BuildConfiguration'], 'Debug'))
     assemblyfilters: '-xunit'
 

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -27,8 +27,9 @@ steps:
 
 - template: publish-coverlet-result-files.yml
 
-#- template: publish-coverage-results.yml
-#  parameters:
-#    reports: $(Build.SourcesDirectory)/**/coverage.opencover.xml
-#    condition: and(succeeded(), eq(variables['_BuildConfig'], 'Debug'))
-#    assemblyfilters: '-xunit*;+Coverlet.Core.*;+Coverlet.Collector.*'
+- template: publish-coverage-results.yml
+  parameters:
+    reports: $(Build.SourcesDirectory)/**/coverage.opencover.xml
+    condition: and(succeeded(), eq(variables['_BuildConfig'], 'Debug'))
+    assemblyfilters: '-xunit'
+

--- a/eng/publish-coverage-results.yml
+++ b/eng/publish-coverage-results.yml
@@ -5,18 +5,28 @@ parameters:
   condition: 'succeeded()'
   reports: ''
   assemblyfilters: '-xunit*'
+  classfilters: ''
   breakBuild: false
 
 steps:
-- task: reportgenerator@5
-  displayName: ReportGenerator
-  condition: ${{parameters.condition}}
+- task: Powershell@2
+  displayName: Prepare coverage files to Upload
   inputs:
-    reports: ${{parameters.reports}}
-    targetdir: $(Build.SourcesDirectory)/artifacts/CoverageReport
-    reporttypes: Html;HtmlInline_AzurePipelines_Dark;Cobertura
-    verbosity: 'Verbose'
-    assemblyfilters: ${{parameters.assemblyfilters}}
+    targetType: inline
+    pwsh: true
+    script: |
+      dotnet tool restore
+      dotnet reportgenerator -reports:"${{parameters.reports}}" -targetdir:"$(Build.SourcesDirectory)/artifacts/CoverageReport" -reporttypes:"Html;HtmlInline_AzurePipelines_Dark;Cobertura" -assemblyfilters:"${{parameters.assemblyfilters}}" -classfilters:"${{parameters.classfilters}}" -verbosity:Verbose
+
+# - task: reportgenerator@5
+#   displayName: ReportGenerator
+#   condition: ${{parameters.condition}}
+#   inputs:
+#     reports: ${{parameters.reports}}
+#     targetdir: $(Build.SourcesDirectory)/artifacts/CoverageReport
+#     reporttypes: Html;HtmlInline_AzurePipelines_Dark;Cobertura
+#     verbosity: 'Verbose'
+#     assemblyfilters: ${{parameters.assemblyfilters}}
 
 - publish: '$(Build.SourcesDirectory)/artifacts/CoverageReport'
   displayName: 'Publish CoverageReport Artifact'

--- a/eng/publish-coverage-results.yml
+++ b/eng/publish-coverage-results.yml
@@ -10,7 +10,8 @@ parameters:
 
 steps:
 - task: Powershell@2
-  displayName: Prepare coverage files to Upload
+  displayName: ReportGenerator
+  condition: ${{parameters.condition}}
   inputs:
     targetType: inline
     pwsh: true

--- a/eng/publish-coverlet-result-files.yml
+++ b/eng/publish-coverlet-result-files.yml
@@ -1,6 +1,6 @@
 steps:
 - task: Powershell@2
-  displayName: Prepare coverage files to Upload
+  displayName: Prepare log files to Upload
   inputs:
     targetType: inline
     pwsh: true
@@ -26,8 +26,15 @@ steps:
   continueOnError: true
   condition: always()
 
+- task: CopyFiles@2
+  displayName: Copy trx files
+  inputs:
+    SourceFolder: '$(Agent.TempDirectory)'
+    Contents: '**/*.trx'
+    TargetFolder: '$(Build.SourcesDirectory)/artifacts/TestLogs'
+
 - task: PublishPipelineArtifact@1
-  displayName: Publish coverage logs
+  displayName: Publish Coverlet logs
   continueOnError: true
   condition: always()
   inputs:

--- a/eng/publish-coverlet-result-files.yml
+++ b/eng/publish-coverlet-result-files.yml
@@ -27,7 +27,7 @@ steps:
   condition: always()
 
 - task: PublishPipelineArtifact@1
-  displayName:  Publish coverage logs
+  displayName: Publish coverage logs
   continueOnError: true
   condition: always()
   inputs:

--- a/src/coverlet.collector/coverlet.collector.csproj
+++ b/src/coverlet.collector/coverlet.collector.csproj
@@ -36,7 +36,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" />
-    <PackageReference Include="NuGet.Frameworks" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/coverlet.collector/coverlet.collector.csproj
+++ b/src/coverlet.collector/coverlet.collector.csproj
@@ -36,6 +36,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" />
+    <PackageReference Include="NuGet.Frameworks" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -6,521 +6,521 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using Coverlet.Core.Abstractions;
 using Coverlet.Core.Helpers;
 using Coverlet.Core.Instrumentation;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Coverlet.Core
 {
-    [DataContract]
-    internal class CoverageParameters
+  [DataContract]
+  internal class CoverageParameters
+  {
+    [DataMember]
+    public string Module { get; set; }
+    [DataMember]
+    public string[] IncludeFilters { get; set; }
+    [DataMember]
+    public string[] IncludeDirectories { get; set; }
+    [DataMember]
+    public string[] ExcludeFilters { get; set; }
+    [DataMember]
+    public string[] ExcludedSourceFiles { get; set; }
+    [DataMember]
+    public string[] ExcludeAttributes { get; set; }
+    [DataMember]
+    public bool IncludeTestAssembly { get; set; }
+    [DataMember]
+    public bool SingleHit { get; set; }
+    [DataMember]
+    public string MergeWith { get; set; }
+    [DataMember]
+    public bool UseSourceLink { get; set; }
+    [DataMember]
+    public string[] DoesNotReturnAttributes { get; set; }
+    [DataMember]
+    public bool SkipAutoProps { get; set; }
+    [DataMember]
+    public bool DeterministicReport { get; set; }
+    [DataMember]
+    public string ExcludeAssembliesWithoutSources { get; set; }
+  }
+
+  internal class Coverage
+  {
+    private readonly string _moduleOrAppDirectory;
+    private readonly ILogger _logger;
+    private readonly IInstrumentationHelper _instrumentationHelper;
+    private readonly IFileSystem _fileSystem;
+    private readonly ISourceRootTranslator _sourceRootTranslator;
+    private readonly ICecilSymbolHelper _cecilSymbolHelper;
+    private readonly List<InstrumenterResult> _results;
+    private readonly CoverageParameters _parameters;
+
+    public string Identifier { get; }
+
+    public Coverage(string moduleOrDirectory,
+        CoverageParameters parameters,
+        ILogger logger,
+        IInstrumentationHelper instrumentationHelper,
+        IFileSystem fileSystem,
+        ISourceRootTranslator sourceRootTranslator,
+        ICecilSymbolHelper cecilSymbolHelper)
     {
-        [DataMember]
-        public string Module { get; set; }
-        [DataMember]
-        public string[] IncludeFilters { get; set; }
-        [DataMember]
-        public string[] IncludeDirectories { get; set; }
-        [DataMember]
-        public string[] ExcludeFilters { get; set; }
-        [DataMember]
-        public string[] ExcludedSourceFiles { get; set; }
-        [DataMember]
-        public string[] ExcludeAttributes { get; set; }
-        [DataMember]
-        public bool IncludeTestAssembly { get; set; }
-        [DataMember]
-        public bool SingleHit { get; set; }
-        [DataMember]
-        public string MergeWith { get; set; }
-        [DataMember]
-        public bool UseSourceLink { get; set; }
-        [DataMember]
-        public string[] DoesNotReturnAttributes { get; set; }
-        [DataMember]
-        public bool SkipAutoProps { get; set; }
-        [DataMember]
-        public bool DeterministicReport { get; set; }
-        [DataMember]
-        public string ExcludeAssembliesWithoutSources { get; set; }
+      _moduleOrAppDirectory = moduleOrDirectory;
+      parameters.IncludeDirectories ??= Array.Empty<string>();
+      _logger = logger;
+      _instrumentationHelper = instrumentationHelper;
+      _parameters = parameters;
+      _fileSystem = fileSystem;
+      _sourceRootTranslator = sourceRootTranslator;
+      _cecilSymbolHelper = cecilSymbolHelper;
+      Identifier = Guid.NewGuid().ToString();
+      _results = new List<InstrumenterResult>();
     }
 
-    internal class Coverage
+    public Coverage(CoveragePrepareResult prepareResult,
+                    ILogger logger,
+                    IInstrumentationHelper instrumentationHelper,
+                    IFileSystem fileSystem,
+                    ISourceRootTranslator sourceRootTranslator)
     {
-        private readonly string _moduleOrAppDirectory;
-        private readonly ILogger _logger;
-        private readonly IInstrumentationHelper _instrumentationHelper;
-        private readonly IFileSystem _fileSystem;
-        private readonly ISourceRootTranslator _sourceRootTranslator;
-        private readonly ICecilSymbolHelper _cecilSymbolHelper;
-        private readonly List<InstrumenterResult> _results;
-        private readonly CoverageParameters _parameters;
-
-        public string Identifier { get; }
-
-        public Coverage(string moduleOrDirectory,
-            CoverageParameters parameters,
-            ILogger logger,
-            IInstrumentationHelper instrumentationHelper,
-            IFileSystem fileSystem,
-            ISourceRootTranslator sourceRootTranslator,
-            ICecilSymbolHelper cecilSymbolHelper)
-        {
-            _moduleOrAppDirectory = moduleOrDirectory;
-            parameters.IncludeDirectories ??= Array.Empty<string>();
-            _logger = logger;
-            _instrumentationHelper = instrumentationHelper;
-            _parameters = parameters;
-            _fileSystem = fileSystem;
-            _sourceRootTranslator = sourceRootTranslator;
-            _cecilSymbolHelper = cecilSymbolHelper;
-            Identifier = Guid.NewGuid().ToString();
-            _results = new List<InstrumenterResult>();
-        }
-
-        public Coverage(CoveragePrepareResult prepareResult,
-                        ILogger logger,
-                        IInstrumentationHelper instrumentationHelper,
-                        IFileSystem fileSystem,
-                        ISourceRootTranslator sourceRootTranslator)
-        {
-            Identifier = prepareResult.Identifier;
-            _moduleOrAppDirectory = prepareResult.ModuleOrDirectory;
-            _parameters = prepareResult.Parameters;
-            _results = new List<InstrumenterResult>(prepareResult.Results);
-            _logger = logger;
-            _instrumentationHelper = instrumentationHelper;
-            _fileSystem = fileSystem;
-            _sourceRootTranslator = sourceRootTranslator;
-        }
-
-        public CoveragePrepareResult PrepareModules()
-        {
-            string[] modules = _instrumentationHelper.GetCoverableModules(_moduleOrAppDirectory, _parameters.IncludeDirectories, _parameters.IncludeTestAssembly);
-
-            Array.ForEach(_parameters.ExcludeFilters ?? Array.Empty<string>(), filter => _logger.LogVerbose($"Excluded module filter '{filter}'"));
-            Array.ForEach(_parameters.IncludeFilters ?? Array.Empty<string>(), filter => _logger.LogVerbose($"Included module filter '{filter}'"));
-            Array.ForEach(_parameters.ExcludedSourceFiles ?? Array.Empty<string>(), filter => _logger.LogVerbose($"Excluded source files filter '{FileSystem.EscapeFileName(filter)}'"));
-
-            _parameters.ExcludeFilters = _parameters.ExcludeFilters?.Where(f => _instrumentationHelper.IsValidFilterExpression(f)).ToArray();
-            _parameters.IncludeFilters = _parameters.IncludeFilters?.Where(f => _instrumentationHelper.IsValidFilterExpression(f)).ToArray();
-
-            foreach (string module in modules)
-            {
-                if (_instrumentationHelper.IsModuleExcluded(module, _parameters.ExcludeFilters) ||
-                    !_instrumentationHelper.IsModuleIncluded(module, _parameters.IncludeFilters))
-                {
-                    _logger.LogVerbose($"Excluded module: '{module}'");
-                    continue;
-                }
-
-                var instrumenter = new Instrumenter(module,
-                                                    Identifier,
-                                                    _parameters,
-                                                    _logger,
-                                                    _instrumentationHelper,
-                                                    _fileSystem,
-                                                    _sourceRootTranslator,
-                                                    _cecilSymbolHelper);
-
-                if (instrumenter.CanInstrument())
-                {
-                    _instrumentationHelper.BackupOriginalModule(module, Identifier);
-
-                    // Guard code path and restore if instrumentation fails.
-                    try
-                    {
-                        InstrumenterResult result = instrumenter.Instrument();
-                        if (!instrumenter.SkipModule)
-                        {
-                            _results.Add(result);
-                            _logger.LogVerbose($"Instrumented module: '{module}'");
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogWarning($"Unable to instrument module: {module}\n{ex}");
-                        _instrumentationHelper.RestoreOriginalModule(module, Identifier);
-                    }
-                }
-            }
-
-            return new CoveragePrepareResult()
-            {
-                Identifier = Identifier,
-                ModuleOrDirectory = _moduleOrAppDirectory,
-                Parameters = _parameters,
-                Results = _results.ToArray()
-            };
-        }
-
-        public CoverageResult GetCoverageResult()
-        {
-            CalculateCoverage();
-
-            var modules = new Modules();
-            foreach (InstrumenterResult result in _results)
-            {
-                var documents = new Documents();
-                foreach (Document doc in result.Documents.Values)
-                {
-                    // Construct Line Results
-                    foreach (Line line in doc.Lines.Values)
-                    {
-                        if (documents.TryGetValue(doc.Path, out Classes classes))
-                        {
-                            if (classes.TryGetValue(line.Class, out Methods methods))
-                            {
-                                if (methods.TryGetValue(line.Method, out Method method))
-                                {
-                                    documents[doc.Path][line.Class][line.Method].Lines.Add(line.Number, line.Hits);
-                                }
-                                else
-                                {
-                                    documents[doc.Path][line.Class].Add(line.Method, new Method());
-                                    documents[doc.Path][line.Class][line.Method].Lines.Add(line.Number, line.Hits);
-                                }
-                            }
-                            else
-                            {
-                                documents[doc.Path].Add(line.Class, new Methods());
-                                documents[doc.Path][line.Class].Add(line.Method, new Method());
-                                documents[doc.Path][line.Class][line.Method].Lines.Add(line.Number, line.Hits);
-                            }
-                        }
-                        else
-                        {
-                            documents.Add(doc.Path, new Classes());
-                            documents[doc.Path].Add(line.Class, new Methods());
-                            documents[doc.Path][line.Class].Add(line.Method, new Method());
-                            documents[doc.Path][line.Class][line.Method].Lines.Add(line.Number, line.Hits);
-                        }
-                    }
-
-                    // Construct Branch Results
-                    foreach (Branch branch in doc.Branches.Values)
-                    {
-                        if (documents.TryGetValue(doc.Path, out Classes classes))
-                        {
-                            if (classes.TryGetValue(branch.Class, out Methods methods))
-                            {
-                                if (methods.TryGetValue(branch.Method, out Method method))
-                                {
-                                    method.Branches.Add(new BranchInfo
-                                    { Line = branch.Number, Hits = branch.Hits, Offset = branch.Offset, EndOffset = branch.EndOffset, Path = branch.Path, Ordinal = branch.Ordinal }
-                                    );
-                                }
-                                else
-                                {
-                                    documents[doc.Path][branch.Class].Add(branch.Method, new Method());
-                                    documents[doc.Path][branch.Class][branch.Method].Branches.Add(new BranchInfo
-                                    { Line = branch.Number, Hits = branch.Hits, Offset = branch.Offset, EndOffset = branch.EndOffset, Path = branch.Path, Ordinal = branch.Ordinal }
-                                    );
-                                }
-                            }
-                            else
-                            {
-                                documents[doc.Path].Add(branch.Class, new Methods());
-                                documents[doc.Path][branch.Class].Add(branch.Method, new Method());
-                                documents[doc.Path][branch.Class][branch.Method].Branches.Add(new BranchInfo
-                                { Line = branch.Number, Hits = branch.Hits, Offset = branch.Offset, EndOffset = branch.EndOffset, Path = branch.Path, Ordinal = branch.Ordinal }
-                                );
-                            }
-                        }
-                        else
-                        {
-                            documents.Add(doc.Path, new Classes());
-                            documents[doc.Path].Add(branch.Class, new Methods());
-                            documents[doc.Path][branch.Class].Add(branch.Method, new Method());
-                            documents[doc.Path][branch.Class][branch.Method].Branches.Add(new BranchInfo
-                            { Line = branch.Number, Hits = branch.Hits, Offset = branch.Offset, EndOffset = branch.EndOffset, Path = branch.Path, Ordinal = branch.Ordinal }
-                            );
-                        }
-                    }
-                }
-
-                modules.Add(Path.GetFileName(result.ModulePath), documents);
-                _instrumentationHelper.RestoreOriginalModule(result.ModulePath, Identifier);
-            }
-
-            // In case of anonymous delegate compiler generate a custom class and passes it as type.method delegate.
-            // If in delegate method we've a branches we need to move these to "actual" class/method that use it.
-            // We search "method" with same "Line" of closure class method and add missing branches to it,
-            // in this way we correctly report missing branch inside compiled generated anonymous delegate.
-            List<string> compileGeneratedClassToRemove = null;
-            foreach (KeyValuePair<string, Documents> module in modules)
-            {
-                foreach (KeyValuePair<string, Classes> document in module.Value)
-                {
-                    foreach (KeyValuePair<string, Methods> @class in document.Value)
-                    {
-                        // We fix only lamda generated class
-                        // https://github.com/dotnet/roslyn/blob/master/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNameKind.cs#L18
-                        if (!@class.Key.Contains("<>c"))
-                        {
-                            continue;
-                        }
-
-                        foreach (KeyValuePair<string, Method> method in @class.Value)
-                        {
-                            foreach (BranchInfo branch in method.Value.Branches)
-                            {
-                                if (BranchInCompilerGeneratedClass(method.Key))
-                                {
-                                    Method actualMethod = GetMethodWithSameLineInSameDocument(document.Value, @class.Key, branch.Line);
-
-                                    if (actualMethod is null)
-                                    {
-                                        continue;
-                                    }
-
-                                    actualMethod.Branches.Add(branch);
-
-                                    if (compileGeneratedClassToRemove is null)
-                                    {
-                                        compileGeneratedClassToRemove = new List<string>();
-                                    }
-
-                                    if (!compileGeneratedClassToRemove.Contains(@class.Key))
-                                    {
-                                        compileGeneratedClassToRemove.Add(@class.Key);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // After method/branches analysis of compiled generated class we can remove noise from reports
-            if (compileGeneratedClassToRemove is not null)
-            {
-                foreach (KeyValuePair<string, Documents> module in modules)
-                {
-                    foreach (KeyValuePair<string, Classes> document in module.Value)
-                    {
-                        foreach (string classToRemove in compileGeneratedClassToRemove)
-                        {
-                            document.Value.Remove(classToRemove);
-                        }
-                    }
-                }
-            }
-
-            var coverageResult = new CoverageResult { Identifier = Identifier, Modules = modules, InstrumentedResults = _results, Parameters = _parameters };
-
-            if (!string.IsNullOrEmpty(_parameters.MergeWith) && !string.IsNullOrWhiteSpace(_parameters.MergeWith) && _fileSystem.Exists(_parameters.MergeWith))
-            {
-                string json = _fileSystem.ReadAllText(_parameters.MergeWith);
-                coverageResult.Merge(JsonConvert.DeserializeObject<Modules>(json));
-            }
-
-            return coverageResult;
-        }
-
-        private bool BranchInCompilerGeneratedClass(string methodName)
-        {
-            foreach (InstrumenterResult instrumentedResult in _results)
-            {
-                if (instrumentedResult.BranchesInCompiledGeneratedClass.Contains(methodName))
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        private static Method GetMethodWithSameLineInSameDocument(Classes documentClasses, string compilerGeneratedClassName, int branchLine)
-        {
-            foreach (KeyValuePair<string, Methods> @class in documentClasses)
-            {
-                if (@class.Key == compilerGeneratedClassName)
-                {
-                    continue;
-                }
-
-                foreach (KeyValuePair<string, Method> method in @class.Value)
-                {
-                    foreach (KeyValuePair<int, int> line in method.Value.Lines)
-                    {
-                        if (line.Key == branchLine)
-                        {
-                            return method.Value;
-                        }
-                    }
-                }
-            }
-            return null;
-        }
-
-        private void CalculateCoverage()
-        {
-            foreach (InstrumenterResult result in _results)
-            {
-                if (!_fileSystem.Exists(result.HitsFilePath))
-                {
-                    // Hits file could be missed mainly for two reason
-                    // 1) Issue during module Unload()
-                    // 2) Instrumented module is never loaded or used so we don't have any hit to register and
-                    //    module tracker is never used
-                    _logger.LogVerbose($"Hits file:'{result.HitsFilePath}' not found for module: '{result.Module}'");
-                    continue;
-                }
-
-                var documents = result.Documents.Values.ToList();
-                if (_parameters.UseSourceLink && result.SourceLink != null)
-                {
-                    JToken jObject = JObject.Parse(result.SourceLink)["documents"];
-                    Dictionary<string, string> sourceLinkDocuments = JsonConvert.DeserializeObject<Dictionary<string, string>>(jObject.ToString());
-                    foreach (Document document in documents)
-                    {
-                        document.Path = GetSourceLinkUrl(sourceLinkDocuments, document.Path);
-                    }
-                }
-
-                // Calculate lines to skip for every hits start/end candidate
-                // Nested ranges win on outermost one
-                foreach (HitCandidate hitCandidate in result.HitCandidates)
-                {
-                    if (hitCandidate.isBranch || hitCandidate.end == hitCandidate.start)
-                    {
-                        continue;
-                    }
-
-                    foreach (HitCandidate hitCandidateToCompare in result.HitCandidates.Where(x => x.docIndex.Equals(hitCandidate.docIndex)))
-                    {
-                        if (hitCandidate != hitCandidateToCompare && !hitCandidateToCompare.isBranch)
-                        {
-                            if (hitCandidateToCompare.start > hitCandidate.start &&
-                               hitCandidateToCompare.end < hitCandidate.end)
-                            {
-                                for (int i = hitCandidateToCompare.start;
-                                     i <= (hitCandidateToCompare.end == 0 ? hitCandidateToCompare.start : hitCandidateToCompare.end);
-                                     i++)
-                                {
-                                    (hitCandidate.AccountedByNestedInstrumentation ??= new HashSet<int>()).Add(i);
-                                }
-                            }
-                        }
-                    }
-                }
-
-                var documentsList = result.Documents.Values.ToList();
-                using (Stream fs = _fileSystem.NewFileStream(result.HitsFilePath, FileMode.Open, FileAccess.Read))
-                using (var br = new BinaryReader(fs))
-                {
-                    int hitCandidatesCount = br.ReadInt32();
-
-                    // TODO: hitCandidatesCount should be verified against result.HitCandidates.Count
-
-                    for (int i = 0; i < hitCandidatesCount; ++i)
-                    {
-                        HitCandidate hitLocation = result.HitCandidates[i];
-                        Document document = documentsList[hitLocation.docIndex];
-                        int hits = br.ReadInt32();
-
-                        if (hits == 0)
-                            continue;
-
-                        hits = hits < 0 ? int.MaxValue : hits;
-
-                        if (hitLocation.isBranch)
-                        {
-                            Branch branch = document.Branches[new BranchKey(hitLocation.start, hitLocation.end)];
-                            branch.Hits += hits;
-
-                            if (branch.Hits < 0)
-                                branch.Hits = int.MaxValue;
-                        }
-                        else
-                        {
-                            for (int j = hitLocation.start; j <= hitLocation.end; j++)
-                            {
-                                if (hitLocation.AccountedByNestedInstrumentation?.Contains(j) == true)
-                                {
-                                    continue;
-                                }
-
-                                Line line = document.Lines[j];
-                                line.Hits += hits;
-
-                                if (line.Hits < 0)
-                                    line.Hits = int.MaxValue;
-                            }
-                        }
-                    }
-                }
-
-                try
-                {
-                    _instrumentationHelper.DeleteHitsFile(result.HitsFilePath);
-                    _logger.LogVerbose($"Hit file '{result.HitsFilePath}' deleted");
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning($"Unable to remove hit file: {result.HitsFilePath} because : {ex.Message}");
-                }
-            }
-        }
-
-        private string GetSourceLinkUrl(Dictionary<string, string> sourceLinkDocuments, string document)
-        {
-            if (sourceLinkDocuments.TryGetValue(document, out string url))
-            {
-                return url;
-            }
-
-            string keyWithBestMatch = string.Empty;
-            string relativePathOfBestMatch = string.Empty;
-
-            foreach (KeyValuePair<string, string> sourceLinkDocument in sourceLinkDocuments)
-            {
-                string key = sourceLinkDocument.Key;
-                if (Path.GetFileName(key) != "*") continue;
-
-                IReadOnlyList<SourceRootMapping> rootMapping = _sourceRootTranslator.ResolvePathRoot(key.Substring(0, key.Length - 1));
-                foreach (string keyMapping in rootMapping is null ? new List<string>() { key } : new List<string>(rootMapping.Select(m => m.OriginalPath)))
-                {
-                    string directoryDocument = Path.GetDirectoryName(document);
-                    string sourceLinkRoot = Path.GetDirectoryName(keyMapping);
-                    string relativePath = "";
-
-                    // if document is on repo root we skip relative path calculation
-                    if (directoryDocument != sourceLinkRoot)
-                    {
-                        if (!directoryDocument.StartsWith(sourceLinkRoot + Path.DirectorySeparatorChar))
-                            continue;
-
-                        relativePath = directoryDocument.Substring(sourceLinkRoot.Length + 1);
-                    }
-
-                    if (relativePathOfBestMatch.Length == 0)
-                    {
-                        keyWithBestMatch = sourceLinkDocument.Key;
-                        relativePathOfBestMatch = relativePath;
-                    }
-
-                    if (relativePath.Length < relativePathOfBestMatch.Length)
-                    {
-                        keyWithBestMatch = sourceLinkDocument.Key;
-                        relativePathOfBestMatch = relativePath;
-                    }
-                }
-            }
-
-            relativePathOfBestMatch = relativePathOfBestMatch == "." ? string.Empty : relativePathOfBestMatch;
-
-            string replacement = Path.Combine(relativePathOfBestMatch, Path.GetFileName(document));
-            replacement = replacement.Replace('\\', '/');
-
-            if (sourceLinkDocuments.TryGetValue(keyWithBestMatch, out url))
-            {
-                return url.Replace("*", replacement);
-            }
-
-            return document;
-        }
+      Identifier = prepareResult.Identifier;
+      _moduleOrAppDirectory = prepareResult.ModuleOrDirectory;
+      _parameters = prepareResult.Parameters;
+      _results = new List<InstrumenterResult>(prepareResult.Results);
+      _logger = logger;
+      _instrumentationHelper = instrumentationHelper;
+      _fileSystem = fileSystem;
+      _sourceRootTranslator = sourceRootTranslator;
     }
+
+    public CoveragePrepareResult PrepareModules()
+    {
+      string[] modules = _instrumentationHelper.GetCoverableModules(_moduleOrAppDirectory, _parameters.IncludeDirectories, _parameters.IncludeTestAssembly);
+
+      Array.ForEach(_parameters.ExcludeFilters ?? Array.Empty<string>(), filter => _logger.LogVerbose($"Excluded module filter '{filter}'"));
+      Array.ForEach(_parameters.IncludeFilters ?? Array.Empty<string>(), filter => _logger.LogVerbose($"Included module filter '{filter}'"));
+      Array.ForEach(_parameters.ExcludedSourceFiles ?? Array.Empty<string>(), filter => _logger.LogVerbose($"Excluded source files filter '{FileSystem.EscapeFileName(filter)}'"));
+
+      _parameters.ExcludeFilters = _parameters.ExcludeFilters?.Where(f => _instrumentationHelper.IsValidFilterExpression(f)).ToArray();
+      _parameters.IncludeFilters = _parameters.IncludeFilters?.Where(f => _instrumentationHelper.IsValidFilterExpression(f)).ToArray();
+
+      foreach (string module in modules)
+      {
+        if (_instrumentationHelper.IsModuleExcluded(module, _parameters.ExcludeFilters) ||
+            !_instrumentationHelper.IsModuleIncluded(module, _parameters.IncludeFilters))
+        {
+          _logger.LogVerbose($"Excluded module: '{module}'");
+          continue;
+        }
+
+        var instrumenter = new Instrumenter(module,
+                                            Identifier,
+                                            _parameters,
+                                            _logger,
+                                            _instrumentationHelper,
+                                            _fileSystem,
+                                            _sourceRootTranslator,
+                                            _cecilSymbolHelper);
+
+        if (instrumenter.CanInstrument())
+        {
+          _instrumentationHelper.BackupOriginalModule(module, Identifier);
+
+          // Guard code path and restore if instrumentation fails.
+          try
+          {
+            InstrumenterResult result = instrumenter.Instrument();
+            if (!instrumenter.SkipModule)
+            {
+              _results.Add(result);
+              _logger.LogVerbose($"Instrumented module: '{module}'");
+            }
+          }
+          catch (Exception ex)
+          {
+            _logger.LogWarning($"Unable to instrument module: {module}\n{ex}");
+            _instrumentationHelper.RestoreOriginalModule(module, Identifier);
+          }
+        }
+      }
+
+      return new CoveragePrepareResult()
+      {
+        Identifier = Identifier,
+        ModuleOrDirectory = _moduleOrAppDirectory,
+        Parameters = _parameters,
+        Results = _results.ToArray()
+      };
+    }
+
+    public CoverageResult GetCoverageResult()
+    {
+      CalculateCoverage();
+
+      var modules = new Modules();
+      foreach (InstrumenterResult result in _results)
+      {
+        var documents = new Documents();
+        foreach (Document doc in result.Documents.Values)
+        {
+          // Construct Line Results
+          foreach (Line line in doc.Lines.Values)
+          {
+            if (documents.TryGetValue(doc.Path, out Classes classes))
+            {
+              if (classes.TryGetValue(line.Class, out Methods methods))
+              {
+                if (methods.TryGetValue(line.Method, out Method method))
+                {
+                  documents[doc.Path][line.Class][line.Method].Lines.Add(line.Number, line.Hits);
+                }
+                else
+                {
+                  documents[doc.Path][line.Class].Add(line.Method, new Method());
+                  documents[doc.Path][line.Class][line.Method].Lines.Add(line.Number, line.Hits);
+                }
+              }
+              else
+              {
+                documents[doc.Path].Add(line.Class, new Methods());
+                documents[doc.Path][line.Class].Add(line.Method, new Method());
+                documents[doc.Path][line.Class][line.Method].Lines.Add(line.Number, line.Hits);
+              }
+            }
+            else
+            {
+              documents.Add(doc.Path, new Classes());
+              documents[doc.Path].Add(line.Class, new Methods());
+              documents[doc.Path][line.Class].Add(line.Method, new Method());
+              documents[doc.Path][line.Class][line.Method].Lines.Add(line.Number, line.Hits);
+            }
+          }
+
+          // Construct Branch Results
+          foreach (Branch branch in doc.Branches.Values)
+          {
+            if (documents.TryGetValue(doc.Path, out Classes classes))
+            {
+              if (classes.TryGetValue(branch.Class, out Methods methods))
+              {
+                if (methods.TryGetValue(branch.Method, out Method method))
+                {
+                  method.Branches.Add(new BranchInfo
+                  { Line = branch.Number, Hits = branch.Hits, Offset = branch.Offset, EndOffset = branch.EndOffset, Path = branch.Path, Ordinal = branch.Ordinal }
+                  );
+                }
+                else
+                {
+                  documents[doc.Path][branch.Class].Add(branch.Method, new Method());
+                  documents[doc.Path][branch.Class][branch.Method].Branches.Add(new BranchInfo
+                  { Line = branch.Number, Hits = branch.Hits, Offset = branch.Offset, EndOffset = branch.EndOffset, Path = branch.Path, Ordinal = branch.Ordinal }
+                  );
+                }
+              }
+              else
+              {
+                documents[doc.Path].Add(branch.Class, new Methods());
+                documents[doc.Path][branch.Class].Add(branch.Method, new Method());
+                documents[doc.Path][branch.Class][branch.Method].Branches.Add(new BranchInfo
+                { Line = branch.Number, Hits = branch.Hits, Offset = branch.Offset, EndOffset = branch.EndOffset, Path = branch.Path, Ordinal = branch.Ordinal }
+                );
+              }
+            }
+            else
+            {
+              documents.Add(doc.Path, new Classes());
+              documents[doc.Path].Add(branch.Class, new Methods());
+              documents[doc.Path][branch.Class].Add(branch.Method, new Method());
+              documents[doc.Path][branch.Class][branch.Method].Branches.Add(new BranchInfo
+              { Line = branch.Number, Hits = branch.Hits, Offset = branch.Offset, EndOffset = branch.EndOffset, Path = branch.Path, Ordinal = branch.Ordinal }
+              );
+            }
+          }
+        }
+
+        modules.Add(Path.GetFileName(result.ModulePath), documents);
+        _instrumentationHelper.RestoreOriginalModule(result.ModulePath, Identifier);
+      }
+
+      // In case of anonymous delegate compiler generate a custom class and passes it as type.method delegate.
+      // If in delegate method we've a branches we need to move these to "actual" class/method that use it.
+      // We search "method" with same "Line" of closure class method and add missing branches to it,
+      // in this way we correctly report missing branch inside compiled generated anonymous delegate.
+      List<string> compileGeneratedClassToRemove = null;
+      foreach (KeyValuePair<string, Documents> module in modules)
+      {
+        foreach (KeyValuePair<string, Classes> document in module.Value)
+        {
+          foreach (KeyValuePair<string, Methods> @class in document.Value)
+          {
+            // We fix only lamda generated class
+            // https://github.com/dotnet/roslyn/blob/master/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNameKind.cs#L18
+            if (!@class.Key.Contains("<>c"))
+            {
+              continue;
+            }
+
+            foreach (KeyValuePair<string, Method> method in @class.Value)
+            {
+              foreach (BranchInfo branch in method.Value.Branches)
+              {
+                if (BranchInCompilerGeneratedClass(method.Key))
+                {
+                  Method actualMethod = GetMethodWithSameLineInSameDocument(document.Value, @class.Key, branch.Line);
+
+                  if (actualMethod is null)
+                  {
+                    continue;
+                  }
+
+                  actualMethod.Branches.Add(branch);
+
+                  if (compileGeneratedClassToRemove is null)
+                  {
+                    compileGeneratedClassToRemove = new List<string>();
+                  }
+
+                  if (!compileGeneratedClassToRemove.Contains(@class.Key))
+                  {
+                    compileGeneratedClassToRemove.Add(@class.Key);
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      // After method/branches analysis of compiled generated class we can remove noise from reports
+      if (compileGeneratedClassToRemove is not null)
+      {
+        foreach (KeyValuePair<string, Documents> module in modules)
+        {
+          foreach (KeyValuePair<string, Classes> document in module.Value)
+          {
+            foreach (string classToRemove in compileGeneratedClassToRemove)
+            {
+              document.Value.Remove(classToRemove);
+            }
+          }
+        }
+      }
+
+      var coverageResult = new CoverageResult { Identifier = Identifier, Modules = modules, InstrumentedResults = _results, Parameters = _parameters };
+
+      if (!string.IsNullOrEmpty(_parameters.MergeWith) && !string.IsNullOrWhiteSpace(_parameters.MergeWith) && _fileSystem.Exists(_parameters.MergeWith))
+      {
+        string json = _fileSystem.ReadAllText(_parameters.MergeWith);
+        coverageResult.Merge(JsonSerializer.Deserialize<Modules>(json));
+      }
+
+      return coverageResult;
+    }
+
+    private bool BranchInCompilerGeneratedClass(string methodName)
+    {
+      foreach (InstrumenterResult instrumentedResult in _results)
+      {
+        if (instrumentedResult.BranchesInCompiledGeneratedClass.Contains(methodName))
+        {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    private static Method GetMethodWithSameLineInSameDocument(Classes documentClasses, string compilerGeneratedClassName, int branchLine)
+    {
+      foreach (KeyValuePair<string, Methods> @class in documentClasses)
+      {
+        if (@class.Key == compilerGeneratedClassName)
+        {
+          continue;
+        }
+
+        foreach (KeyValuePair<string, Method> method in @class.Value)
+        {
+          foreach (KeyValuePair<int, int> line in method.Value.Lines)
+          {
+            if (line.Key == branchLine)
+            {
+              return method.Value;
+            }
+          }
+        }
+      }
+      return null;
+    }
+
+    private void CalculateCoverage()
+    {
+      foreach (InstrumenterResult result in _results)
+      {
+        if (!_fileSystem.Exists(result.HitsFilePath))
+        {
+          // Hits file could be missed mainly for two reason
+          // 1) Issue during module Unload()
+          // 2) Instrumented module is never loaded or used so we don't have any hit to register and
+          //    module tracker is never used
+          _logger.LogVerbose($"Hits file:'{result.HitsFilePath}' not found for module: '{result.Module}'");
+          continue;
+        }
+
+        var documents = result.Documents.Values.ToList();
+        if (_parameters.UseSourceLink && result.SourceLink != null)
+        {
+          JsonNode jObject = JsonNode.Parse(result.SourceLink)["documents"];
+          Dictionary<string, string> sourceLinkDocuments = JsonSerializer.Deserialize<Dictionary<string, string>>(jObject.ToString());
+          foreach (Document document in documents)
+          {
+            document.Path = GetSourceLinkUrl(sourceLinkDocuments, document.Path);
+          }
+        }
+
+        // Calculate lines to skip for every hits start/end candidate
+        // Nested ranges win on outermost one
+        foreach (HitCandidate hitCandidate in result.HitCandidates)
+        {
+          if (hitCandidate.isBranch || hitCandidate.end == hitCandidate.start)
+          {
+            continue;
+          }
+
+          foreach (HitCandidate hitCandidateToCompare in result.HitCandidates.Where(x => x.docIndex.Equals(hitCandidate.docIndex)))
+          {
+            if (hitCandidate != hitCandidateToCompare && !hitCandidateToCompare.isBranch)
+            {
+              if (hitCandidateToCompare.start > hitCandidate.start &&
+                 hitCandidateToCompare.end < hitCandidate.end)
+              {
+                for (int i = hitCandidateToCompare.start;
+                     i <= (hitCandidateToCompare.end == 0 ? hitCandidateToCompare.start : hitCandidateToCompare.end);
+                     i++)
+                {
+                  (hitCandidate.AccountedByNestedInstrumentation ??= new HashSet<int>()).Add(i);
+                }
+              }
+            }
+          }
+        }
+
+        var documentsList = result.Documents.Values.ToList();
+        using (Stream fs = _fileSystem.NewFileStream(result.HitsFilePath, FileMode.Open, FileAccess.Read))
+        using (var br = new BinaryReader(fs))
+        {
+          int hitCandidatesCount = br.ReadInt32();
+
+          // TODO: hitCandidatesCount should be verified against result.HitCandidates.Count
+
+          for (int i = 0; i < hitCandidatesCount; ++i)
+          {
+            HitCandidate hitLocation = result.HitCandidates[i];
+            Document document = documentsList[hitLocation.docIndex];
+            int hits = br.ReadInt32();
+
+            if (hits == 0)
+              continue;
+
+            hits = hits < 0 ? int.MaxValue : hits;
+
+            if (hitLocation.isBranch)
+            {
+              Branch branch = document.Branches[new BranchKey(hitLocation.start, hitLocation.end)];
+              branch.Hits += hits;
+
+              if (branch.Hits < 0)
+                branch.Hits = int.MaxValue;
+            }
+            else
+            {
+              for (int j = hitLocation.start; j <= hitLocation.end; j++)
+              {
+                if (hitLocation.AccountedByNestedInstrumentation?.Contains(j) == true)
+                {
+                  continue;
+                }
+
+                Line line = document.Lines[j];
+                line.Hits += hits;
+
+                if (line.Hits < 0)
+                  line.Hits = int.MaxValue;
+              }
+            }
+          }
+        }
+
+        try
+        {
+          _instrumentationHelper.DeleteHitsFile(result.HitsFilePath);
+          _logger.LogVerbose($"Hit file '{result.HitsFilePath}' deleted");
+        }
+        catch (Exception ex)
+        {
+          _logger.LogWarning($"Unable to remove hit file: {result.HitsFilePath} because : {ex.Message}");
+        }
+      }
+    }
+
+    private string GetSourceLinkUrl(Dictionary<string, string> sourceLinkDocuments, string document)
+    {
+      if (sourceLinkDocuments.TryGetValue(document, out string url))
+      {
+        return url;
+      }
+
+      string keyWithBestMatch = string.Empty;
+      string relativePathOfBestMatch = string.Empty;
+
+      foreach (KeyValuePair<string, string> sourceLinkDocument in sourceLinkDocuments)
+      {
+        string key = sourceLinkDocument.Key;
+        if (Path.GetFileName(key) != "*") continue;
+
+        IReadOnlyList<SourceRootMapping> rootMapping = _sourceRootTranslator.ResolvePathRoot(key.Substring(0, key.Length - 1));
+        foreach (string keyMapping in rootMapping is null ? new List<string>() { key } : new List<string>(rootMapping.Select(m => m.OriginalPath)))
+        {
+          string directoryDocument = Path.GetDirectoryName(document);
+          string sourceLinkRoot = Path.GetDirectoryName(keyMapping);
+          string relativePath = "";
+
+          // if document is on repo root we skip relative path calculation
+          if (directoryDocument != sourceLinkRoot)
+          {
+            if (!directoryDocument.StartsWith(sourceLinkRoot + Path.DirectorySeparatorChar))
+              continue;
+
+            relativePath = directoryDocument.Substring(sourceLinkRoot.Length + 1);
+          }
+
+          if (relativePathOfBestMatch.Length == 0)
+          {
+            keyWithBestMatch = sourceLinkDocument.Key;
+            relativePathOfBestMatch = relativePath;
+          }
+
+          if (relativePath.Length < relativePathOfBestMatch.Length)
+          {
+            keyWithBestMatch = sourceLinkDocument.Key;
+            relativePathOfBestMatch = relativePath;
+          }
+        }
+      }
+
+      relativePathOfBestMatch = relativePathOfBestMatch == "." ? string.Empty : relativePathOfBestMatch;
+
+      string replacement = Path.Combine(relativePathOfBestMatch, Path.GetFileName(document));
+      replacement = replacement.Replace('\\', '/');
+
+      if (sourceLinkDocuments.TryGetValue(keyWithBestMatch, out url))
+      {
+        return url.Replace("*", replacement);
+      }
+
+      return document;
+    }
+  }
 }

--- a/src/coverlet.core/CoverageResult.cs
+++ b/src/coverlet.core/CoverageResult.cs
@@ -10,17 +10,11 @@ namespace Coverlet.Core
 {
   internal class BranchInfo
   {
-    [System.Text.Json.Serialization.JsonInclude]
     public int Line { get; set; }
-    [System.Text.Json.Serialization.JsonInclude]
     public int Offset { get; set; }
-    [System.Text.Json.Serialization.JsonInclude]
     public int EndOffset { get; set; }
-    [System.Text.Json.Serialization.JsonInclude]
     public int Path { get; set; }
-    [System.Text.Json.Serialization.JsonInclude]
     public uint Ordinal { get; set; }
-    [System.Text.Json.Serialization.JsonInclude]
     public int Hits { get; set; }
   }
   internal class Lines : SortedDictionary<int, int> { }
@@ -33,9 +27,7 @@ namespace Coverlet.Core
       Lines = new Lines();
       Branches = new Branches();
     }
-    [System.Text.Json.Serialization.JsonInclude]
     public Lines Lines;
-    [System.Text.Json.Serialization.JsonInclude]
     public Branches Branches;
   }
   internal class Methods : Dictionary<string, Method> { }

--- a/src/coverlet.core/CoverageResult.cs
+++ b/src/coverlet.core/CoverageResult.cs
@@ -8,175 +8,181 @@ using Coverlet.Core.Instrumentation;
 
 namespace Coverlet.Core
 {
-    internal class BranchInfo
+  internal class BranchInfo
+  {
+    [System.Text.Json.Serialization.JsonInclude]
+    public int Line { get; set; }
+    [System.Text.Json.Serialization.JsonInclude]
+    public int Offset { get; set; }
+    [System.Text.Json.Serialization.JsonInclude]
+    public int EndOffset { get; set; }
+    [System.Text.Json.Serialization.JsonInclude]
+    public int Path { get; set; }
+    [System.Text.Json.Serialization.JsonInclude]
+    public uint Ordinal { get; set; }
+    [System.Text.Json.Serialization.JsonInclude]
+    public int Hits { get; set; }
+  }
+  internal class Lines : SortedDictionary<int, int> { }
+  internal class Branches : List<BranchInfo> { }
+
+  internal class Method
+  {
+    internal Method()
     {
-        public int Line { get; set; }
-        public int Offset { get; set; }
-        public int EndOffset { get; set; }
-        public int Path { get; set; }
-        public uint Ordinal { get; set; }
-        public int Hits { get; set; }
+      Lines = new Lines();
+      Branches = new Branches();
     }
+    [System.Text.Json.Serialization.JsonInclude]
+    public Lines Lines;
+    [System.Text.Json.Serialization.JsonInclude]
+    public Branches Branches;
+  }
+  internal class Methods : Dictionary<string, Method> { }
+  internal class Classes : Dictionary<string, Methods> { }
+  internal class Documents : Dictionary<string, Classes> { }
+  internal class Modules : Dictionary<string, Documents> { }
 
-    internal class Lines : SortedDictionary<int, int> { }
+  internal class CoverageResult
+  {
+    public string Identifier { get; set; }
+    public Modules Modules { get; set; }
+    public List<InstrumenterResult> InstrumentedResults { get; set; }
+    public CoverageParameters Parameters { get; set; }
 
-    internal class Branches : List<BranchInfo> { }
+    public CoverageResult() { }
 
-    internal class Method
+    public void Merge(Modules modules)
     {
-        internal Method()
+      foreach (KeyValuePair<string, Documents> module in modules)
+      {
+        if (!Modules.Keys.Contains(module.Key))
         {
-            Lines = new Lines();
-            Branches = new Branches();
+          Modules.Add(module.Key, module.Value);
         }
-        public Lines Lines;
-        public Branches Branches;
-    }
-    internal class Methods : Dictionary<string, Method> { }
-    internal class Classes : Dictionary<string, Methods> { }
-    internal class Documents : Dictionary<string, Classes> { }
-    internal class Modules : Dictionary<string, Documents> { }
-
-    internal class CoverageResult
-    {
-        public string Identifier { get; set; }
-        public Modules Modules { get; set; }
-        public List<InstrumenterResult> InstrumentedResults { get; set; }
-        public CoverageParameters Parameters { get; set; }
-
-        public CoverageResult() { }
-
-        public void Merge(Modules modules)
+        else
         {
-            foreach (KeyValuePair<string, Documents> module in modules)
+          foreach (KeyValuePair<string, Classes> document in module.Value)
+          {
+            if (!Modules[module.Key].ContainsKey(document.Key))
             {
-                if (!Modules.Keys.Contains(module.Key))
+              Modules[module.Key].Add(document.Key, document.Value);
+            }
+            else
+            {
+              foreach (KeyValuePair<string, Methods> @class in document.Value)
+              {
+                if (!Modules[module.Key][document.Key].ContainsKey(@class.Key))
                 {
-                    Modules.Add(module.Key, module.Value);
+                  Modules[module.Key][document.Key].Add(@class.Key, @class.Value);
                 }
                 else
                 {
-                    foreach (KeyValuePair<string, Classes> document in module.Value)
+                  foreach (KeyValuePair<string, Method> method in @class.Value)
+                  {
+                    if (!Modules[module.Key][document.Key][@class.Key].ContainsKey(method.Key))
                     {
-                        if (!Modules[module.Key].ContainsKey(document.Key))
+                      Modules[module.Key][document.Key][@class.Key].Add(method.Key, method.Value);
+                    }
+                    else
+                    {
+                      foreach (KeyValuePair<int, int> line in method.Value.Lines)
+                      {
+                        if (!Modules[module.Key][document.Key][@class.Key][method.Key].Lines.ContainsKey(line.Key))
                         {
-                            Modules[module.Key].Add(document.Key, document.Value);
+                          Modules[module.Key][document.Key][@class.Key][method.Key].Lines.Add(line.Key, line.Value);
                         }
                         else
                         {
-                            foreach (KeyValuePair<string, Methods> @class in document.Value)
-                            {
-                                if (!Modules[module.Key][document.Key].ContainsKey(@class.Key))
-                                {
-                                    Modules[module.Key][document.Key].Add(@class.Key, @class.Value);
-                                }
-                                else
-                                {
-                                    foreach (KeyValuePair<string, Method> method in @class.Value)
-                                    {
-                                        if (!Modules[module.Key][document.Key][@class.Key].ContainsKey(method.Key))
-                                        {
-                                            Modules[module.Key][document.Key][@class.Key].Add(method.Key, method.Value);
-                                        }
-                                        else
-                                        {
-                                            foreach (KeyValuePair<int, int> line in method.Value.Lines)
-                                            {
-                                                if (!Modules[module.Key][document.Key][@class.Key][method.Key].Lines.ContainsKey(line.Key))
-                                                {
-                                                    Modules[module.Key][document.Key][@class.Key][method.Key].Lines.Add(line.Key, line.Value);
-                                                }
-                                                else
-                                                {
-                                                    Modules[module.Key][document.Key][@class.Key][method.Key].Lines[line.Key] += line.Value;
-                                                }
-                                            }
-
-                                            foreach (BranchInfo branch in method.Value.Branches)
-                                            {
-                                                Branches branches = Modules[module.Key][document.Key][@class.Key][method.Key].Branches;
-                                                BranchInfo branchInfo = branches.FirstOrDefault(b => b.EndOffset == branch.EndOffset && b.Line == branch.Line && b.Offset == branch.Offset && b.Ordinal == branch.Ordinal && b.Path == branch.Path);
-                                                if (branchInfo == null)
-                                                    branches.Add(branch);
-                                                else
-                                                    branchInfo.Hits += branch.Hits;
-                                            }
-                                        }
-                                    }
-                                }
-                            }
+                          Modules[module.Key][document.Key][@class.Key][method.Key].Lines[line.Key] += line.Value;
                         }
+                      }
+
+                      foreach (BranchInfo branch in method.Value.Branches)
+                      {
+                        Branches branches = Modules[module.Key][document.Key][@class.Key][method.Key].Branches;
+                        BranchInfo branchInfo = branches.FirstOrDefault(b => b.EndOffset == branch.EndOffset && b.Line == branch.Line && b.Offset == branch.Offset && b.Ordinal == branch.Ordinal && b.Path == branch.Path);
+                        if (branchInfo == null)
+                          branches.Add(branch);
+                        else
+                          branchInfo.Hits += branch.Hits;
+                      }
                     }
+                  }
                 }
+              }
             }
+          }
         }
-
-        public ThresholdTypeFlags GetThresholdTypesBelowThreshold(CoverageSummary summary, Dictionary<ThresholdTypeFlags, double> thresholdTypeFlagValues, ThresholdStatistic thresholdStat)
-        {
-            ThresholdTypeFlags thresholdTypeFlags = ThresholdTypeFlags.None;
-            switch (thresholdStat)
-            {
-                case ThresholdStatistic.Minimum:
-                    {
-                        if (!Modules.Any())
-                            thresholdTypeFlags = CompareThresholdValues(thresholdTypeFlagValues, thresholdTypeFlags, 0, 0, 0);
-
-                        foreach (KeyValuePair<string, Documents> module in Modules)
-                        {
-                            double line = summary.CalculateLineCoverage(module.Value).Percent;
-                            double branch = summary.CalculateBranchCoverage(module.Value).Percent;
-                            double method = summary.CalculateMethodCoverage(module.Value).Percent;
-
-                            thresholdTypeFlags = CompareThresholdValues(thresholdTypeFlagValues, thresholdTypeFlags, line, branch, method);
-                        }
-                    }
-                    break;
-                case ThresholdStatistic.Average:
-                    {
-                        double line = summary.CalculateLineCoverage(Modules).AverageModulePercent;
-                        double branch = summary.CalculateBranchCoverage(Modules).AverageModulePercent;
-                        double method = summary.CalculateMethodCoverage(Modules).AverageModulePercent;
-
-                        thresholdTypeFlags = CompareThresholdValues(thresholdTypeFlagValues, thresholdTypeFlags, line, branch, method);
-                    }
-                    break;
-                case ThresholdStatistic.Total:
-                    {
-                        double line = summary.CalculateLineCoverage(Modules).Percent;
-                        double branch = summary.CalculateBranchCoverage(Modules).Percent;
-                        double method = summary.CalculateMethodCoverage(Modules).Percent;
-
-                        thresholdTypeFlags = CompareThresholdValues(thresholdTypeFlagValues, thresholdTypeFlags, line, branch, method);
-                    }
-                    break;
-            }
-
-            return thresholdTypeFlags;
-        }
-
-        private static ThresholdTypeFlags CompareThresholdValues(
-            Dictionary<ThresholdTypeFlags, double> thresholdTypeFlagValues, ThresholdTypeFlags thresholdTypeFlags,
-            double line, double branch, double method)
-        {
-            if (thresholdTypeFlagValues.TryGetValue(ThresholdTypeFlags.Line, out double lineThresholdValue) &&
-                lineThresholdValue > line)
-            {
-                thresholdTypeFlags |= ThresholdTypeFlags.Line;
-            }
-
-            if (thresholdTypeFlagValues.TryGetValue(ThresholdTypeFlags.Branch, out double branchThresholdValue) &&
-                branchThresholdValue > branch)
-            {
-                thresholdTypeFlags |= ThresholdTypeFlags.Branch;
-            }
-
-            if (thresholdTypeFlagValues.TryGetValue(ThresholdTypeFlags.Method, out double methodThresholdValue) &&
-                methodThresholdValue > method)
-            {
-                thresholdTypeFlags |= ThresholdTypeFlags.Method;
-            }
-
-            return thresholdTypeFlags;
-        }
+      }
     }
+
+    public ThresholdTypeFlags GetThresholdTypesBelowThreshold(CoverageSummary summary, Dictionary<ThresholdTypeFlags, double> thresholdTypeFlagValues, ThresholdStatistic thresholdStat)
+    {
+      ThresholdTypeFlags thresholdTypeFlags = ThresholdTypeFlags.None;
+      switch (thresholdStat)
+      {
+        case ThresholdStatistic.Minimum:
+          {
+            if (!Modules.Any())
+              thresholdTypeFlags = CompareThresholdValues(thresholdTypeFlagValues, thresholdTypeFlags, 0, 0, 0);
+
+            foreach (KeyValuePair<string, Documents> module in Modules)
+            {
+              double line = summary.CalculateLineCoverage(module.Value).Percent;
+              double branch = summary.CalculateBranchCoverage(module.Value).Percent;
+              double method = summary.CalculateMethodCoverage(module.Value).Percent;
+
+              thresholdTypeFlags = CompareThresholdValues(thresholdTypeFlagValues, thresholdTypeFlags, line, branch, method);
+            }
+          }
+          break;
+        case ThresholdStatistic.Average:
+          {
+            double line = summary.CalculateLineCoverage(Modules).AverageModulePercent;
+            double branch = summary.CalculateBranchCoverage(Modules).AverageModulePercent;
+            double method = summary.CalculateMethodCoverage(Modules).AverageModulePercent;
+
+            thresholdTypeFlags = CompareThresholdValues(thresholdTypeFlagValues, thresholdTypeFlags, line, branch, method);
+          }
+          break;
+        case ThresholdStatistic.Total:
+          {
+            double line = summary.CalculateLineCoverage(Modules).Percent;
+            double branch = summary.CalculateBranchCoverage(Modules).Percent;
+            double method = summary.CalculateMethodCoverage(Modules).Percent;
+
+            thresholdTypeFlags = CompareThresholdValues(thresholdTypeFlagValues, thresholdTypeFlags, line, branch, method);
+          }
+          break;
+      }
+
+      return thresholdTypeFlags;
+    }
+
+    private static ThresholdTypeFlags CompareThresholdValues(
+        Dictionary<ThresholdTypeFlags, double> thresholdTypeFlagValues, ThresholdTypeFlags thresholdTypeFlags,
+        double line, double branch, double method)
+    {
+      if (thresholdTypeFlagValues.TryGetValue(ThresholdTypeFlags.Line, out double lineThresholdValue) &&
+          lineThresholdValue > line)
+      {
+        thresholdTypeFlags |= ThresholdTypeFlags.Line;
+      }
+
+      if (thresholdTypeFlagValues.TryGetValue(ThresholdTypeFlags.Branch, out double branchThresholdValue) &&
+          branchThresholdValue > branch)
+      {
+        thresholdTypeFlags |= ThresholdTypeFlags.Branch;
+      }
+
+      if (thresholdTypeFlagValues.TryGetValue(ThresholdTypeFlags.Method, out double methodThresholdValue) &&
+          methodThresholdValue > method)
+      {
+        thresholdTypeFlags |= ThresholdTypeFlags.Method;
+      }
+
+      return thresholdTypeFlags;
+    }
+  }
 }

--- a/src/coverlet.core/Instrumentation/CecilAssemblyResolver.cs
+++ b/src/coverlet.core/Instrumentation/CecilAssemblyResolver.cs
@@ -5,312 +5,318 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using Coverlet.Core.Abstractions;
 using Coverlet.Core.Exceptions;
 using Microsoft.Extensions.DependencyModel;
 using Microsoft.Extensions.DependencyModel.Resolution;
 using Mono.Cecil;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+
 
 namespace Coverlet.Core.Instrumentation
 {
-    /// <summary>
-    /// In case of testing different runtime i.e. netfx we could find netstandard.dll in folder.
-    /// netstandard.dll is a forward only lib, there is no IL but only forwards to "runtime" implementation.
-    /// For some classes implementation are in different assembly for different runtime for instance:
-    ///
-    /// For NetFx 4.7
-    /// // Token: 0x2700072C RID: 1836
-    /// .class extern forwarder System.Security.Cryptography.X509Certificates.StoreName
-    /// {
-    ///    .assembly extern System
-    /// }
-    ///
-    /// For netcoreapp2.2
-    /// Token: 0x2700072C RID: 1836
-    /// .class extern forwarder System.Security.Cryptography.X509Certificates.StoreName
-    /// {
-    ///    .assembly extern System.Security.Cryptography.X509Certificates
-    /// }
-    ///
-    /// There is a concrete possibility that Cecil cannot find implementation and throws StackOverflow exception https://github.com/jbevain/cecil/issues/575
-    /// This custom resolver check if requested lib is a "official" netstandard.dll and load once of "current runtime" with
-    /// correct forwards.
-    /// Check compares 'assembly name' and 'public key token', because versions could differ between runtimes.
-    /// </summary>
-    internal class NetstandardAwareAssemblyResolver : DefaultAssemblyResolver
+  /// <summary>
+  /// In case of testing different runtime i.e. netfx we could find netstandard.dll in folder.
+  /// netstandard.dll is a forward only lib, there is no IL but only forwards to "runtime" implementation.
+  /// For some classes implementation are in different assembly for different runtime for instance:
+  ///
+  /// For NetFx 4.7
+  /// // Token: 0x2700072C RID: 1836
+  /// .class extern forwarder System.Security.Cryptography.X509Certificates.StoreName
+  /// {
+  ///    .assembly extern System
+  /// }
+  ///
+  /// For netcoreapp2.2
+  /// Token: 0x2700072C RID: 1836
+  /// .class extern forwarder System.Security.Cryptography.X509Certificates.StoreName
+  /// {
+  ///    .assembly extern System.Security.Cryptography.X509Certificates
+  /// }
+  ///
+  /// There is a concrete possibility that Cecil cannot find implementation and throws StackOverflow exception https://github.com/jbevain/cecil/issues/575
+  /// This custom resolver check if requested lib is a "official" netstandard.dll and load once of "current runtime" with
+  /// correct forwards.
+  /// Check compares 'assembly name' and 'public key token', because versions could differ between runtimes.
+  /// </summary>
+  internal class NetstandardAwareAssemblyResolver : DefaultAssemblyResolver
+  {
+    private static readonly System.Reflection.Assembly s_netStandardAssembly;
+    private static readonly string s_name;
+    private static readonly byte[] s_publicKeyToken;
+    private static readonly AssemblyDefinition s_assemblyDefinition;
+
+    private readonly string _modulePath;
+    private readonly Lazy<CompositeCompilationAssemblyResolver> _compositeResolver;
+    private readonly ILogger _logger;
+
+    static NetstandardAwareAssemblyResolver()
     {
-        private static readonly System.Reflection.Assembly s_netStandardAssembly;
-        private static readonly string s_name;
-        private static readonly byte[] s_publicKeyToken;
-        private static readonly AssemblyDefinition s_assemblyDefinition;
+      try
+      {
+        // To be sure to load information of "real" runtime netstandard implementation
+        s_netStandardAssembly = System.Reflection.Assembly.LoadFile(Path.Combine(Path.GetDirectoryName(typeof(object).Assembly.Location), "netstandard.dll"));
+        System.Reflection.AssemblyName name = s_netStandardAssembly.GetName();
+        s_name = name.Name;
+        s_publicKeyToken = name.GetPublicKeyToken();
+        s_assemblyDefinition = AssemblyDefinition.ReadAssembly(s_netStandardAssembly.Location);
+      }
+      catch (FileNotFoundException)
+      {
+        // netstandard not supported
+      }
+    }
 
-        private readonly string _modulePath;
-        private readonly Lazy<CompositeCompilationAssemblyResolver> _compositeResolver;
-        private readonly ILogger _logger;
+    public NetstandardAwareAssemblyResolver(string modulePath, ILogger logger)
+    {
+      _modulePath = modulePath;
+      _logger = logger;
 
-        static NetstandardAwareAssemblyResolver()
-        {
-            try
-            {
-                // To be sure to load information of "real" runtime netstandard implementation
-                s_netStandardAssembly = System.Reflection.Assembly.LoadFile(Path.Combine(Path.GetDirectoryName(typeof(object).Assembly.Location), "netstandard.dll"));
-                System.Reflection.AssemblyName name = s_netStandardAssembly.GetName();
-                s_name = name.Name;
-                s_publicKeyToken = name.GetPublicKeyToken();
-                s_assemblyDefinition = AssemblyDefinition.ReadAssembly(s_netStandardAssembly.Location);
-            }
-            catch (FileNotFoundException)
-            {
-                // netstandard not supported
-            }
-        }
-
-        public NetstandardAwareAssemblyResolver(string modulePath, ILogger logger)
-        {
-            _modulePath = modulePath;
-            _logger = logger;
-
-            // this is lazy because we cannot create NetCoreSharedFrameworkResolver if not on .NET Core runtime,
-            // runtime folders are different
-            _compositeResolver = new Lazy<CompositeCompilationAssemblyResolver>(() => new CompositeCompilationAssemblyResolver(new ICompilationAssemblyResolver[]
-            {
+      // this is lazy because we cannot create NetCoreSharedFrameworkResolver if not on .NET Core runtime,
+      // runtime folders are different
+      _compositeResolver = new Lazy<CompositeCompilationAssemblyResolver>(() => new CompositeCompilationAssemblyResolver(new ICompilationAssemblyResolver[]
+      {
                 new AppBaseCompilationAssemblyResolver(),
                 new PackageCompilationAssemblyResolver(),
                 new NetCoreSharedFrameworkResolver(modulePath, _logger),
                 new ReferenceAssemblyPathResolver(),
-            }), true);
+      }), true);
+    }
+
+    // Check name and public key but not version that could be different
+    private static bool CheckIfSearchingNetstandard(AssemblyNameReference name)
+    {
+      if (s_netStandardAssembly is null)
+      {
+        return false;
+      }
+
+      if (s_name != name.Name)
+      {
+        return false;
+      }
+
+      if (name.PublicKeyToken.Length != s_publicKeyToken.Length)
+      {
+        return false;
+      }
+
+      for (int i = 0; i < name.PublicKeyToken.Length; i++)
+      {
+        if (s_publicKeyToken[i] != name.PublicKeyToken[i])
+        {
+          return false;
+        }
+      }
+
+      return true;
+    }
+
+    public override AssemblyDefinition Resolve(AssemblyNameReference name)
+    {
+      if (CheckIfSearchingNetstandard(name))
+      {
+        return s_assemblyDefinition;
+      }
+      else
+      {
+        try
+        {
+          return base.Resolve(name);
+        }
+        catch (AssemblyResolutionException)
+        {
+          AssemblyDefinition asm = TryWithCustomResolverOnDotNetCore(name);
+
+          if (asm != null)
+          {
+            return asm;
+          }
+
+          throw;
+        }
+      }
+    }
+
+    private static bool IsDotNetCore()
+    {
+      // object for .NET Framework is inside mscorlib.dll
+      return Path.GetFileName(typeof(object).Assembly.Location) == "System.Private.CoreLib.dll";
+    }
+
+    /// <summary>
+    ///
+    /// We try to manually load assembly.
+    /// To work test project needs to use
+    ///
+    /// <PropertyGroup>
+    ///     <PreserveCompilationContext>true</PreserveCompilationContext>
+    /// </PropertyGroup>
+    ///
+    /// Runtime configuration file doc https://github.com/dotnet/cli/blob/master/Documentation/specs/runtime-configuration-file.md
+    ///
+    /// </summary>
+    internal AssemblyDefinition TryWithCustomResolverOnDotNetCore(AssemblyNameReference name)
+    {
+      _logger.LogVerbose($"TryWithCustomResolverOnDotNetCore for {name}");
+
+      if (!IsDotNetCore())
+      {
+        _logger.LogVerbose($"Not a dotnet core app");
+        return null;
+      }
+
+      if (string.IsNullOrEmpty(_modulePath))
+      {
+        throw new AssemblyResolutionException(name);
+      }
+
+      using var contextJsonReader = new DependencyContextJsonReader();
+      var libraries = new Dictionary<string, Lazy<AssemblyDefinition>>();
+
+      foreach (string fileName in Directory.GetFiles(Path.GetDirectoryName(_modulePath), "*.deps.json"))
+      {
+        using FileStream depsFile = File.OpenRead(fileName);
+        _logger.LogVerbose($"Loading {fileName}");
+        DependencyContext dependencyContext = contextJsonReader.Read(depsFile);
+        foreach (CompilationLibrary library in dependencyContext.CompileLibraries)
+        {
+          // we're interested only on nuget package
+          if (library.Type == "project")
+          {
+            continue;
+          }
+
+          try
+          {
+            string path = library.ResolveReferencePaths(_compositeResolver.Value).FirstOrDefault();
+            if (string.IsNullOrEmpty(path))
+            {
+              continue;
+            }
+
+            // We could load more than one deps file, we need to check if lib is already found
+            if (!libraries.ContainsKey(library.Name))
+            {
+              libraries.Add(library.Name, new Lazy<AssemblyDefinition>(() => AssemblyDefinition.ReadAssembly(path, new ReaderParameters() { AssemblyResolver = this })));
+            }
+          }
+          catch (Exception ex)
+          {
+            // if we don't find a lib go on
+            _logger.LogVerbose($"TryWithCustomResolverOnDotNetCore exception: {ex}");
+          }
+        }
+      }
+
+      if (libraries.TryGetValue(name.Name, out Lazy<AssemblyDefinition> asm))
+      {
+        return asm.Value;
+      }
+
+      throw new CecilAssemblyResolutionException($"AssemblyResolutionException for '{name}'. Try to add <PreserveCompilationContext>true</PreserveCompilationContext> to test projects </PropertyGroup> or pass '/p:CopyLocalLockFileAssemblies=true' option to the 'dotnet test' command-line", new AssemblyResolutionException(name));
+    }
+  }
+
+  internal class NetCoreSharedFrameworkResolver : ICompilationAssemblyResolver
+  {
+    private readonly List<string> _aspNetSharedFrameworkDirs = new();
+    private readonly ILogger _logger;
+
+    public NetCoreSharedFrameworkResolver(string modulePath, ILogger logger)
+    {
+      _logger = logger;
+
+      string runtimeConfigFile = Path.Combine(
+          Path.GetDirectoryName(modulePath)!,
+          Path.GetFileNameWithoutExtension(modulePath) + ".runtimeconfig.json");
+      if (!File.Exists(runtimeConfigFile))
+      {
+        return;
+      }
+
+      var reader = new RuntimeConfigurationReader(runtimeConfigFile);
+      IEnumerable<(string Name, string Version)> referencedFrameworks = reader.GetFrameworks();
+      string runtimePath = Path.GetDirectoryName(typeof(object).Assembly.Location);
+      string runtimeRootPath = Path.Combine(runtimePath!, "../..");
+      foreach ((string frameworkName, string frameworkVersion) in referencedFrameworks)
+      {
+        var majorVersion = string.Join(".", frameworkVersion.Split('.').Take(2)) + ".";
+        var directory = new DirectoryInfo(Path.Combine(runtimeRootPath, frameworkName));
+        var latestVersion = directory.GetDirectories().Where(x => x.Name.StartsWith(majorVersion))
+            .Select(x => Convert.ToUInt32(x.Name.Substring(majorVersion.Length))).Max();
+        _aspNetSharedFrameworkDirs.Add(Path.Combine(directory.FullName, majorVersion + latestVersion));
+      }
+
+      _logger.LogVerbose("NetCoreSharedFrameworkResolver search paths:");
+      foreach (string searchPath in _aspNetSharedFrameworkDirs)
+      {
+        _logger.LogVerbose(searchPath);
+      }
+    }
+
+    public bool TryResolveAssemblyPaths(CompilationLibrary library, List<string> assemblies)
+    {
+      string dllName = $"{library.Name}.dll";
+
+      foreach (string sharedFrameworkPath in _aspNetSharedFrameworkDirs)
+      {
+        if (!Directory.Exists(sharedFrameworkPath))
+        {
+          continue;
         }
 
-        // Check name and public key but not version that could be different
-        private static bool CheckIfSearchingNetstandard(AssemblyNameReference name)
+        string[] files = Directory.GetFiles(sharedFrameworkPath);
+        foreach (string file in files)
         {
-            if (s_netStandardAssembly is null)
-            {
-                return false;
-            }
-
-            if (s_name != name.Name)
-            {
-                return false;
-            }
-
-            if (name.PublicKeyToken.Length != s_publicKeyToken.Length)
-            {
-                return false;
-            }
-
-            for (int i = 0; i < name.PublicKeyToken.Length; i++)
-            {
-                if (s_publicKeyToken[i] != name.PublicKeyToken[i])
-                {
-                    return false;
-                }
-            }
-
+          if (Path.GetFileName(file).Equals(dllName, StringComparison.OrdinalIgnoreCase))
+          {
+            _logger.LogVerbose($"'{dllName}' found in '{file}'");
+            assemblies.Add(file);
             return true;
+          }
         }
+      }
 
-        public override AssemblyDefinition Resolve(AssemblyNameReference name)
-        {
-            if (CheckIfSearchingNetstandard(name))
-            {
-                return s_assemblyDefinition;
-            }
-            else
-            {
-                try
-                {
-                    return base.Resolve(name);
-                }
-                catch (AssemblyResolutionException)
-                {
-                    AssemblyDefinition asm = TryWithCustomResolverOnDotNetCore(name);
-
-                    if (asm != null)
-                    {
-                        return asm;
-                    }
-
-                    throw;
-                }
-            }
-        }
-
-        private static bool IsDotNetCore()
-        {
-            // object for .NET Framework is inside mscorlib.dll
-            return Path.GetFileName(typeof(object).Assembly.Location) == "System.Private.CoreLib.dll";
-        }
-
-        /// <summary>
-        ///
-        /// We try to manually load assembly.
-        /// To work test project needs to use
-        ///
-        /// <PropertyGroup>
-        ///     <PreserveCompilationContext>true</PreserveCompilationContext>
-        /// </PropertyGroup>
-        ///
-        /// Runtime configuration file doc https://github.com/dotnet/cli/blob/master/Documentation/specs/runtime-configuration-file.md
-        ///
-        /// </summary>
-        internal AssemblyDefinition TryWithCustomResolverOnDotNetCore(AssemblyNameReference name)
-        {
-            _logger.LogVerbose($"TryWithCustomResolverOnDotNetCore for {name}");
-
-            if (!IsDotNetCore())
-            {
-                _logger.LogVerbose($"Not a dotnet core app");
-                return null;
-            }
-
-            if (string.IsNullOrEmpty(_modulePath))
-            {
-                throw new AssemblyResolutionException(name);
-            }
-
-            using var contextJsonReader = new DependencyContextJsonReader();
-            var libraries = new Dictionary<string, Lazy<AssemblyDefinition>>();
-
-            foreach (string fileName in Directory.GetFiles(Path.GetDirectoryName(_modulePath), "*.deps.json"))
-            {
-                using FileStream depsFile = File.OpenRead(fileName);
-                _logger.LogVerbose($"Loading {fileName}");
-                DependencyContext dependencyContext = contextJsonReader.Read(depsFile);
-                foreach (CompilationLibrary library in dependencyContext.CompileLibraries)
-                {
-                    // we're interested only on nuget package
-                    if (library.Type == "project")
-                    {
-                        continue;
-                    }
-
-                    try
-                    {
-                        string path = library.ResolveReferencePaths(_compositeResolver.Value).FirstOrDefault();
-                        if (string.IsNullOrEmpty(path))
-                        {
-                            continue;
-                        }
-
-                        // We could load more than one deps file, we need to check if lib is already found
-                        if (!libraries.ContainsKey(library.Name))
-                        {
-                            libraries.Add(library.Name, new Lazy<AssemblyDefinition>(() => AssemblyDefinition.ReadAssembly(path, new ReaderParameters() { AssemblyResolver = this })));
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        // if we don't find a lib go on
-                        _logger.LogVerbose($"TryWithCustomResolverOnDotNetCore exception: {ex}");
-                    }
-                }
-            }
-
-            if (libraries.TryGetValue(name.Name, out Lazy<AssemblyDefinition> asm))
-            {
-                return asm.Value;
-            }
-
-            throw new CecilAssemblyResolutionException($"AssemblyResolutionException for '{name}'. Try to add <PreserveCompilationContext>true</PreserveCompilationContext> to test projects </PropertyGroup> or pass '/p:CopyLocalLockFileAssemblies=true' option to the 'dotnet test' command-line", new AssemblyResolutionException(name));
-        }
+      return false;
     }
+  }
 
-    internal class NetCoreSharedFrameworkResolver : ICompilationAssemblyResolver
+  internal class RuntimeConfigurationReader
+  {
+    private readonly string _runtimeConfigFile;
+
+    public RuntimeConfigurationReader(string runtimeConfigFile)
     {
-        private readonly List<string> _aspNetSharedFrameworkDirs = new();
-        private readonly ILogger _logger;
-
-        public NetCoreSharedFrameworkResolver(string modulePath, ILogger logger)
-        {
-            _logger = logger;
-
-            string runtimeConfigFile = Path.Combine(
-                Path.GetDirectoryName(modulePath)!,
-                Path.GetFileNameWithoutExtension(modulePath) + ".runtimeconfig.json");
-            if (!File.Exists(runtimeConfigFile))
-            {
-                return;
-            }
-
-            var reader = new RuntimeConfigurationReader(runtimeConfigFile);
-            IEnumerable<(string Name, string Version)> referencedFrameworks = reader.GetFrameworks();
-            string runtimePath = Path.GetDirectoryName(typeof(object).Assembly.Location);
-            string runtimeRootPath = Path.Combine(runtimePath!, "../..");
-            foreach ((string frameworkName, string frameworkVersion) in referencedFrameworks)
-            {
-                var majorVersion = string.Join(".", frameworkVersion.Split('.').Take(2)) + ".";
-                var directory = new DirectoryInfo(Path.Combine(runtimeRootPath, frameworkName));
-                var latestVersion = directory.GetDirectories().Where(x => x.Name.StartsWith(majorVersion))
-                    .Select(x => Convert.ToUInt32(x.Name.Substring(majorVersion.Length))).Max();
-                _aspNetSharedFrameworkDirs.Add(Path.Combine(directory.FullName, majorVersion + latestVersion));
-            }
-
-            _logger.LogVerbose("NetCoreSharedFrameworkResolver search paths:");
-            foreach (string searchPath in _aspNetSharedFrameworkDirs)
-            {
-                _logger.LogVerbose(searchPath);
-            }
-        }
-
-        public bool TryResolveAssemblyPaths(CompilationLibrary library, List<string> assemblies)
-        {
-            string dllName = $"{library.Name}.dll";
-
-            foreach (string sharedFrameworkPath in _aspNetSharedFrameworkDirs)
-            {
-                if (!Directory.Exists(sharedFrameworkPath))
-                {
-                    continue;
-                }
-
-                string[] files = Directory.GetFiles(sharedFrameworkPath);
-                foreach (string file in files)
-                {
-                    if (Path.GetFileName(file).Equals(dllName, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _logger.LogVerbose($"'{dllName}' found in '{file}'");
-                        assemblies.Add(file);
-                        return true;
-                    }
-                }
-            }
-
-            return false;
-        }
+      _runtimeConfigFile = runtimeConfigFile;
     }
 
-    internal class RuntimeConfigurationReader
+    public IEnumerable<(string Name, string Version)> GetFrameworks()
     {
-        private readonly string _runtimeConfigFile;
+      string jsonString = File.ReadAllText(_runtimeConfigFile);
 
-        public RuntimeConfigurationReader(string runtimeConfigFile)
-        {
-            _runtimeConfigFile = runtimeConfigFile;
-        }
+      var documentOptions = new JsonDocumentOptions
+      {
+        CommentHandling = JsonCommentHandling.Skip
+      };
 
-        public IEnumerable<(string Name, string Version)> GetFrameworks()
-        {
-            JObject configuration =
-                new JsonSerializer().Deserialize<JObject>(
-                    new JsonTextReader(new StringReader(File.ReadAllText(_runtimeConfigFile))));
+      using var configuration = JsonDocument.Parse(jsonString, documentOptions);
 
-            JToken runtimeOptions = configuration["runtimeOptions"];
-            JToken framework = runtimeOptions?["framework"];
-            if (framework != null)
-            {
-                return new[] {(framework["name"].Value<string>(), framework["version"].Value<string>())};
-            }
+      JsonElement rootElement = configuration.RootElement;
 
-            JToken frameworks = runtimeOptions?["frameworks"];
-            if (frameworks != null)
-            {
-                return frameworks.Select(x => (x["name"].Value<string>(), x["version"].Value<string>()));
-            }
+      JsonElement runtimeOptionsElement = rootElement.GetProperty("runtimeOptions");
 
-            throw new InvalidOperationException($"Unable to read runtime configuration from {_runtimeConfigFile}.");
-        }
+      if (runtimeOptionsElement.TryGetProperty("framework", out JsonElement frameworkElement))
+      {
+        return new[] { (frameworkElement.GetProperty("name").GetString(), frameworkElement.GetProperty("version").GetString()) };
+      }
+
+      if (runtimeOptionsElement.TryGetProperty("frameworks", out JsonElement frameworksElement))
+      {
+        return frameworksElement.EnumerateArray().Select(x => (x.GetProperty("name").GetString(), x.GetProperty("version").GetString())).ToList();
+      }
+
+      throw new InvalidOperationException($"Unable to read runtime configuration from {_runtimeConfigFile}.");
     }
+  }
 }

--- a/src/coverlet.core/Reporters/JsonReporter.cs
+++ b/src/coverlet.core/Reporters/JsonReporter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Toni Solarin-Sodara
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using Coverlet.Core.Abstractions;
 
@@ -18,6 +19,8 @@ namespace Coverlet.Core.Reporters
     {
       var options = new JsonSerializerOptions
       {
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        IncludeFields = true,
         WriteIndented = true,
       };
       return JsonSerializer.Serialize(result.Modules, options);

--- a/src/coverlet.core/Reporters/JsonReporter.cs
+++ b/src/coverlet.core/Reporters/JsonReporter.cs
@@ -1,22 +1,26 @@
 ﻿// Copyright (c) Toni Solarin-Sodara
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text.Json;
 using Coverlet.Core.Abstractions;
-using Newtonsoft.Json;
 
 namespace Coverlet.Core.Reporters
 {
-    internal class JsonReporter : IReporter
+  internal class JsonReporter : IReporter
+  {
+    public ReporterOutputType OutputType => ReporterOutputType.File;
+
+    public string Format => "json";
+
+    public string Extension => "json";
+
+    public string Report(CoverageResult result, ISourceRootTranslator _)
     {
-        public ReporterOutputType OutputType => ReporterOutputType.File;
-
-        public string Format => "json";
-
-        public string Extension => "json";
-
-        public string Report(CoverageResult result, ISourceRootTranslator _)
-        {
-            return JsonConvert.SerializeObject(result.Modules, Formatting.Indented);
-        }
+      var options = new JsonSerializerOptions
+      {
+        WriteIndented = true,
+      };
+      return JsonSerializer.Serialize(result.Modules, options);
     }
+  }
 }

--- a/src/coverlet.core/coverlet.core.csproj
+++ b/src/coverlet.core/coverlet.core.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="Mono.Cecil" />
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="System.Reflection.Metadata" />
-    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/coverlet.core/coverlet.core.csproj
+++ b/src/coverlet.core/coverlet.core.csproj
@@ -11,9 +11,9 @@
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Mono.Cecil" />
-    <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="System.Reflection.Metadata" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
 </Project>

--- a/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
+++ b/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
@@ -807,5 +807,31 @@ public class SampleClass
 
       directory.Delete(true);
     }
+    [Fact]
+    public void RuntimeConfigurationReaderSingleFrameworkCheck()
+    {
+      var reader = new RuntimeConfigurationReader(@"TestAssets/single.framework.runtimeconfig.json");
+
+      IEnumerable<(string Name, string Version)> referencedFrameworks = reader.GetFrameworks();
+
+      Assert.Single(referencedFrameworks);
+      Assert.Collection(referencedFrameworks, item => Assert.Equal("Microsoft.NETCore.App", item.Name));
+      Assert.Collection(referencedFrameworks, item => Assert.Equal("6.0.0", item.Version));
+
+    }
+
+    [Fact]
+    public void RuntimeConfigurationReaderMultipleFrameworkCheck()
+    {
+      var reader = new RuntimeConfigurationReader(@"TestAssets/multiple.frameworks.runtimeconfig.json");
+
+      (string Name, string Version)[] referencedFrameworks = reader.GetFrameworks().ToArray();
+
+      Assert.Equal(2, referencedFrameworks.Length);
+      Assert.Equal("Microsoft.NETCore.App", referencedFrameworks[0].Name);
+      Assert.Equal("6.0.0", referencedFrameworks[0].Version);
+      Assert.Equal("Microsoft.AspNetCore.App", referencedFrameworks[1].Name);
+      Assert.Equal("6.0.0", referencedFrameworks[1].Version);
+    }
   }
 }

--- a/test/coverlet.core.tests/Reporters/JsonReporterTests.cs
+++ b/test/coverlet.core.tests/Reporters/JsonReporterTests.cs
@@ -1,13 +1,14 @@
 ﻿// Copyright (c) Toni Solarin-Sodara
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using Coverlet.Core.Abstractions;
 using Moq;
+using System;
 using Xunit;
 
 namespace Coverlet.Core.Reporters.Tests
 {
+
   public class JsonReporterTests
   {
     private static readonly string s_resultModule = @"{
@@ -29,8 +30,10 @@ namespace Coverlet.Core.Reporters.Tests
     [Fact]
     public void TestReport()
     {
-      var result = new CoverageResult();
-      result.Identifier = Guid.NewGuid().ToString();
+      var result = new CoverageResult
+      {
+        Identifier = Guid.NewGuid().ToString()
+      };
 
       var lines = new Lines();
       lines.Add(1, 1);

--- a/test/coverlet.core.tests/TestAssets/multiple.frameworks.runtimeconfig.json
+++ b/test/coverlet.core.tests/TestAssets/multiple.frameworks.runtimeconfig.json
@@ -1,0 +1,19 @@
+﻿{
+    "runtimeOptions": {
+        "tfm": "net6.0",
+        "frameworks": [
+            {
+                "name": "Microsoft.NETCore.App",
+                "version": "6.0.0"
+            },
+            {
+                "name": "Microsoft.AspNetCore.App",
+                "version": "6.0.0"
+            }
+        ],
+        "configProperties": {
+            "System.GC.Server": true,
+            "System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization": false
+        }
+    }
+}

--- a/test/coverlet.core.tests/TestAssets/single.framework.runtimeconfig.json
+++ b/test/coverlet.core.tests/TestAssets/single.framework.runtimeconfig.json
@@ -1,0 +1,9 @@
+{
+    "runtimeOptions": {
+        "tfm": "net6.0",
+        "framework": {
+            "name": "Microsoft.NETCore.App",
+            "version": "6.0.0"
+        }
+    }
+}

--- a/test/coverlet.core.tests/coverlet.core.tests.csproj
+++ b/test/coverlet.core.tests/coverlet.core.tests.csproj
@@ -45,6 +45,12 @@
     <None Update="TestAssets\CoverletSourceRootsMappingTest">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="TestAssets\multiple.frameworks.runtimeconfig.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="TestAssets\single.framework.runtimeconfig.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="TestAssets\System.Private.CoreLib.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/test/coverlet.integration.tests/DeterministicBuild.cs
+++ b/test/coverlet.integration.tests/DeterministicBuild.cs
@@ -78,15 +78,22 @@ namespace Coverlet.Integration.Tests
         public void Msbuild()
         {
             CreateDeterministicTestPropsFile();
-            DotnetCli($"build -c {_buildConfiguration} /p:DeterministicSourcePaths=true", out string standardOutput, out string _, _testProjectPath);
+            DotnetCli($"build -c {_buildConfiguration} /p:DeterministicSourcePaths=true", out string standardOutput, out string standardError, _testProjectPath);
             Assert.Contains("Build succeeded.", standardOutput);
             string sourceRootMappingFilePath = Path.Combine(_testProjectPath, "bin", _buildConfiguration, _testProjectTfm!, "CoverletSourceRootsMapping_coverletsample.integration.determisticbuild");
             Assert.True(File.Exists(sourceRootMappingFilePath), sourceRootMappingFilePath);
             Assert.True(!string.IsNullOrEmpty(File.ReadAllText(sourceRootMappingFilePath)), "Empty CoverletSourceRootsMapping file");
             Assert.Contains("=/_/", File.ReadAllText(sourceRootMappingFilePath));
 
-            DotnetCli($"test -c {_buildConfiguration} --no-build /p:CollectCoverage=true /p:DeterministicReport=true /p:CoverletOutputFormat=\"cobertura%2cjson\" /p:Include=\"[coverletsample.integration.determisticbuild]*DeepThought\" /p:IncludeTestAssembly=true", out standardOutput, out _, _testProjectPath);
-            _output.WriteLine(standardOutput);
+            DotnetCli($"test -c {_buildConfiguration} --no-build /p:CollectCoverage=true /p:DeterministicReport=true /p:CoverletOutputFormat=\"cobertura%2cjson\" /p:Include=\"[coverletsample.integration.determisticbuild]*DeepThought\" /p:IncludeTestAssembly=true", out standardOutput, out standardError, _testProjectPath);
+            if (!string.IsNullOrEmpty(standardError))
+            {
+              _output.WriteLine(standardError);
+            }
+            else
+            {
+              _output.WriteLine(standardOutput);
+            }
             Assert.Contains("Passed!", standardOutput);
             Assert.Contains("| coverletsample.integration.determisticbuild | 100% | 100%   | 100%   |", standardOutput);
             Assert.True(File.Exists(Path.Combine(_testProjectPath, "coverage.json")));
@@ -102,14 +109,22 @@ namespace Coverlet.Integration.Tests
         public void Msbuild_SourceLink()
         {
             CreateDeterministicTestPropsFile();
-            DotnetCli($"build -c {_buildConfiguration} /p:DeterministicSourcePaths=true", out string standardOutput, out string _, _testProjectPath);
+            DotnetCli($"build -c {_buildConfiguration} /p:DeterministicSourcePaths=true", out string standardOutput, out string standardError, _testProjectPath);
             Assert.Contains("Build succeeded.", standardOutput);
             string sourceRootMappingFilePath = Path.Combine(_testProjectPath, "bin", _buildConfiguration, _testProjectTfm!, "CoverletSourceRootsMapping_coverletsample.integration.determisticbuild");
             Assert.True(File.Exists(sourceRootMappingFilePath), sourceRootMappingFilePath);
             Assert.True(!string.IsNullOrEmpty(File.ReadAllText(sourceRootMappingFilePath)), "Empty CoverletSourceRootsMapping file");
             Assert.Contains("=/_/", File.ReadAllText(sourceRootMappingFilePath));
 
-            DotnetCli($"test -c {_buildConfiguration} --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=\"cobertura%2cjson\" /p:UseSourceLink=true /p:Include=\"[coverletsample.integration.determisticbuild]*DeepThought\" /p:IncludeTestAssembly=true", out standardOutput, out _, _testProjectPath);
+            DotnetCli($"test -c {_buildConfiguration} --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=\"cobertura%2cjson\" /p:UseSourceLink=true /p:Include=\"[coverletsample.integration.determisticbuild]*DeepThought\" /p:IncludeTestAssembly=true", out standardOutput, out standardError, _testProjectPath);
+            if (!string.IsNullOrEmpty(standardError))
+            {
+              _output.WriteLine(standardError);
+            }
+            else
+            {
+              _output.WriteLine(standardOutput);
+            }
             Assert.Contains("Passed!", standardOutput);
             Assert.Contains("| coverletsample.integration.determisticbuild | 100% | 100%   | 100%   |", standardOutput);
             Assert.True(File.Exists(Path.Combine(_testProjectPath, "coverage.json")));
@@ -126,7 +141,7 @@ namespace Coverlet.Integration.Tests
         public void Collectors()
         {
             CreateDeterministicTestPropsFile();
-            DotnetCli($"build -c {_buildConfiguration} /p:DeterministicSourcePaths=true", out string standardOutput, out string _, _testProjectPath);
+            DotnetCli($"build -c {_buildConfiguration} /p:DeterministicSourcePaths=true", out string standardOutput, out string standardError, _testProjectPath);
             Assert.Contains("Build succeeded.", standardOutput);
             string sourceRootMappingFilePath = Path.Combine(_testProjectPath, "bin", GetAssemblyBuildConfiguration().ToString(), _testProjectTfm!, "CoverletSourceRootsMapping_coverletsample.integration.determisticbuild");
             Assert.True(File.Exists(sourceRootMappingFilePath), sourceRootMappingFilePath);
@@ -134,7 +149,15 @@ namespace Coverlet.Integration.Tests
             Assert.Contains("=/_/", File.ReadAllText(sourceRootMappingFilePath));
 
             string runSettingsPath = AddCollectorRunsettingsFile(_testProjectPath, "[coverletsample.integration.determisticbuild]*DeepThought", deterministicReport: true);
-            Assert.True(DotnetCli($"test -c {_buildConfiguration} --no-build \"{_testProjectPath}\" --collect:\"XPlat Code Coverage\" --settings \"{runSettingsPath}\" --diag:{Path.Combine(_testProjectPath, "log.txt")}", out standardOutput, out _), standardOutput);
+            Assert.True(DotnetCli($"test -c {_buildConfiguration} --no-build \"{_testProjectPath}\" --collect:\"XPlat Code Coverage\" --settings \"{runSettingsPath}\" --diag:{Path.Combine(_testProjectPath, "log.txt")}", out standardOutput, out standardError), standardOutput);
+            if (!string.IsNullOrEmpty(standardError))
+            {
+              _output.WriteLine(standardError);
+            }
+            else
+            {
+              _output.WriteLine(standardOutput);
+            }
             Assert.Contains("Passed!", standardOutput);
             AssertCoverage(standardOutput);
 
@@ -154,7 +177,7 @@ namespace Coverlet.Integration.Tests
         public void Collectors_SourceLink()
         {
             CreateDeterministicTestPropsFile();
-            DotnetCli($"build -c {_buildConfiguration} /p:DeterministicSourcePaths=true", out string standardOutput, out string _, _testProjectPath);
+            DotnetCli($"build -c {_buildConfiguration} /p:DeterministicSourcePaths=true", out string standardOutput, out string standardError, _testProjectPath);
             Assert.Contains("Build succeeded.", standardOutput);
             string sourceRootMappingFilePath = Path.Combine(_testProjectPath, "bin", GetAssemblyBuildConfiguration().ToString(), _testProjectTfm!, "CoverletSourceRootsMapping_coverletsample.integration.determisticbuild");
             Assert.True(File.Exists(sourceRootMappingFilePath), sourceRootMappingFilePath);
@@ -162,7 +185,15 @@ namespace Coverlet.Integration.Tests
             Assert.Contains("=/_/", File.ReadAllText(sourceRootMappingFilePath));
 
             string runSettingsPath = AddCollectorRunsettingsFile(_testProjectPath, "[coverletsample.integration.determisticbuild]*DeepThought", sourceLink: true);
-            Assert.True(DotnetCli($"test -c {_buildConfiguration} --no-build \"{_testProjectPath}\" --collect:\"XPlat Code Coverage\" --settings \"{runSettingsPath}\" --diag:{Path.Combine(_testProjectPath, "log.txt")}", out standardOutput, out _), standardOutput);
+            Assert.True(DotnetCli($"test -c {_buildConfiguration} --no-build \"{_testProjectPath}\" --collect:\"XPlat Code Coverage\" --settings \"{runSettingsPath}\" --diag:{Path.Combine(_testProjectPath, "log.txt")}", out standardOutput, out standardError), standardOutput);
+            if (!string.IsNullOrEmpty(standardError))
+            {
+              _output.WriteLine(standardError);
+            }
+            else
+            {
+              _output.WriteLine(standardOutput);
+            }
             Assert.Contains("Passed!", standardOutput);
             AssertCoverage(standardOutput, checkDeterministicReport: false);
             Assert.Contains("raw.githubusercontent.com", File.ReadAllText(Directory.GetFiles(_testProjectPath, "coverage.cobertura.xml", SearchOption.AllDirectories).Single()));

--- a/test/coverlet.integration.tests/DeterministicBuild.cs
+++ b/test/coverlet.integration.tests/DeterministicBuild.cs
@@ -8,6 +8,7 @@ using System.Xml.Linq;
 using Coverlet.Core;
 using Newtonsoft.Json;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Coverlet.Integration.Tests
 {
@@ -17,10 +18,12 @@ namespace Coverlet.Integration.Tests
         private string? _testProjectTfm;
         private const string PropsFileName = "DeterministicTest.props";
         private readonly string _buildConfiguration;
+        private readonly ITestOutputHelper _output;
 
-        public DeterministicBuild()
+    public DeterministicBuild(ITestOutputHelper output)
         {
             _buildConfiguration = GetAssemblyBuildConfiguration().ToString();
+            _output = output;
         }
 
         private void CreateDeterministicTestPropsFile()
@@ -83,6 +86,7 @@ namespace Coverlet.Integration.Tests
             Assert.Contains("=/_/", File.ReadAllText(sourceRootMappingFilePath));
 
             DotnetCli($"test -c {_buildConfiguration} --no-build /p:CollectCoverage=true /p:DeterministicReport=true /p:CoverletOutputFormat=\"cobertura%2cjson\" /p:Include=\"[coverletsample.integration.determisticbuild]*DeepThought\" /p:IncludeTestAssembly=true", out standardOutput, out _, _testProjectPath);
+            _output.WriteLine(standardOutput);
             Assert.Contains("Passed!", standardOutput);
             Assert.Contains("| coverletsample.integration.determisticbuild | 100% | 100%   | 100%   |", standardOutput);
             Assert.True(File.Exists(Path.Combine(_testProjectPath, "coverage.json")));

--- a/test/coverlet.integration.tests/DotnetTool.cs
+++ b/test/coverlet.integration.tests/DotnetTool.cs
@@ -5,11 +5,18 @@ using System.IO;
 using System.Linq;
 using Coverlet.Tests.Xunit.Extensions;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Coverlet.Integration.Tests
 {
   public class DotnetGlobalTools : BaseTest
   {
+    private readonly ITestOutputHelper _output;
+
+    public DotnetGlobalTools(ITestOutputHelper output)
+    {
+      _output = output;
+    }
     private string InstallTool(string projectPath)
     {
       _ = DotnetCli($"tool install coverlet.console --version {GetPackageVersion("*console*.nupkg")} --tool-path \"{Path.Combine(projectPath, "coverletTool")}\"", out string standardOutput, out _, projectPath);
@@ -26,6 +33,10 @@ namespace Coverlet.Integration.Tests
       DotnetCli($"build {clonedTemplateProject.ProjectRootPath}", out string standardOutput, out string standardError);
       string publishedTestFile = clonedTemplateProject.GetFiles("*" + ClonedTemplateProject.AssemblyName + ".dll").Single(f => !f.Contains("obj") && !f.Contains("ref"));
       RunCommand(coverletToolCommandPath, $"\"{publishedTestFile}\" --target \"dotnet\" --targetargs \"test {Path.Combine(clonedTemplateProject.ProjectRootPath, ClonedTemplateProject.ProjectFileName)} --no-build\"  --include-test-assembly --output \"{clonedTemplateProject.ProjectRootPath}\"{Path.DirectorySeparatorChar}", out standardOutput, out standardError);
+      if (!string.IsNullOrEmpty(standardError))
+      {
+        _output.WriteLine(standardError);
+      }
       Assert.Contains("Passed!", standardOutput);
       AssertCoverage(clonedTemplateProject, standardOutput: standardOutput);
     }
@@ -39,6 +50,10 @@ namespace Coverlet.Integration.Tests
       DotnetCli($"build {clonedTemplateProject.ProjectRootPath}", out string standardOutput, out string standardError);
       string publishedTestFile = clonedTemplateProject.GetFiles("*" + ClonedTemplateProject.AssemblyName + ".dll").Single(f => !f.Contains("obj") && !f.Contains("ref"));
       RunCommand(coverletToolCommandPath, $"\"{Path.GetDirectoryName(publishedTestFile)}\" --target \"dotnet\" --targetargs \"{publishedTestFile}\"  --output \"{clonedTemplateProject.ProjectRootPath}\"{Path.DirectorySeparatorChar}", out standardOutput, out standardError);
+      if (!string.IsNullOrEmpty(standardError))
+      {
+        _output.WriteLine(standardError);
+      }
       Assert.Contains("Hello World!", standardOutput);
       AssertCoverage(clonedTemplateProject, standardOutput: standardOutput);
     }
@@ -54,6 +69,10 @@ namespace Coverlet.Integration.Tests
       DotnetCli($"build {clonedTemplateProject.ProjectRootPath}", out string standardOutput, out string standardError);
       string publishedTestFile = clonedTemplateProject.GetFiles("*" + ClonedTemplateProject.AssemblyName + ".dll").Single(f => !f.Contains("obj") && !f.Contains("ref"));
       Assert.False(RunCommand(coverletToolCommandPath, $"\"{Path.GetDirectoryName(publishedTestFile)}\" --target \"dotnet\" --targetargs \"{publishedTestFile}\"  --threshold 80 --output \"{clonedTemplateProject.ProjectRootPath}\"\\", out standardOutput, out standardError));
+      if (!string.IsNullOrEmpty(standardError))
+      {
+        _output.WriteLine(standardError);
+      }
       Assert.Contains("Hello World!", standardOutput);
       AssertCoverage(clonedTemplateProject, standardOutput: standardOutput);
       Assert.Contains("The minimum line coverage is below the specified 80", standardOutput);
@@ -71,6 +90,10 @@ namespace Coverlet.Integration.Tests
       DotnetCli($"build {clonedTemplateProject.ProjectRootPath}", out string standardOutput, out string standardError);
       string publishedTestFile = clonedTemplateProject.GetFiles("*" + ClonedTemplateProject.AssemblyName + ".dll").Single(f => !f.Contains("obj") && !f.Contains("ref"));
       Assert.False(RunCommand(coverletToolCommandPath, $"\"{Path.GetDirectoryName(publishedTestFile)}\" --target \"dotnet\" --targetargs \"{publishedTestFile}\"  --threshold 80 --threshold-type line --output \"{clonedTemplateProject.ProjectRootPath}\"\\", out standardOutput, out standardError));
+      if (!string.IsNullOrEmpty(standardError))
+      {
+        _output.WriteLine(standardError);
+      }
       Assert.Contains("Hello World!", standardOutput);
       AssertCoverage(clonedTemplateProject, standardOutput: standardOutput);
       Assert.Contains("The minimum line coverage is below the specified 80", standardOutput);
@@ -88,6 +111,10 @@ namespace Coverlet.Integration.Tests
       DotnetCli($"build {clonedTemplateProject.ProjectRootPath}", out string standardOutput, out string standardError);
       string publishedTestFile = clonedTemplateProject.GetFiles("*" + ClonedTemplateProject.AssemblyName + ".dll").Single(f => !f.Contains("obj") && !f.Contains("ref"));
       Assert.False(RunCommand(coverletToolCommandPath, $"\"{Path.GetDirectoryName(publishedTestFile)}\" --target \"dotnet\" --targetargs \"{publishedTestFile}\"  --threshold 80 --threshold-type line --threshold-type method --output \"{clonedTemplateProject.ProjectRootPath}\"\\", out standardOutput, out standardError));
+      if (!string.IsNullOrEmpty(standardError))
+      {
+        _output.WriteLine(standardError);
+      }
       Assert.Contains("Hello World!", standardOutput);
       AssertCoverage(clonedTemplateProject, standardOutput: standardOutput);
       Assert.Contains("The minimum line coverage is below the specified 80", standardOutput);

--- a/test/coverlet.integration.tests/Msbuild.cs
+++ b/test/coverlet.integration.tests/Msbuild.cs
@@ -4,212 +4,220 @@
 using System.IO;
 using System.Linq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Coverlet.Integration.Tests
 {
-    public class Msbuild : BaseTest
+  public class Msbuild : BaseTest
+  {
+    private readonly string _buildConfiguration;
+    private readonly ITestOutputHelper _output;
+
+    public Msbuild(ITestOutputHelper output)
     {
-        private readonly string _buildConfiguration;
-
-        public Msbuild()
-        {
-            _buildConfiguration = GetAssemblyBuildConfiguration().ToString();
-        }
-
-        private ClonedTemplateProject PrepareTemplateProject()
-        {
-            ClonedTemplateProject clonedTemplateProject = CloneTemplateProject();
-            UpdateNugeConfigtWithLocalPackageFolder(clonedTemplateProject.ProjectRootPath!);
-            AddCoverletMsbuildRef(clonedTemplateProject.ProjectRootPath!);
-            return clonedTemplateProject;
-        }
-
-        [Fact]
-        public void TestMsbuild()
-        {
-            using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
-            Assert.True(DotnetCli($"test -c {_buildConfiguration} \"{clonedTemplateProject.ProjectRootPath}\" /p:CollectCoverage=true /p:Include=\"[{ClonedTemplateProject.AssemblyName}]*DeepThought\" /p:IncludeTestAssembly=true /p:CoverletOutput=\"{clonedTemplateProject.ProjectRootPath}\"\\", out string standardOutput, out string standardError), standardOutput);
-            Assert.Contains("Passed!", standardOutput);
-            Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput);
-            Assert.True(File.Exists(Path.Combine(clonedTemplateProject.ProjectRootPath, "coverage.json")));
-            AssertCoverage(clonedTemplateProject);
-        }
-
-        [Fact]
-        public void TestMsbuild_NoCoverletOutput()
-        {
-            using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
-            Assert.True(DotnetCli($"test -c {_buildConfiguration} \"{clonedTemplateProject.ProjectRootPath}\" /p:CollectCoverage=true /p:Include=\"[{ClonedTemplateProject.AssemblyName}]*DeepThought\" /p:IncludeTestAssembly=true", out string standardOutput, out string standardError), standardOutput);
-            Assert.Contains("Passed!", standardOutput);
-            Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput);
-            Assert.True(File.Exists(Path.Combine(clonedTemplateProject.ProjectRootPath, "coverage.json")));
-            AssertCoverage(clonedTemplateProject);
-        }
-
-        [Fact]
-        public void TestMsbuild_CoverletOutput_Folder_FileNameWithoutExtension()
-        {
-            using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
-            Assert.True(DotnetCli($"test -c {_buildConfiguration} \"{clonedTemplateProject.ProjectRootPath}\" /p:CollectCoverage=true /p:Include=\"[{ClonedTemplateProject.AssemblyName}]*DeepThought\" /p:IncludeTestAssembly=true /p:CoverletOutput=\"{clonedTemplateProject.ProjectRootPath}\"\\file", out string standardOutput, out string standardError), standardOutput);
-            Assert.Contains("Passed!", standardOutput);
-            Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput);
-            Assert.True(File.Exists(Path.Combine(clonedTemplateProject.ProjectRootPath, "file.json")));
-            AssertCoverage(clonedTemplateProject, "file.json");
-        }
-
-        [Fact]
-        public void TestMsbuild_CoverletOutput_Folder_FileNameExtension()
-        {
-            using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
-            Assert.True(DotnetCli($"test -c {_buildConfiguration} \"{clonedTemplateProject.ProjectRootPath}\" /p:CollectCoverage=true /p:Include=\"[{ClonedTemplateProject.AssemblyName}]*DeepThought\" /p:IncludeTestAssembly=true /p:CoverletOutput=\"{clonedTemplateProject.ProjectRootPath}\"\\file.ext", out string standardOutput, out string standardError), standardOutput);
-            Assert.Contains("Passed!", standardOutput);
-            Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput);
-            Assert.True(File.Exists(Path.Combine(clonedTemplateProject.ProjectRootPath, "file.ext")));
-            AssertCoverage(clonedTemplateProject, "file.ext");
-        }
-
-        [Fact]
-        public void TestMsbuild_CoverletOutput_Folder_FileNameExtension_SpecifyFramework()
-        {
-            using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
-            Assert.False(clonedTemplateProject.IsMultipleTargetFramework());
-            string framework = clonedTemplateProject.GetTargetFrameworks().Single();
-            Assert.True(DotnetCli($"test -c {_buildConfiguration} -f {framework} \"{clonedTemplateProject.ProjectRootPath}\" /p:CollectCoverage=true /p:Include=\"[{ClonedTemplateProject.AssemblyName}]*DeepThought\" /p:IncludeTestAssembly=true /p:CoverletOutput=\"{clonedTemplateProject.ProjectRootPath}\"\\file.ext", out string standardOutput, out string standardError), standardOutput);
-            Assert.Contains("Passed!", standardOutput);
-            Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput);
-            Assert.True(File.Exists(Path.Combine(clonedTemplateProject.ProjectRootPath, "file.ext")));
-            AssertCoverage(clonedTemplateProject, "file.ext");
-        }
-
-        [Fact]
-        public void TestMsbuild_CoverletOutput_Folder_FileNameWithDoubleExtension()
-        {
-            using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
-            Assert.True(DotnetCli($"test -c {_buildConfiguration} \"{clonedTemplateProject.ProjectRootPath}\" /p:CollectCoverage=true /p:Include=\"[{ClonedTemplateProject.AssemblyName}]*DeepThought\" /p:IncludeTestAssembly=true /p:CoverletOutput=\"{clonedTemplateProject.ProjectRootPath}\"\\file.ext1.ext2", out string standardOutput, out string standardError), standardOutput);
-            Assert.Contains("Passed!", standardOutput);
-            Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput);
-            Assert.True(File.Exists(Path.Combine(clonedTemplateProject.ProjectRootPath, "file.ext1.ext2")));
-            AssertCoverage(clonedTemplateProject, "file.ext1.ext2");
-        }
-
-        [Fact]
-        public void Test_MultipleTargetFrameworkReport_NoCoverletOutput()
-        {
-            using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
-            string[] targetFrameworks = new string[] { "net6.0", "net7.0" };
-            UpdateProjectTargetFramework(clonedTemplateProject, targetFrameworks);
-            Assert.True(DotnetCli($"test -c {_buildConfiguration} \"{clonedTemplateProject.ProjectRootPath}\" /p:CollectCoverage=true /p:Include=\"[{ClonedTemplateProject.AssemblyName}]*DeepThought\" /p:IncludeTestAssembly=true", out string standardOutput, out string standardError, clonedTemplateProject.ProjectRootPath!), standardOutput);
-            Assert.Contains("Passed!", standardOutput);
-            Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput);
-
-            foreach (string targetFramework in targetFrameworks)
-            {
-                Assert.True(File.Exists(Path.Combine(clonedTemplateProject.ProjectRootPath, $"coverage.{targetFramework}.json")));
-            }
-
-            AssertCoverage(clonedTemplateProject, "coverage.*.json");
-        }
-
-        [Fact]
-        public void Test_MultipleTargetFrameworkReport_CoverletOutput_Folder()
-        {
-            using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
-            string[] targetFrameworks = new string[] { "net6.0", "net7.0" };
-            UpdateProjectTargetFramework(clonedTemplateProject, targetFrameworks);
-            Assert.True(DotnetCli($"test -c {_buildConfiguration} \"{clonedTemplateProject.ProjectRootPath}\" /p:CollectCoverage=true /p:Include=\"[{ClonedTemplateProject.AssemblyName}]*DeepThought\" /p:IncludeTestAssembly=true /p:CoverletOutput=\"{clonedTemplateProject.ProjectRootPath}\"\\", out string standardOutput, out string standardError, clonedTemplateProject.ProjectRootPath!), standardOutput);
-            Assert.Contains("Passed!", standardOutput);
-            Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput);
-
-            foreach (string targetFramework in targetFrameworks)
-            {
-                string fileToCheck = Path.Combine(clonedTemplateProject.ProjectRootPath, $"coverage.{targetFramework}.json");
-                Assert.True(File.Exists(fileToCheck), $"Expected file '{fileToCheck}'\nOutput:\n{standardOutput}");
-            }
-
-            AssertCoverage(clonedTemplateProject, "coverage.*.json");
-        }
-
-        [Fact]
-        public void Test_MultipleTargetFrameworkReport_CoverletOutput_Folder_FileNameWithoutExtension()
-        {
-            using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
-            string[] targetFrameworks = new string[] {"net6.0", "net7.0" };
-            UpdateProjectTargetFramework(clonedTemplateProject, targetFrameworks);
-            Assert.True(DotnetCli($"test -c {_buildConfiguration} \"{clonedTemplateProject.ProjectRootPath}\" /p:CollectCoverage=true /p:Include=\"[{ClonedTemplateProject.AssemblyName}]*DeepThought\" /p:IncludeTestAssembly=true /p:CoverletOutput=\"{clonedTemplateProject.ProjectRootPath}\"\\file", out string standardOutput, out string standardError, clonedTemplateProject.ProjectRootPath!), standardOutput);
-            Assert.Contains("Passed!", standardOutput);
-            Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput);
-
-            foreach (string targetFramework in targetFrameworks)
-            {
-                Assert.True(File.Exists(Path.Combine(clonedTemplateProject.ProjectRootPath, $"file.{targetFramework}.json")));
-            }
-
-            AssertCoverage(clonedTemplateProject, "file.*.json");
-        }
-
-        [Fact]
-        public void Test_MultipleTargetFrameworkReport_CoverletOutput_Folder_FileNameWithExtension_SpecifyFramework()
-        {
-            using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
-            string[] targetFrameworks = new string[] {"net6.0", "net7.0" };
-            UpdateProjectTargetFramework(clonedTemplateProject, targetFrameworks);
-            Assert.True(clonedTemplateProject.IsMultipleTargetFramework());
-            string[] frameworks = clonedTemplateProject.GetTargetFrameworks();
-            Assert.Equal(2, frameworks.Length);
-            string framework = frameworks.FirstOrDefault()!;
-            Assert.True(DotnetCli($"test -c {_buildConfiguration} -f {framework} \"{clonedTemplateProject.ProjectRootPath}\" /p:CollectCoverage=true /p:Include=\"[{ClonedTemplateProject.AssemblyName}]*DeepThought\" /p:IncludeTestAssembly=true /p:CoverletOutput=\"{clonedTemplateProject.ProjectRootPath}\"\\file.ext", out string standardOutput, out string standardError, clonedTemplateProject.ProjectRootPath!), standardOutput);
-            Assert.Contains("Passed!", standardOutput);
-            Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput);
-
-            foreach (string targetFramework in targetFrameworks)
-            {
-                if (framework == targetFramework)
-                {
-                    Assert.True(File.Exists(Path.Combine(clonedTemplateProject.ProjectRootPath, $"file.{targetFramework}.ext")));
-                }
-                else
-                {
-                    Assert.False(File.Exists(Path.Combine(clonedTemplateProject.ProjectRootPath, $"file.{targetFramework}.ext")));
-                }
-            }
-
-            AssertCoverage(clonedTemplateProject, "file.*.ext");
-        }
-
-        [Fact]
-        public void Test_MultipleTargetFrameworkReport_CoverletOutput_Folder_FileNameWithExtension()
-        {
-            using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
-            string[] targetFrameworks = new string[] {"net6.0", "net7.0" };
-            UpdateProjectTargetFramework(clonedTemplateProject, targetFrameworks);
-            Assert.True(DotnetCli($"test -c {_buildConfiguration} \"{clonedTemplateProject.ProjectRootPath}\" /p:CollectCoverage=true /p:Include=\"[{ClonedTemplateProject.AssemblyName}]*DeepThought\" /p:IncludeTestAssembly=true /p:CoverletOutput=\"{clonedTemplateProject.ProjectRootPath}\"\\file.ext", out string standardOutput, out string standardError, clonedTemplateProject.ProjectRootPath!), standardOutput);
-            Assert.Contains("Passed!", standardOutput);
-            Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput);
-
-            foreach (string targetFramework in targetFrameworks)
-            {
-                Assert.True(File.Exists(Path.Combine(clonedTemplateProject.ProjectRootPath, $"file.{targetFramework}.ext")));
-            }
-
-            AssertCoverage(clonedTemplateProject, "file.*.ext");
-        }
-
-        [Fact]
-        public void Test_MultipleTargetFrameworkReport_CoverletOutput_Folder_FileNameWithDoubleExtension()
-        {
-            using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
-            string[] targetFrameworks = new string[] {"net6.0", "net7.0" };
-            UpdateProjectTargetFramework(clonedTemplateProject, targetFrameworks);
-            Assert.True(DotnetCli($"test -c {_buildConfiguration} \"{clonedTemplateProject.ProjectRootPath}\" /p:CollectCoverage=true /p:Include=\"[{ClonedTemplateProject.AssemblyName}]*DeepThought\" /p:IncludeTestAssembly=true /p:CoverletOutput=\"{clonedTemplateProject.ProjectRootPath}\"\\file.ext1.ext2", out string standardOutput, out string standardError, clonedTemplateProject.ProjectRootPath!), standardOutput);
-            Assert.Contains("Passed!", standardOutput);
-            Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput);
-
-            foreach (string targetFramework in targetFrameworks)
-            {
-                Assert.True(File.Exists(Path.Combine(clonedTemplateProject.ProjectRootPath, $"file.ext1.{targetFramework}.ext2")));
-            }
-
-            AssertCoverage(clonedTemplateProject, "file.ext1.*.ext2");
-        }
+      _buildConfiguration = GetAssemblyBuildConfiguration().ToString();
+      _output = output;
     }
+
+    private ClonedTemplateProject PrepareTemplateProject()
+    {
+      ClonedTemplateProject clonedTemplateProject = CloneTemplateProject();
+      UpdateNugeConfigtWithLocalPackageFolder(clonedTemplateProject.ProjectRootPath!);
+      AddCoverletMsbuildRef(clonedTemplateProject.ProjectRootPath!);
+      return clonedTemplateProject;
+    }
+
+    [Fact]
+    public void TestMsbuild()
+    {
+      using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
+      Assert.True(DotnetCli($"test -c {_buildConfiguration} \"{clonedTemplateProject.ProjectRootPath}\" /p:CollectCoverage=true /p:Include=\"[{ClonedTemplateProject.AssemblyName}]*DeepThought\" /p:IncludeTestAssembly=true /p:CoverletOutput=\"{clonedTemplateProject.ProjectRootPath}\"\\", out string standardOutput, out string standardError), standardOutput);
+      Assert.Contains("Passed!", standardOutput);
+      Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput);
+      Assert.True(File.Exists(Path.Combine(clonedTemplateProject.ProjectRootPath, "coverage.json")));
+      AssertCoverage(clonedTemplateProject);
+    }
+
+    [Fact]
+    public void TestMsbuild_NoCoverletOutput()
+    {
+      using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
+      Assert.True(DotnetCli($"test -c {_buildConfiguration} \"{clonedTemplateProject.ProjectRootPath}\" /p:CollectCoverage=true /p:Include=\"[{ClonedTemplateProject.AssemblyName}]*DeepThought\" /p:IncludeTestAssembly=true", out string standardOutput, out string standardError), standardOutput);
+      Assert.Contains("Passed!", standardOutput);
+      Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput);
+      Assert.True(File.Exists(Path.Combine(clonedTemplateProject.ProjectRootPath, "coverage.json")));
+      AssertCoverage(clonedTemplateProject);
+    }
+
+    [Fact]
+    public void TestMsbuild_CoverletOutput_Folder_FileNameWithoutExtension()
+    {
+      using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
+      Assert.True(DotnetCli($"test -c {_buildConfiguration} \"{clonedTemplateProject.ProjectRootPath}\" /p:CollectCoverage=true /p:Include=\"[{ClonedTemplateProject.AssemblyName}]*DeepThought\" /p:IncludeTestAssembly=true /p:CoverletOutput=\"{clonedTemplateProject.ProjectRootPath}\"\\file", out string standardOutput, out string standardError), standardOutput);
+      Assert.Contains("Passed!", standardOutput);
+      Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput);
+      Assert.True(File.Exists(Path.Combine(clonedTemplateProject.ProjectRootPath, "file.json")));
+      AssertCoverage(clonedTemplateProject, "file.json");
+    }
+
+    [Fact]
+    public void TestMsbuild_CoverletOutput_Folder_FileNameExtension()
+    {
+      using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
+      Assert.True(DotnetCli($"test -c {_buildConfiguration} \"{clonedTemplateProject.ProjectRootPath}\" /p:CollectCoverage=true /p:Include=\"[{ClonedTemplateProject.AssemblyName}]*DeepThought\" /p:IncludeTestAssembly=true /p:CoverletOutput=\"{clonedTemplateProject.ProjectRootPath}\"\\file.ext", out string standardOutput, out string standardError), standardOutput);
+      Assert.Contains("Passed!", standardOutput);
+      Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput);
+      Assert.True(File.Exists(Path.Combine(clonedTemplateProject.ProjectRootPath, "file.ext")));
+      AssertCoverage(clonedTemplateProject, "file.ext");
+    }
+
+    [Fact]
+    public void TestMsbuild_CoverletOutput_Folder_FileNameExtension_SpecifyFramework()
+    {
+      using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
+      Assert.False(clonedTemplateProject.IsMultipleTargetFramework());
+      string framework = clonedTemplateProject.GetTargetFrameworks().Single();
+      Assert.True(DotnetCli($"test -c {_buildConfiguration} -f {framework} \"{clonedTemplateProject.ProjectRootPath}\" /p:CollectCoverage=true /p:Include=\"[{ClonedTemplateProject.AssemblyName}]*DeepThought\" /p:IncludeTestAssembly=true /p:CoverletOutput=\"{clonedTemplateProject.ProjectRootPath}\"\\file.ext", out string standardOutput, out string standardError), standardOutput);
+      Assert.Contains("Passed!", standardOutput);
+      Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput);
+      Assert.True(File.Exists(Path.Combine(clonedTemplateProject.ProjectRootPath, "file.ext")));
+      AssertCoverage(clonedTemplateProject, "file.ext");
+    }
+
+    [Fact]
+    public void TestMsbuild_CoverletOutput_Folder_FileNameWithDoubleExtension()
+    {
+      using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
+      Assert.True(DotnetCli($"test -c {_buildConfiguration} \"{clonedTemplateProject.ProjectRootPath}\" /p:CollectCoverage=true /p:Include=\"[{ClonedTemplateProject.AssemblyName}]*DeepThought\" /p:IncludeTestAssembly=true /p:CoverletOutput=\"{clonedTemplateProject.ProjectRootPath}\"\\file.ext1.ext2", out string standardOutput, out string standardError), standardOutput);
+      Assert.Contains("Passed!", standardOutput);
+      Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput);
+      Assert.True(File.Exists(Path.Combine(clonedTemplateProject.ProjectRootPath, "file.ext1.ext2")));
+      AssertCoverage(clonedTemplateProject, "file.ext1.ext2");
+    }
+
+    [Fact]
+    public void Test_MultipleTargetFrameworkReport_NoCoverletOutput()
+    {
+      using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
+      string[] targetFrameworks = new string[] { "net6.0", "net7.0" };
+      UpdateProjectTargetFramework(clonedTemplateProject, targetFrameworks);
+      Assert.True(DotnetCli($"test -c {_buildConfiguration} \"{clonedTemplateProject.ProjectRootPath}\" /p:CollectCoverage=true /p:Include=\"[{ClonedTemplateProject.AssemblyName}]*DeepThought\" /p:IncludeTestAssembly=true", out string standardOutput, out string standardError, clonedTemplateProject.ProjectRootPath!), standardOutput);
+      Assert.Contains("Passed!", standardOutput);
+      Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput);
+
+      foreach (string targetFramework in targetFrameworks)
+      {
+        Assert.True(File.Exists(Path.Combine(clonedTemplateProject.ProjectRootPath, $"coverage.{targetFramework}.json")));
+      }
+
+      AssertCoverage(clonedTemplateProject, "coverage.*.json");
+    }
+
+    [Fact]
+    public void Test_MultipleTargetFrameworkReport_CoverletOutput_Folder()
+    {
+      using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
+      string[] targetFrameworks = new string[] { "net6.0", "net7.0" };
+      UpdateProjectTargetFramework(clonedTemplateProject, targetFrameworks);
+      bool result = DotnetCli($"test -c {_buildConfiguration} \"{clonedTemplateProject.ProjectRootPath}\" /p:CollectCoverage=true /p:Include=\"[{ClonedTemplateProject.AssemblyName}]*DeepThought\" /p:IncludeTestAssembly=true /p:CoverletOutput=\"{clonedTemplateProject.ProjectRootPath}\"\\", out string standardOutput, out string standardError, clonedTemplateProject.ProjectRootPath!);
+      if (!string.IsNullOrEmpty(standardError))
+      {
+        _output.WriteLine(standardError);
+      }
+      Assert.True(result);
+      Assert.Contains("Passed!", standardOutput);
+      Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput);
+
+      foreach (string targetFramework in targetFrameworks)
+      {
+        string fileToCheck = Path.Combine(clonedTemplateProject.ProjectRootPath, $"coverage.{targetFramework}.json");
+        Assert.True(File.Exists(fileToCheck), $"Expected file '{fileToCheck}'\nOutput:\n{standardOutput}");
+      }
+
+      AssertCoverage(clonedTemplateProject, "coverage.*.json");
+    }
+
+    [Fact]
+    public void Test_MultipleTargetFrameworkReport_CoverletOutput_Folder_FileNameWithoutExtension()
+    {
+      using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
+      string[] targetFrameworks = new string[] { "net6.0", "net7.0" };
+      UpdateProjectTargetFramework(clonedTemplateProject, targetFrameworks);
+      Assert.True(DotnetCli($"test -c {_buildConfiguration} \"{clonedTemplateProject.ProjectRootPath}\" /p:CollectCoverage=true /p:Include=\"[{ClonedTemplateProject.AssemblyName}]*DeepThought\" /p:IncludeTestAssembly=true /p:CoverletOutput=\"{clonedTemplateProject.ProjectRootPath}\"\\file", out string standardOutput, out string standardError, clonedTemplateProject.ProjectRootPath!), standardOutput);
+      Assert.Contains("Passed!", standardOutput);
+      Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput);
+
+      foreach (string targetFramework in targetFrameworks)
+      {
+        Assert.True(File.Exists(Path.Combine(clonedTemplateProject.ProjectRootPath, $"file.{targetFramework}.json")));
+      }
+
+      AssertCoverage(clonedTemplateProject, "file.*.json");
+    }
+
+    [Fact]
+    public void Test_MultipleTargetFrameworkReport_CoverletOutput_Folder_FileNameWithExtension_SpecifyFramework()
+    {
+      using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
+      string[] targetFrameworks = new string[] { "net6.0", "net7.0" };
+      UpdateProjectTargetFramework(clonedTemplateProject, targetFrameworks);
+      Assert.True(clonedTemplateProject.IsMultipleTargetFramework());
+      string[] frameworks = clonedTemplateProject.GetTargetFrameworks();
+      Assert.Equal(2, frameworks.Length);
+      string framework = frameworks.FirstOrDefault()!;
+      Assert.True(DotnetCli($"test -c {_buildConfiguration} -f {framework} \"{clonedTemplateProject.ProjectRootPath}\" /p:CollectCoverage=true /p:Include=\"[{ClonedTemplateProject.AssemblyName}]*DeepThought\" /p:IncludeTestAssembly=true /p:CoverletOutput=\"{clonedTemplateProject.ProjectRootPath}\"\\file.ext", out string standardOutput, out string standardError, clonedTemplateProject.ProjectRootPath!), standardOutput);
+      Assert.Contains("Passed!", standardOutput);
+      Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput);
+
+      foreach (string targetFramework in targetFrameworks)
+      {
+        if (framework == targetFramework)
+        {
+          Assert.True(File.Exists(Path.Combine(clonedTemplateProject.ProjectRootPath, $"file.{targetFramework}.ext")));
+        }
+        else
+        {
+          Assert.False(File.Exists(Path.Combine(clonedTemplateProject.ProjectRootPath, $"file.{targetFramework}.ext")));
+        }
+      }
+
+      AssertCoverage(clonedTemplateProject, "file.*.ext");
+    }
+
+    [Fact]
+    public void Test_MultipleTargetFrameworkReport_CoverletOutput_Folder_FileNameWithExtension()
+    {
+      using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
+      string[] targetFrameworks = new string[] { "net6.0", "net7.0" };
+      UpdateProjectTargetFramework(clonedTemplateProject, targetFrameworks);
+      Assert.True(DotnetCli($"test -c {_buildConfiguration} \"{clonedTemplateProject.ProjectRootPath}\" /p:CollectCoverage=true /p:Include=\"[{ClonedTemplateProject.AssemblyName}]*DeepThought\" /p:IncludeTestAssembly=true /p:CoverletOutput=\"{clonedTemplateProject.ProjectRootPath}\"\\file.ext", out string standardOutput, out string standardError, clonedTemplateProject.ProjectRootPath!), standardOutput);
+      Assert.Contains("Passed!", standardOutput);
+      Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput);
+
+      foreach (string targetFramework in targetFrameworks)
+      {
+        Assert.True(File.Exists(Path.Combine(clonedTemplateProject.ProjectRootPath, $"file.{targetFramework}.ext")));
+      }
+
+      AssertCoverage(clonedTemplateProject, "file.*.ext");
+    }
+
+    [Fact]
+    public void Test_MultipleTargetFrameworkReport_CoverletOutput_Folder_FileNameWithDoubleExtension()
+    {
+      using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
+      string[] targetFrameworks = new string[] { "net6.0", "net7.0" };
+      UpdateProjectTargetFramework(clonedTemplateProject, targetFrameworks);
+      Assert.True(DotnetCli($"test -c {_buildConfiguration} \"{clonedTemplateProject.ProjectRootPath}\" /p:CollectCoverage=true /p:Include=\"[{ClonedTemplateProject.AssemblyName}]*DeepThought\" /p:IncludeTestAssembly=true /p:CoverletOutput=\"{clonedTemplateProject.ProjectRootPath}\"\\file.ext1.ext2", out string standardOutput, out string standardError, clonedTemplateProject.ProjectRootPath!), standardOutput);
+      Assert.Contains("Passed!", standardOutput);
+      Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput);
+
+      foreach (string targetFramework in targetFrameworks)
+      {
+        Assert.True(File.Exists(Path.Combine(clonedTemplateProject.ProjectRootPath, $"file.ext1.{targetFramework}.ext2")));
+      }
+
+      AssertCoverage(clonedTemplateProject, "file.ext1.*.ext2");
+    }
+  }
 }

--- a/test/coverlet.integration.tests/coverlet.integration.tests.csproj
+++ b/test/coverlet.integration.tests/coverlet.integration.tests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0"/>
     <PackageReference Include="Moq" Version="4.18.4"/>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NuGet.Packaging" Version="6.6.1"/>
     <PackageReference Include="xunit" Version="2.5.0"/>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>


### PR DESCRIPTION
- uses System.Text.Json instead of Newtonsoft.Json for nuget packages
- integration test is still using Newtonsoft.Json
- generates code coverage report #1516 (Azure DevOps build pipeline)

:exclamation: PR #1510 should be merged before this one. The System.Text.Json updates shall be merges separately.