### PR TITLE
Fix TypeInitializer issue

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
+- Type initializer errors after updating from 6.0.0 to 6.0.1 [#1629](https://github.com/coverlet-coverage/coverlet/issues/1629)
 - Exception when multiple exclude-by-attribute filters specified [#1624](https://github.com/coverlet-coverage/coverlet/issues/1624)
 
 ### Improvements

--- a/src/coverlet.collector/coverlet.collector.csproj
+++ b/src/coverlet.collector/coverlet.collector.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyTitle>coverlet.collector</AssemblyTitle>
     <DevelopmentDependency>true</DevelopmentDependency>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/src/coverlet.core/coverlet.core.csproj
+++ b/src/coverlet.core/coverlet.core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/coverlet.msbuild.tasks/buildMultiTargeting/coverlet.msbuild.props
+++ b/src/coverlet.msbuild.tasks/buildMultiTargeting/coverlet.msbuild.props
@@ -1,4 +1,0 @@
-<!-- buildMultiTargeting/coverlet.msbuild.props -->
-<Project>
-  <Import Project="..\build\coverlet.msbuild.props" />
-</Project>

--- a/src/coverlet.msbuild.tasks/coverlet.msbuild.props
+++ b/src/coverlet.msbuild.tasks/coverlet.msbuild.props
@@ -19,7 +19,7 @@
     <ExcludeAssembliesWithoutSources Condition="$(ExcludeAssembliesWithoutSources) == ''"></ExcludeAssembliesWithoutSources>
   </PropertyGroup>
   <PropertyGroup>
-    <CoverletToolsPath Condition="'$(CoverletToolsPath)' == '' and '$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tasks\net6.0\</CoverletToolsPath>
-    <CoverletToolsPath Condition="'$(CoverletToolsPath)' == '' and '$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tasks\netstandard2.0\</CoverletToolsPath>
+    <CoverletToolsPath Condition="$(TargetFrameworkIdentifier) == '.NETCoreApp'">$(MSBuildThisFileDirectory)..\tasks\net6.0\</CoverletToolsPath>
+    <CoverletToolsPath Condition="$(TargetFrameworkIdentifier) != '.NETCoreApp'">$(MSBuildThisFileDirectory)..\tasks\netstandard2.0\</CoverletToolsPath>
   </PropertyGroup>
 </Project>

--- a/src/coverlet.msbuild.tasks/coverlet.msbuild.props
+++ b/src/coverlet.msbuild.tasks/coverlet.msbuild.props
@@ -19,7 +19,6 @@
     <ExcludeAssembliesWithoutSources Condition="$(ExcludeAssembliesWithoutSources) == ''"></ExcludeAssembliesWithoutSources>
   </PropertyGroup>
   <PropertyGroup>
-    <CoverletToolsPath Condition="$(TargetFrameworkIdentifier) == '.NETCoreApp'">$(MSBuildThisFileDirectory)..\tasks\net6.0\</CoverletToolsPath>
-    <CoverletToolsPath Condition="$(TargetFrameworkIdentifier) != '.NETCoreApp'">$(MSBuildThisFileDirectory)..\tasks\netstandard2.0\</CoverletToolsPath>
+    <CoverletToolsPath Condition=" '$(CoverletToolsPath)' == '' ">$(MSBuildThisFileDirectory)..\tasks\netstandard2.0\</CoverletToolsPath>
   </PropertyGroup>
 </Project>

--- a/src/coverlet.msbuild.tasks/coverlet.msbuild.tasks.csproj
+++ b/src/coverlet.msbuild.tasks/coverlet.msbuild.tasks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyTitle>coverlet.msbuild.tasks</AssemblyTitle>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);PackBuildOutputs</TargetsForTfmSpecificContentInPackage>
@@ -54,9 +54,6 @@
   <ItemGroup>
     <None Include="coverlet.msbuild.props" Pack="true" PackagePath="build\">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory >
-    </None>
-    <None Include="buildMultiTargeting\coverlet.msbuild.props" Pack="true" PackagePath="buildMultiTargeting\">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="coverlet.msbuild.targets" Pack="true" PackagePath="build\">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -14,8 +14,7 @@
              This is required when the coverlet.msbuild imports are made in their src directory
              (so that msbuild eval works even before they are built)
              so that they can still find the tooling that will be built by the build. -->
-        <CoverletToolsPath Condition="'$(MSBuildRuntimeType)' == 'Core'">$(RepoRoot)artifacts\bin\coverlet.msbuild.tasks\$(Configuration.ToLowerInvariant())_net6.0\</CoverletToolsPath>
-        <CoverletToolsPath Condition="'$(MSBuildRuntimeType)' != 'Core'">$(RepoRoot)artifacts\bin\coverlet.msbuild.tasks\$(Configuration.ToLowerInvariant())_netstandard2.0\</CoverletToolsPath>
+        <CoverletToolsPath>$(RepoRoot)artifacts\bin\coverlet.msbuild.tasks\$(Configuration.ToLowerInvariant())_netstandard2.0\</CoverletToolsPath>
       </PropertyGroup>
     </When>
   </Choose>

--- a/test/coverlet.integration.determisticbuild/coverlet.integration.determisticbuild.csproj
+++ b/test/coverlet.integration.determisticbuild/coverlet.integration.determisticbuild.csproj
@@ -12,7 +12,6 @@
       https://api.nuget.org/v3/index.json;
       $(RepoRoot)artifacts/package/$(Configuration.ToLowerInvariant())
     </RestoreSources>
-    <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
closes #1629 

OK I guess I need a review here. Changing the tfm of core to only `netstandard2.0` fixes the problem. But from my perspective the `CoverletToolsPath` should also be resolved properly. The change of the condition for `CoverletToolsPath` I did in this PR still doesn't seem to work properly. No matter what I do it always point to netstandard2.0
```cmd
CoverletToolsPath = C:\Users\...\.nuget\packages\coverlet.msbuild\6.0.2-preview.7.ga760715d51\build\..\tasks\netstandard2.0\
```

But what I think, for e.g. `net6` it should point to 
```cmd
CoverletToolsPath = C:\Users\...\.nuget\packages\coverlet.msbuild\6.0.2-preview.7.ga760715d51\build\..\tasks\net6.0\
```
@MarcoRossignoli @Bertk Am I missing something? Can you help out here?

