### PR TITLE
allow newer SDK versions

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-reportgenerator-globaltool": {
-      "version": "5.2.1",
+      "version": "5.2.4",
       "commands": [
         "reportgenerator"
       ]

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
     <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <LangVersion>preview</LangVersion>
-    <NoWarn>$(NoWarn);NU1507;NU5105;CS1591</NoWarn>
+    <NoWarn>$(NoWarn);NU1507;NU5105;CS1591;IDE0008;IDE2000</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RestoreSources>
       https://api.nuget.org/v3/index.json;
@@ -69,9 +69,9 @@
             <MicrosoftBuildTaskVersion>15.7.179</MicrosoftBuildTaskVersion>
             <MicrosoftBuildTaskUtilitiesCoreVersion>15.7.179</MicrosoftBuildTaskUtilitiesCoreVersion>
             <NuGetBuildTasksPackageVersion>6.9.0-rc.86</NuGetBuildTasksPackageVersion>
-            <MicrosoftBuildTaskSystemReflectionMetaData>1.4.2</MicrosoftBuildTaskSystemReflectionMetaData> 
+            <MicrosoftBuildTaskSystemReflectionMetaData>1.4.2</MicrosoftBuildTaskSystemReflectionMetaData>
             <MicrosoftBuildTaskSystemCollectionImmutable>1.5.0</MicrosoftBuildTaskSystemCollectionImmutable>  >= 1.3.1
-    -->       
+    -->
   </PropertyGroup>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,5 +1,7 @@
 {
     "sdk": {
-        "version": "8.0.101"
+        "version": "8.0.101",
+        "rollForward": "latestFeature",
+        "allowPrerelease": false
     }
 }

--- a/src/coverlet.console/coverlet.console.csproj
+++ b/src/coverlet.console/coverlet.console.csproj
@@ -16,13 +16,12 @@
     <PackageTags>coverage;testing;unit-test;lcov;opencover;quality</PackageTags>
     <PackageReadmeFile>GlobalTool.md</PackageReadmeFile>
     <PackageReleaseNotes>https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/Changelog.md</PackageReleaseNotes>
-    <PackageIconUrl>https://raw.githubusercontent.com/tonerdo/coverlet/master/_assets/coverlet-icon.svg?sanitize=true</PackageIconUrl>
     <PackageIcon>coverlet-icon.png</PackageIcon>
     <PackageProjectUrl>https://github.com/coverlet-coverage/coverlet</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
- 
+
   <ItemGroup>
     <PackageReference Include="System.CommandLine" />
   </ItemGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -3,6 +3,6 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
     <IsTestProject>true</IsTestProject>
-    <NoWarn>$(NoWarn);NU1301</NoWarn>
+    <NoWarn>$(NoWarn);NU1301;IDE0007</NoWarn>
   </PropertyGroup>
 </Project>

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -1,5 +1,6 @@
+
 <Project>
-  <Import Project="$(RepoRoot)/Directory.Build.targets" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
   <Choose>
     <!-- This condition tests whether coverlet.msbuild.props has been imported by the project -->
     <When Condition=" '$(ThresholdType)' != '' ">


### PR DESCRIPTION
- allow newer SDK version without modification of global.json
- remove deprecated property _**PackageIconUrl**_
- suppress IDE warnings IDE0007, IDE0008, IDE2000
- update local tool dotnet-reportgenerator-global version
