### PR TITLE
sign binaries and nuget packages

### DIFF
--- a/Documentation/ReleasePlan.md
+++ b/Documentation/ReleasePlan.md
@@ -85,26 +85,54 @@ This is the steps to release new packages to nuget.org
 
     Do a PR and merge to master.
 
-2. Clone repo, **remember to build packages from master and not from your fork or metadata links will point to your forked repo.** . Run `git log -5` from repo root to verify last commit.
+1. Clone repo, **remember to build packages from master and not from your fork or metadata links will point to your forked repo.** . Run `git log -5` from repo root to verify last commit.
 
-3. From new cloned, aligned and versions updated repo root run pack command
+1. From new cloned, aligned and versions updated repo root run build command
+
+  ```shell
+  dotnet build -c release /p:TF_BUILD=true /p:PublicRelease=true
+  ...
+  coverlet.core -> C:\GitHub\coverlet\artifacts\bin\coverlet.core\release_netstandard2.0\coverlet.core.dll
+  coverlet.core -> C:\GitHub\coverlet\artifacts\bin\coverlet.core\release_net6.0\coverlet.core.dll
+  coverlet.collector -> C:\GitHub\coverlet\artifacts\bin\coverlet.collector\release_netstandard2.0\coverlet.collector.dll
+  coverlet.collector -> C:\GitHub\coverlet\artifacts\bin\coverlet.collector\release_net6.0\coverlet.collector.dll
+  coverlet.msbuild.tasks -> C:\GitHub\coverlet\artifacts\bin\coverlet.msbuild.tasks\release_netstandard2.0\coverlet.msbuild.tasks.dll
+  coverlet.msbuild.tasks -> C:\GitHub\coverlet\artifacts\bin\coverlet.msbuild.tasks\release_net6.0\coverlet.msbuild.tasks.dll
+  coverlet.console -> C:\GitHub\coverlet\artifacts\bin\coverlet.console\release\coverlet.console.dll
+  coverlet.console -> C:\GitHub\coverlet\artifacts\bin\coverlet.console\release\coverlet.console.exe
+  ...
+  ```
+
+1. Sign binary files for nuget packages
+
+```shell
+> AzureSignTool.exe sign --file-digest sha256 --timestamp-rfc3161 http://timestamp.digicert.com --timestamp-digest sha256 `
+>> --azure-key-vault-url KEYVAULT-URL `
+>> --azure-key-vault-client-id CLIENT-ID `
+>> --azure-key-vault-tenant-id TENANT-ID `
+>> --azure-key-vault-client-secret KEYVAULT-SECRET `
+>> --azure-key-vault-certificate CERT-FRIENDLY-NAME `
+>> artifacts\bin\coverlet.console\release\coverlet.console.dll `
+>> artifacts\bin\coverlet.console\release\coverlet.console.exe `
+>> artifacts\bin\coverlet.core\release_net6.0\coverlet.core.dll `
+>> artifacts\bin\coverlet.core\release_netstandard2.0\coverlet.core.dll `
+>> artifacts\bin\coverlet.collector\release_net6.0\coverlet.collector.dll `
+>> artifacts\bin\coverlet.collector\release_netstandard2.0\coverlet.collector.dll `
+>> artifacts\bin\coverlet.msbuild.tasks\release_net6.0\coverlet.msbuild.tasks.dll `
+>> artifacts\bin\coverlet.msbuild.tasks\release_netstandard2.0\coverlet.msbuild.tasks.dll
+```
+
+1. Run pack command for signed binaries
+
+```shell
+  dotnet pack --no-build -c release /p:TF_BUILD=true /p:PublicRelease=true src\coverlet.console
+  dotnet pack --no-build -c release /p:TF_BUILD=true /p:PublicRelease=true src\coverlet.collector
+  dotnet pack -c release /p:TF_BUILD=true /p:PublicRelease=true src\coverlet.msbuild.tasks
+```
+
+1. Sign the packages using NuGetKeyVaultSignTool <https://www.nuget.org/packages/NuGetKeyVaultSignTool>
 
     ```shell
-    dotnet pack -c release /p:TF_BUILD=true /p:PublicRelease=true
-    ...
-    coverlet.console -> D:\git\coverlet\src\coverlet.console\bin\Release\net6.0\coverlet.console.dll
-    coverlet.console -> D:\git\coverlet\src\coverlet.console\bin\Release\net6.0\publish\
-    Successfully created package 'D:\git\coverlet\bin\Release\Packages\coverlet.collector.6.0.1-preview.6.g918cd179e0.nupkg'.
-    Successfully created package 'D:\git\coverlet\bin\Release\Packages\coverlet.collector.6.0.1-preview.6.g918cd179e0.snupkg'.
-    Successfully created package 'D:\git\coverlet\bin\Release\Packages\coverlet.msbuild.6.0.1-preview.6.g918cd179e0.nupkg'.
-    Successfully created package 'D:\git\coverlet\bin\Release\Packages\coverlet.msbuild.6.0.1-preview.6.g918cd179e0.snupkg'.
-    Successfully created package 'D:\git\coverlet\bin\Release\Packages\coverlet.console.6.0.1-preview.6.g918cd179e0.nupkg'.
-    Successfully created package 'D:\git\coverlet\bin\Release\Packages\coverlet.console.6.0.1-preview.6.g918cd179e0.snupkg'.
-    ```
-
-4. Sign the packages using NuGetKeyVaultSignTool <https://www.nuget.org/packages/NuGetKeyVaultSignTool>
-
-    ```
     ❯ NuGetKeyVaultSignTool sign **/*.nupkg --file-digest sha256 --timestamp-rfc3161 http://timestamp.digicert.com --timestamp-digest sha256 `
     >> --azure-key-vault-url KEYVAULT-URL `
     >> --azure-key-vault-client-id CLIENT-ID `
@@ -113,9 +141,9 @@ This is the steps to release new packages to nuget.org
     >> --azure-key-vault-certificate CERT-FRIENDLY-NAME
     ```
 
-5. Upload *.nupkg files to Nuget.org site. **Check all metadata(url links, deterministic build etc...) before "Submit"**
+1. Upload *.nupkg files to Nuget.org site. **Check all metadata(url links, deterministic build etc...) before "Submit"**
 
-6. **On your fork**:
+1. **On your fork**:
     * Align to master
     * Bump version by one (fix part) and re-add `-preview.{height}`
     * Create release on repo <https://github.com/coverlet-coverage/coverlet/releases>


### PR DESCRIPTION
:warning: Do not merge

ToDo: coverlet.msbuild.tasks fails to create nuget package with `--no-build` option