### PR TITLE
fix deadlog in BaseTest

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,4 +25,9 @@
     <Deterministic>true</Deterministic>
   </PropertyGroup>
 
+  <ItemGroup>
+    <VSTestLogger Include="trx%3BLogFileName=TestResults-$(TargetFramework)-$(MSBuildProjectName).trx" />
+    <VSTestLogger Include="html%3BLogFileName=TestResults-$(TargetFramework)-$(MSBuildProjectName).html" />
+  </ItemGroup>
+
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,6 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.5.0"/>
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="2.10.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />

--- a/eng/publish-coverlet-result-files.yml
+++ b/eng/publish-coverlet-result-files.yml
@@ -1,36 +1,20 @@
 steps:
-- task: Powershell@2
-  displayName: Prepare log files to Upload
-  inputs:
-    targetType: inline
-    pwsh: true
-    script: |
-      New-Item -ItemType Directory "$(Build.SourcesDirectory)/artifacts/TestLogs/"
-      function Copy-FileKeepPath {
-      param (
-          $Filter,$FileToCopy,$Destination,$StartIndex
-          )
-      Get-ChildItem -Path $FileToCopy -Filter $Filter -Recurse -File | ForEach-Object {
-          $fileName = $_.FullName
-          $newDestination=Join-Path -Path $Destination -ChildPath $fileName.Substring($StartIndex)
-          $folder=Split-Path -Path $newDestination -Parent
-          if (!(Test-Path -Path $folder)) {New-Item $folder -Type Directory -Force -Verbose}
-          Copy-Item -Path $fileName -Destination $newDestination -Recurse -Force -Verbose
-          }
-      }
-      $logfiles = "coverage.opencover.xml", "coverage.cobertura.xml", "coverage.json", "log.txt", "log.datacollector.*.txt", "log.host.*.txt"
-      foreach ($logfile in $logfiles ) {
-      Copy-FileKeepPath -FileToCopy "$(Build.SourcesDirectory)/test/*" -des "$(Build.SourcesDirectory)/artifacts/TestLogs/" -filter $logfile -startIndex "$(Build.SourcesDirectory)/test/coverlet.integration.tests/bin/".Length
-      }
-
+- task: CopyFiles@2
+  displayName: Copy tests results
   continueOnError: true
   condition: always()
-
-- task: CopyFiles@2
-  displayName: Copy trx files
   inputs:
-    SourceFolder: '$(Agent.TempDirectory)'
-    Contents: '**/*.trx'
+    SourceFolder: '$(Build.SourcesDirectory)/artifacts'
+    Contents: |
+       **/*.trx
+       **/*.html
+       **/*.binlog
+       **/coverage.opencover.xml
+       **/coverage.cobertura.xml
+       **/coverage.json
+       **/log.txt
+       **/log.datacollector.*.txt
+       **/log.host.*.txt
     TargetFolder: '$(Build.SourcesDirectory)/artifacts/TestLogs'
 
 - task: PublishPipelineArtifact@1

--- a/test/coverlet.core.tests/coverlet.core.tests.csproj
+++ b/test/coverlet.core.tests/coverlet.core.tests.csproj
@@ -8,29 +8,34 @@
     <MSBuildWarningsAsMessages>NU1702</MSBuildWarningsAsMessages>
     <!--For test TestInstrument_NetstandardAwareAssemblyResolver_PreserveCompilationContext-->
     <PreserveCompilationContext>true</PreserveCompilationContext>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LinqKit.Microsoft.EntityFrameworkCore" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
-    <PackageReference Include="Moq" />
-    <PackageReference Include="ReportGenerator.Core" />
-    <PackageReference Include="System.Linq.Async"  />
-    <PackageReference Include="Tmds.ExecFunction" />
-    <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="LinqKit.Microsoft.EntityFrameworkCore" Version="7.1.4" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.10.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="ReportGenerator.Core" Version="5.1.23" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    <PackageReference Include="Tmds.ExecFunction" Version="0.6.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)src\coverlet.core\coverlet.core.csproj" />
     <ProjectReference Include="$(RepoRoot)test\coverlet.tests.xunit.extensions\coverlet.tests.xunit.extensions.csproj" />
-    
+
     <ProjectReference Include="$(RepoRoot)test\coverlet.core.tests.samples.netstandard\coverlet.core.tests.samples.netstandard.csproj" />
     <ProjectReference Include="$(RepoRoot)test\coverlet.tests.projectsample.empty\coverlet.tests.projectsample.empty.csproj" />
     <ProjectReference Include="$(RepoRoot)test\coverlet.tests.projectsample.excludedbyattribute\coverlet.tests.projectsample.excludedbyattribute.csproj" />
