### PR TITLE
Update docs on new source-mapping-file argument

### DIFF
--- a/Documentation/GlobalTool.md
+++ b/Documentation/GlobalTool.md
@@ -37,7 +37,7 @@ Options:
   --use-source-link                     Specifies whether to use SourceLink URIs in place of file system paths.
   --does-not-return-attribute           Attributes that mark methods that do not return.
   --exclude-assemblies-without-sources  Specifies behaviour of heuristic to ignore assemblies with missing source documents.
-  --use-mapping-file                    Specifies the path to a SourceRootsMappings file.
+  --source-mapping-file                    Specifies the path to a SourceRootsMappings file.
   --version                             Show version information
   -?, -h, --help                        Show help and usage information
 ```


### PR DESCRIPTION
I forgot to update the help docs for the feature in https://github.com/coverlet-coverage/coverlet/pull/1568 which had the original argument name I used. This updates the docs to display `--source-mapping-file` as the correct argument