### PR TITLE
Broken exclude-by-attribute feature in `coverlet.console`

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
+- Exception when multiple exclude-by-attribute filters specified [#1624](https://github.com/coverlet-coverage/coverlet/issues/1624)
+
+### Improvements
+- More concise options to specify multiple parameters in coverlet.console [#1624](https://github.com/coverlet-coverage/coverlet/issues/1624)
+
+## Release date 2024-02-19
+### Packages
+coverlet.msbuild 6.0.1
+coverlet.console 6.0.1
+coverlet.collector 6.0.1
+
+### Fixed
 - Uncovered lines in .NET 8 for inheriting records [#1555](https://github.com/coverlet-coverage/coverlet/issues/1555)
 - Fix record constructors not covered when SkipAutoProps is true [#1561](https://github.com/coverlet-coverage/coverlet/issues/1561)
 - Fix .NET 7 Method Group branch coverage issue [#1447](https://github.com/coverlet-coverage/coverlet/issues/1447)

--- a/Documentation/GlobalTool.md
+++ b/Documentation/GlobalTool.md
@@ -42,10 +42,16 @@ Options:
   -?, -h, --help                        Show help and usage information
 ```
 
-NB. For a [multiple value] options you have to specify values multiple times i.e.
+NB. For [multiple value] options you can either specify values multiple times i.e.
 
 ```shell
 --exclude-by-attribute 'Obsolete' --exclude-by-attribute 'GeneratedCode' --exclude-by-attribute 'CompilerGenerated'
+```
+
+or pass the multiple values as space separated sequence, i.e.
+
+```shell
+--exclude-by-attribute "Obsolete" "GeneratedCode" "CompilerGenerated"
 ```
 
 For `--merge-with` [check the sample](Examples.md).

--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -40,7 +40,7 @@ namespace Coverlet.Console
       var includeFilters = new Option<string[]>("--include", "Filter expressions to include only specific modules and types.") { Arity = ArgumentArity.ZeroOrMore };
       var excludedSourceFiles = new Option<string[]>("--exclude-by-file", "Glob patterns specifying source files to exclude.") { Arity = ArgumentArity.ZeroOrMore };
       var includeDirectories = new Option<string[]>("--include-directory", "Include directories containing additional assemblies to be instrumented.") { Arity = ArgumentArity.ZeroOrMore };
-      var excludeAttributes = new Option<string[]>("--exclude-by-attribute", "Attributes to exclude from code coverage.") { Arity = ArgumentArity.ZeroOrOne };
+      var excludeAttributes = new Option<string[]>("--exclude-by-attribute", "Attributes to exclude from code coverage.") { Arity = ArgumentArity.ZeroOrMore };
       var includeTestAssembly = new Option<bool>("--include-test-assembly", "Specifies whether to report code coverage of the test assembly.") { Arity = ArgumentArity.Zero };
       var singleHit = new Option<bool>("--single-hit", "Specifies whether to limit code coverage hit reporting to a single hit for each location") { Arity = ArgumentArity.Zero };
       var skipAutoProp = new Option<bool>("--skipautoprops", "Neither track nor record auto-implemented properties.") { Arity = ArgumentArity.Zero };


### PR DESCRIPTION
closes #1624 

**Before**:

![grafik](https://github.com/coverlet-coverage/coverlet/assets/19378678/dcf4b4da-c7ad-4bdf-b6e0-cce93a36f087)


**After** code adaption in this PR:

![grafik](https://github.com/coverlet-coverage/coverlet/assets/19378678/b7bec50e-a0be-46a9-886d-c651c0c4422e)