-    <ProjectReference Include="$(RepoRoot)test\coverlet.tests.projectsample.fsharp\coverlet.tests.projectsample.fsharp.fsproj" />    
+    <ProjectReference Include="$(RepoRoot)test\coverlet.tests.projectsample.fsharp\coverlet.tests.projectsample.fsharp.fsproj" />
     <ProjectReference Include="$(RepoRoot)test\coverlet.tests.projectsample.netframework\coverlet.tests.projectsample.netframework.csproj" />
     <ProjectReference Include="$(RepoRoot)test\coverlet.tests.projectsample.vbmynamespace\coverlet.tests.projectsample.vbmynamespace.vbproj" />
   </ItemGroup>

--- a/test/coverlet.integration.determisticbuild/coverlet.integration.determisticbuild.csproj
+++ b/test/coverlet.integration.determisticbuild/coverlet.integration.determisticbuild.csproj
@@ -24,5 +24,6 @@
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
   </ItemGroup>
 </Project>

--- a/test/coverlet.integration.tests/DeterministicBuild.cs
+++ b/test/coverlet.integration.tests/DeterministicBuild.cs
@@ -149,7 +149,7 @@ namespace Coverlet.Integration.Tests
             Assert.Contains("=/_/", File.ReadAllText(sourceRootMappingFilePath));
 
             string runSettingsPath = AddCollectorRunsettingsFile(_testProjectPath, "[coverletsample.integration.determisticbuild]*DeepThought", deterministicReport: true);
-            Assert.True(DotnetCli($"test -c {_buildConfiguration} --no-build \"{_testProjectPath}\" --collect:\"XPlat Code Coverage\" --settings \"{runSettingsPath}\" --diag:{Path.Combine(_testProjectPath, "log.txt")}", out standardOutput, out standardError), standardOutput);
+            bool result = DotnetCli($"test -c {_buildConfiguration} --no-build \"{_testProjectPath}\" --collect:\"XPlat Code Coverage\" --settings \"{runSettingsPath}\" --diag:{Path.Combine(_testProjectPath, "log.txt")}", out standardOutput, out standardError);
             if (!string.IsNullOrEmpty(standardError))
             {
               _output.WriteLine(standardError);
@@ -158,6 +158,7 @@ namespace Coverlet.Integration.Tests
             {
               _output.WriteLine(standardOutput);
             }
+            Assert.True(result);
             Assert.Contains("Passed!", standardOutput);
             AssertCoverage(standardOutput);
 
@@ -185,7 +186,7 @@ namespace Coverlet.Integration.Tests
             Assert.Contains("=/_/", File.ReadAllText(sourceRootMappingFilePath));
 
             string runSettingsPath = AddCollectorRunsettingsFile(_testProjectPath, "[coverletsample.integration.determisticbuild]*DeepThought", sourceLink: true);
-            Assert.True(DotnetCli($"test -c {_buildConfiguration} --no-build \"{_testProjectPath}\" --collect:\"XPlat Code Coverage\" --settings \"{runSettingsPath}\" --diag:{Path.Combine(_testProjectPath, "log.txt")}", out standardOutput, out standardError), standardOutput);
+            bool result = DotnetCli($"test -c {_buildConfiguration} --no-build \"{_testProjectPath}\" --collect:\"XPlat Code Coverage\" --settings \"{runSettingsPath}\" --diag:{Path.Combine(_testProjectPath, "log.txt")}", out standardOutput, out standardError);
             if (!string.IsNullOrEmpty(standardError))
             {
               _output.WriteLine(standardError);
@@ -194,6 +195,7 @@ namespace Coverlet.Integration.Tests
             {
               _output.WriteLine(standardOutput);
             }
+            Assert.True(result);
             Assert.Contains("Passed!", standardOutput);
             AssertCoverage(standardOutput, checkDeterministicReport: false);
             Assert.Contains("raw.githubusercontent.com", File.ReadAllText(Directory.GetFiles(_testProjectPath, "coverage.cobertura.xml", SearchOption.AllDirectories).Single()));


### PR DESCRIPTION
- 
- use project names for test artifacts (trx, html) 
- use CopyFiles instead of powershell script (publish-coverlet-result-files.yml)
- disable CPM for coverlet.core.tests.csproj (VS reports "restore loop")