### PR TITLE
use latest System.CommandLine version (GA?)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -227,3 +227,4 @@ csharp_style_prefer_top_level_statements = true:silent
 csharp_style_prefer_primary_constructors = true:suggestion
 csharp_style_expression_bodied_lambdas = true:silent
 csharp_style_expression_bodied_local_functions = false:silent
+dotnet_diagnostic.IDE0007.severity = suggestion

--- a/.gitignore
+++ b/.gitignore
@@ -319,3 +319,4 @@ FolderProfile.pubxml
 nuget.config
 *.dmp
 Playground*/
+coverlet.MTP/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
     <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <LangVersion>12.0</LangVersion>
-    <NoWarn>$(NoWarn);NU1507;NU5105;CS1591</NoWarn>
+    <NoWarn>$(NoWarn);NU1507;NU5105;CS1591;NU1608;NU1900</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RestoreSources>
       https://api.nuget.org/v3/index.json;

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,11 +8,11 @@
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.7.115" />
   </ItemGroup>
   <PropertyGroup>
-    <MicrosoftBuildVersion>17.13.9</MicrosoftBuildVersion>
+    <MicrosoftBuildVersion>17.11.31</MicrosoftBuildVersion> <!-- .NET 8.0 support -->
     <MicrosoftCodeAnalysisVersion>4.12.0</MicrosoftCodeAnalysisVersion>
     <!-- Test Platform, .NET Test SDK and Object Model  -->
-    <MicrosoftNETTestSdkVersion>17.13.0</MicrosoftNETTestSdkVersion>
-    <NugetPackageVersion>6.13.2</NugetPackageVersion>
+    <MicrosoftNETTestSdkVersion>17.14.1</MicrosoftNETTestSdkVersion>
+    <NugetPackageVersion>6.14.0</NugetPackageVersion>
     <XunitV3Version>2.0.0</XunitV3Version>
     <XunitRunnerVisualstudioVersion>3.0.2</XunitRunnerVisualstudioVersion>
   </PropertyGroup>
@@ -21,7 +21,7 @@
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
-    <PackageVersion Include="Microsoft.Build.Locator" Version="1.7.8" />
+    <PackageVersion Include="Microsoft.Build.Locator" Version="1.9.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
@@ -48,7 +48,7 @@
     <PackageVersion Include="ReportGenerator.Core" Version="5.3.11" />
     <!--For test issue 809 https://github.com/coverlet-coverage/coverlet/issues/809-->
     <PackageVersion Include="LinqKit.Microsoft.EntityFrameworkCore" Version="8.1.8" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.0-beta6.25358.103" />
     <!--To test issue 1104 https://github.com/coverlet-coverage/coverlet/issues/1104-->
     <!-- latest Tmds.ExecFunction package uses EnvDTE V17.8.37221 -->
     <PackageVersion Include="Tmds.ExecFunction" Version="0.8.0" />

--- a/Documentation/GlobalTool.md
+++ b/Documentation/GlobalTool.md
@@ -38,7 +38,7 @@ Options:
   --merge-with <merge-with>                                                  Path to existing coverage result to merge.
   --use-source-link                                                          Specifies whether to use SourceLink URIs in place of file system paths.
   --does-not-return-attribute <does-not-return-attribute>                    Attributes that mark methods that do not return
-  --exclude-assemblies-without-sources <exclude-assemblies-without-sources>  Specifies behaviour of heuristic to ignore assemblies with missing source documents.
+  --exclude-assemblies-without-sources <exclude-assemblies-without-sources>  Specifies behavior of heuristic to ignore assemblies with missing source documents. [default: MissingAll]
   --source-mapping-file <source-mapping-file>                                Specifies the path to a SourceRootsMappings file.
   --version                                                                  Show version information
   -?, -h, --help                                                             Show help and usage information
@@ -275,5 +275,4 @@ Coverlet outputs specific exit codes to better support build automation systems 
 2 - Coverage percentage is below threshold.
 3 - Test fails and also coverage percentage is below threshold.
 101 - General exception occurred during coverlet process.
-102 - Missing options or invalid arguments for coverlet process.
 ```

--- a/eng/azure-pipelines-nightly.yml
+++ b/eng/azure-pipelines-nightly.yml
@@ -15,6 +15,9 @@ steps:
 - task: NuGetAuthenticate@1
   displayName: Authenticate with NuGet feeds
 
+- script: dotnet restore
+  displayName: Restore packages
+
 - script: dotnet pack -c Release /p:PublicRelease=false
   displayName: Create NuGet packages
 

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -15,8 +15,22 @@ steps:
     New-Item -ItemType Directory -Path artifacts/package/release -Force
   displayName: create folder artifacts/package/$(BuildConfiguration)
 
-- script: dotnet restore
+# Authenticate Azure DevOps NuGet feed
+- task: NuGetAuthenticate@1
+  displayName: 'Authenticate Azure DevOps NuGet feed'
+  inputs:
+    forceReinstallCredentialProvider: true
+
+- script: dotnet restore -v n -s "https://api.nuget.org/v3/index.json"
   displayName: Restore packages
+
+# - task: DotNetCoreCLI@2
+#   displayName: Restore packages
+#   inputs:
+#     command: restore
+#     projects: 'coverlet.sln'
+#     feedsToUse: 'config'
+#     nugetConfigPath: 'nuget.config'
 
 - script: dotnet build -c $(BuildConfiguration) --no-restore -bl:build.msbuild.binlog
   displayName: Build

--- a/src/coverlet.collector/coverlet.collector.csproj
+++ b/src/coverlet.collector/coverlet.collector.csproj
@@ -27,7 +27,6 @@
     <Authors>tonerdo</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/coverlet-coverage/coverlet</PackageProjectUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/tonerdo/coverlet/master/_assets/coverlet-icon.svg?sanitize=true</PackageIconUrl>
     <PackageIcon>coverlet-icon.png</PackageIcon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Description>Coverlet is a cross platform code coverage library for .NET, with support for line, branch and method coverage.</Description>

--- a/src/coverlet.console/ExitCodes.cs
+++ b/src/coverlet.console/ExitCodes.cs
@@ -29,9 +29,5 @@ internal enum CommandExitCodes
   /// </summary>
   Exception = 101,
 
-  /// <summary>
-  /// Indicates missing options or empty arguments for Coverlet process.
-  /// </summary>
-  CommandParsingException = 102
 }
 

--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -28,7 +28,7 @@ namespace Coverlet.Console
   public static class Program
   {
     static int s_exitCode;
-    static async Task Main(string[] args)
+    static async Task<int> Main(string[] args)
     {
       Argument<string> moduleOrAppDirectory = new("path") { Description = "Path to the test assembly or application directory." };
       Option<string> target = new("--target", aliases: new[] { "--target", "-t" }) { Description = "Path to the test runner application.", Arity = ArgumentArity.ZeroOrOne, Required = true };
@@ -143,7 +143,7 @@ namespace Coverlet.Console
       CommandLineConfiguration config = new(rootCommand);
 
       await config.InvokeAsync(args).ConfigureAwait(false);
-      Environment.Exit(s_exitCode);
+      return s_exitCode;
     }
     private static Task<int> HandleCommand(string moduleOrAppDirectory,
                                                            string target,

--- a/src/coverlet.console/Properties/AssemblyInfo.cs
+++ b/src/coverlet.console/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Toni Solarin-Sodara
+// Copyright (c) Toni Solarin-Sodara
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.CompilerServices;

--- a/src/coverlet.console/coverlet.console.csproj
+++ b/src/coverlet.console/coverlet.console.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -16,13 +16,12 @@
     <PackageTags>coverage;testing;unit-test;lcov;opencover;quality</PackageTags>
     <PackageReadmeFile>GlobalTool.md</PackageReadmeFile>
     <PackageReleaseNotes>https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/Changelog.md</PackageReleaseNotes>
-    <PackageIconUrl>https://raw.githubusercontent.com/tonerdo/coverlet/master/_assets/coverlet-icon.svg?sanitize=true</PackageIconUrl>
     <PackageIcon>coverlet-icon.png</PackageIcon>
     <PackageProjectUrl>https://github.com/coverlet-coverage/coverlet</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
- 
+
   <ItemGroup>
     <PackageReference Include="System.CommandLine" />
   </ItemGroup>

--- a/src/coverlet.core/coverlet.core.csproj
+++ b/src/coverlet.core/coverlet.core.csproj
@@ -1,9 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);IDE0057</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,6 +18,7 @@
     <PackageReference Include="System.Text.Json" VersionOverride="6.0.11" />
     <PackageReference Include="System.Reflection.Metadata" VersionOverride="$(SystemReflectionMetadataVersion)" />
     <PackageReference Include="System.Collections.Immutable" VersionOverride="$(SystemCollectionsImmutableVersion)" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
     <PackageReference Include="System.Buffers" />
     <PackageReference Include="System.Memory" />
     <PackageReference Include="System.Threading.Tasks.Extensions" />

--- a/src/coverlet.msbuild.tasks/coverlet.msbuild.tasks.csproj
+++ b/src/coverlet.msbuild.tasks/coverlet.msbuild.tasks.csproj
@@ -28,7 +28,6 @@
     <Authors>tonerdo</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/coverlet-coverage/coverlet</PackageProjectUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/tonerdo/coverlet/master/_assets/coverlet-icon.svg?sanitize=true</PackageIconUrl>
     <PackageIcon>coverlet-icon.png</PackageIcon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <DevelopmentDependency>true</DevelopmentDependency>

--- a/test/coverlet.core.tests.samples.netstandard/coverlet.core.tests.samples.netstandard.csproj
+++ b/test/coverlet.core.tests.samples.netstandard/coverlet.core.tests.samples.netstandard.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.0" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
   </ItemGroup>
 
 </Project>

--- a/test/coverlet.integration.determisticbuild/coverlet.integration.determisticbuild.csproj
+++ b/test/coverlet.integration.determisticbuild/coverlet.integration.determisticbuild.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(MSBuildThisFileDirectory)\DeterministicTest.props" />
   
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>coverletsample.integration.determisticbuild</AssemblyName>
     <MSBuildWarningsAsMessages>NU1604;NU1701</MSBuildWarningsAsMessages>
@@ -29,6 +29,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="6.0.5" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.1" />
   </ItemGroup>
 </Project>

--- a/test/coverlet.integration.template/DeepThought.cs
+++ b/test/coverlet.integration.template/DeepThought.cs
@@ -1,10 +1,21 @@
-﻿namespace Coverlet.Integration.Template
+namespace Coverlet.Integration.Template
 {
-    public class DeepThought
+  public class DeepThought
+  {
+    public int AnswerToTheUltimateQuestionOfLifeTheUniverseAndEverything()
     {
-        public int AnswerToTheUltimateQuestionOfLifeTheUniverseAndEverything()
-        {
-            return 42;
-        }
+      return 42;
     }
+
+    // This method is not covered by any test
+    // It is here to demonstrate how Coverlet will report on untested code
+    // required for Coverlet.Integration.Tests.DotnetGlobalTools.StandAloneThreshold
+    // required for Coverlet.Integration.Tests.DotnetGlobalTools.DotnetToolThreshold
+    public void TheUntestedMethod()
+    {
+#pragma warning disable CS0219 // Variable is assigned but its value is never used
+      string s = "this will never be covered by any test";
+#pragma warning restore CS0219 // Variable is assigned but its value is never used
+    }
+  }
 }

--- a/test/coverlet.integration.tests/Collectors.cs
+++ b/test/coverlet.integration.tests/Collectors.cs
@@ -80,11 +80,10 @@ namespace Coverlet.Integration.Tests
     public void TestVsTest_Test()
     {
       using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
-      int cmdExitCode = DotnetCli($"test -c {_buildConfiguration} -f {_buildTargetFramework} \"{clonedTemplateProject.ProjectRootPath}\" --collect:\"XPlat Code Coverage\" --diag:{Path.Combine(clonedTemplateProject.ProjectRootPath, "log.txt")}", out string standardOutput, out string standardError, clonedTemplateProject.ProjectRootPath!);
+      Assert.Equal(0, DotnetCli($"test -c {_buildConfiguration} -f {_buildTargetFramework} \"{clonedTemplateProject.ProjectRootPath}\" --collect:\"XPlat Code Coverage\" --diag:{Path.Combine(clonedTemplateProject.ProjectRootPath, "log.txt")}", out string standardOutput, out string standardError, clonedTemplateProject.ProjectRootPath!));
       // We don't have any result to check because tests and code to instrument are in same assembly so we need to pass
       // IncludeTestAssembly=true we do it in other test
 
-      Assert.Equal(0, cmdExitCode);
       Assert.Contains("Passed!", standardOutput);
       AssertCollectorsInjection(clonedTemplateProject);
 
@@ -95,9 +94,7 @@ namespace Coverlet.Integration.Tests
     {
       using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
       string runSettingsPath = AddCollectorRunsettingsFile(clonedTemplateProject.ProjectRootPath!);
-      int cmdExitCode = DotnetCli($"test -c {_buildConfiguration} -f {_buildTargetFramework} \"{clonedTemplateProject.ProjectRootPath}\" --collect:\"XPlat Code Coverage\" --settings \"{runSettingsPath}\" --diag:{Path.Combine(clonedTemplateProject.ProjectRootPath, "log.txt")}", out string standardOutput, out string standardError);
-
-      Assert.Equal(0, cmdExitCode);
+      Assert.Equal(0, DotnetCli($"test -c {_buildConfiguration} -f {_buildTargetFramework} \"{clonedTemplateProject.ProjectRootPath}\" --collect:\"XPlat Code Coverage\" --settings \"{runSettingsPath}\" --diag:{Path.Combine(clonedTemplateProject.ProjectRootPath, "log.txt")}", out string standardOutput, out string standardError));
       Assert.Contains("Passed!", standardOutput);
       AssertCoverage(clonedTemplateProject);
       AssertCollectorsInjection(clonedTemplateProject);
@@ -108,12 +105,10 @@ namespace Coverlet.Integration.Tests
     {
       using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
       string runSettingsPath = AddCollectorRunsettingsFile(clonedTemplateProject.ProjectRootPath!);
-      int cmdExitCode = DotnetCli($"publish -c {_buildConfiguration} -f {_buildTargetFramework} {clonedTemplateProject.ProjectRootPath}", out string standardOutput, out string standardError);
-
-      Assert.Equal(0, cmdExitCode);
+      Assert.Equal(0, DotnetCli($"publish -c {_buildConfiguration} -f {_buildTargetFramework} {clonedTemplateProject.ProjectRootPath}", out string standardOutput, out string standardError));
       string publishedTestFile = clonedTemplateProject.GetFiles("*" + ClonedTemplateProject.AssemblyName + ".dll").Single(f => f.Contains("publish"));
       Assert.NotNull(publishedTestFile);
-      cmdExitCode = DotnetCli($"vstest \"{publishedTestFile}\" --collect:\"XPlat Code Coverage\" --diag:{Path.Combine(clonedTemplateProject.ProjectRootPath, "log.txt")}", out standardOutput, out standardError);
+      Assert.Equal(0, DotnetCli($"vstest \"{publishedTestFile}\" --collect:\"XPlat Code Coverage\" --diag:{Path.Combine(clonedTemplateProject.ProjectRootPath, "log.txt")}", out standardOutput, out standardError));
       // We don't have any result to check because tests and code to instrument are in same assembly so we need to pass
       // IncludeTestAssembly=true we do it in other test
       Assert.Contains("Passed!", standardOutput);
@@ -125,12 +120,10 @@ namespace Coverlet.Integration.Tests
     {
       using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
       string runSettingsPath = AddCollectorRunsettingsFile(clonedTemplateProject.ProjectRootPath!);
-      int cmdExitCode = DotnetCli($"publish -c {_buildConfiguration} -f {_buildTargetFramework} \"{clonedTemplateProject.ProjectRootPath}\"", out string standardOutput, out string standardError);
-
-      Assert.Equal(0, cmdExitCode);
+      Assert.Equal(0, DotnetCli($"publish -c {_buildConfiguration} -f {_buildTargetFramework} \"{clonedTemplateProject.ProjectRootPath}\"", out string standardOutput, out string standardError));
       string publishedTestFile = clonedTemplateProject.GetFiles("*" + ClonedTemplateProject.AssemblyName + ".dll").Single(f => f.Contains("publish"));
       Assert.NotNull(publishedTestFile);
-      cmdExitCode = DotnetCli($"vstest \"{publishedTestFile}\" --collect:\"XPlat Code Coverage\" --ResultsDirectory:\"{clonedTemplateProject.ProjectRootPath}\" /settings:\"{runSettingsPath}\" --diag:{Path.Combine(clonedTemplateProject.ProjectRootPath, "log.txt")}", out standardOutput, out standardError);
+      Assert.Equal(0, DotnetCli($"vstest \"{publishedTestFile}\" --collect:\"XPlat Code Coverage\" --ResultsDirectory:\"{clonedTemplateProject.ProjectRootPath}\" /settings:\"{runSettingsPath}\" --diag:{Path.Combine(clonedTemplateProject.ProjectRootPath, "log.txt")}", out standardOutput, out standardError));
       Assert.Contains("Passed!", standardOutput);
       AssertCoverage(clonedTemplateProject);
       AssertCollectorsInjection(clonedTemplateProject);

--- a/test/coverlet.integration.tests/DeterministicBuild.cs
+++ b/test/coverlet.integration.tests/DeterministicBuild.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Toni Solarin-Sodara
+// Copyright (c) Toni Solarin-Sodara
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -299,7 +299,7 @@ namespace Coverlet.Integration.Tests
     {
       if (Directory.Exists(testResultsPath))
       {
-        DirectoryInfo hdDirectory = new DirectoryInfo(testResultsPath);
+        DirectoryInfo hdDirectory = new (testResultsPath);
 
         // search for directory "In" which has second copy e.g. '_fv-az365-374_2023-10-10_14_26_42\In\fv-az365-374\coverage.json'
         DirectoryInfo[] intermediateFolder = hdDirectory.GetDirectories("In", SearchOption.AllDirectories);
@@ -315,7 +315,7 @@ namespace Coverlet.Integration.Tests
     {
       if (Directory.Exists(directory))
       {
-        DirectoryInfo hdDirectory = new DirectoryInfo(directory);
+        DirectoryInfo hdDirectory = new (directory);
         FileInfo[] filesInDir = hdDirectory.GetFiles("log.*.txt");
 
         foreach (FileInfo foundFile in filesInDir)
@@ -343,7 +343,7 @@ namespace Coverlet.Integration.Tests
     {
       if (Directory.Exists(directory))
       {
-        DirectoryInfo hdDirectory = new DirectoryInfo(directory);
+        DirectoryInfo hdDirectory = new (directory);
         FileInfo[] filesInDir = hdDirectory.GetFiles("coverage.cobertura.xml");
 
         foreach (FileInfo foundFile in filesInDir)

--- a/test/coverlet.integration.tests/Msbuild.cs
+++ b/test/coverlet.integration.tests/Msbuild.cs
@@ -45,7 +45,7 @@ namespace Coverlet.Integration.Tests
       }
       Assert.Equal(0, result);
       Assert.Contains("Passed!", standardOutput, StringComparison.Ordinal);
-      Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput, StringComparison.Ordinal);
+      Assert.Contains("| coverletsamplelib.integration.template | 50%  | 100%   | 50%    |", standardOutput, StringComparison.Ordinal);
       string coverageFileName = $"coverage.json";
       Assert.True(File.Exists(Path.Combine(clonedTemplateProject.ProjectRootPath, coverageFileName)));
       AssertCoverage(clonedTemplateProject, coverageFileName);
@@ -66,7 +66,7 @@ namespace Coverlet.Integration.Tests
       }
       Assert.Equal(0, result);
       Assert.Contains("Passed!", standardOutput, StringComparison.Ordinal);
-      Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput, StringComparison.Ordinal);
+      Assert.Contains("| coverletsamplelib.integration.template | 50%  | 100%   | 50%    |", standardOutput, StringComparison.Ordinal);
       string coverageFileName = $"coverage.json";
       Assert.True(File.Exists(Path.Combine(clonedTemplateProject.ProjectRootPath, coverageFileName)));
       AssertCoverage(clonedTemplateProject, coverageFileName);
@@ -87,7 +87,7 @@ namespace Coverlet.Integration.Tests
       }
       Assert.Equal(0, result);
       Assert.Contains("Passed!", standardOutput, StringComparison.Ordinal);
-      Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput, StringComparison.Ordinal);
+      Assert.Contains("| coverletsamplelib.integration.template | 50%  | 100%   | 50%    |", standardOutput, StringComparison.Ordinal);
       string coverageFileName = $"file.json";
       Assert.True(File.Exists(Path.Combine(clonedTemplateProject.ProjectRootPath, coverageFileName)));
       AssertCoverage(clonedTemplateProject, coverageFileName);
@@ -99,7 +99,7 @@ namespace Coverlet.Integration.Tests
       using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
       Assert.Equal(0, DotnetCli($"test -c {_buildConfiguration} -f {_buildTargetFramework} \"{clonedTemplateProject.ProjectRootPath}\" /p:CollectCoverage=true /p:Include=\"[{ClonedTemplateProject.AssemblyName}]*DeepThought\" /p:IncludeTestAssembly=true /p:CoverletOutput=\"{clonedTemplateProject.ProjectRootPath}\"\\file.ext", out string standardOutput, out string standardError));
       Assert.Contains("Passed!", standardOutput, StringComparison.Ordinal);
-      Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput, StringComparison.Ordinal);
+      Assert.Contains("| coverletsamplelib.integration.template | 50%  | 100%   | 50%    |", standardOutput, StringComparison.Ordinal);
       string coverageFileName = $"file.ext";
       Assert.True(File.Exists(Path.Combine(clonedTemplateProject.ProjectRootPath, coverageFileName)));
       AssertCoverage(clonedTemplateProject, coverageFileName);
@@ -123,7 +123,7 @@ namespace Coverlet.Integration.Tests
         _output.WriteLine(standardOutput);
       }
       Assert.Contains("Passed!", standardOutput, StringComparison.Ordinal);
-      Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput, StringComparison.Ordinal);
+      Assert.Contains("| coverletsamplelib.integration.template | 50%  | 100%   | 50%    |", standardOutput, StringComparison.Ordinal);
       Assert.True(File.Exists(Path.Combine(clonedTemplateProject.ProjectRootPath, "file.ext")));
       AssertCoverage(clonedTemplateProject, "file.ext");
     }
@@ -142,7 +142,7 @@ namespace Coverlet.Integration.Tests
         _output.WriteLine(standardOutput);
       }
       Assert.Contains("Passed!", standardOutput, StringComparison.Ordinal);
-      Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput, StringComparison.Ordinal);
+      Assert.Contains("| coverletsamplelib.integration.template | 50%  | 100%   | 50%    |", standardOutput, StringComparison.Ordinal);
       string coverageFileName = $"file.ext1.ext2";
       Assert.True(File.Exists(Path.Combine(clonedTemplateProject.ProjectRootPath, coverageFileName)));
       AssertCoverage(clonedTemplateProject, coverageFileName);
@@ -164,7 +164,7 @@ namespace Coverlet.Integration.Tests
         _output.WriteLine(standardOutput);
       }
       Assert.Contains("Passed!", standardOutput, StringComparison.Ordinal);
-      Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput, StringComparison.Ordinal);
+      Assert.Contains("| coverletsamplelib.integration.template | 50%  | 100%   | 50%    |", standardOutput, StringComparison.Ordinal);
 
       foreach (string targetFramework in targetFrameworks)
       {
@@ -191,7 +191,7 @@ namespace Coverlet.Integration.Tests
       }
       Assert.Equal(0, result);
       Assert.Contains("Passed!", standardOutput, StringComparison.Ordinal);
-      Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput, StringComparison.Ordinal);
+      Assert.Contains("| coverletsamplelib.integration.template | 50%  | 100%   | 50%    |", standardOutput, StringComparison.Ordinal);
 
       foreach (string targetFramework in targetFrameworks)
       {
@@ -218,7 +218,7 @@ namespace Coverlet.Integration.Tests
         _output.WriteLine(standardOutput);
       }
       Assert.Contains("Passed!", standardOutput, StringComparison.Ordinal);
-      Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput, StringComparison.Ordinal);
+      Assert.Contains("| coverletsamplelib.integration.template | 50%  | 100%   | 50%    |", standardOutput, StringComparison.Ordinal);
 
       foreach (string targetFramework in targetFrameworks)
       {
@@ -248,7 +248,7 @@ namespace Coverlet.Integration.Tests
         _output.WriteLine(standardOutput);
       }
       Assert.Contains("Passed!", standardOutput, StringComparison.Ordinal);
-      Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput, StringComparison.Ordinal);
+      Assert.Contains("| coverletsamplelib.integration.template | 50%  | 100%   | 50%    |", standardOutput, StringComparison.Ordinal);
 
       foreach (string targetFramework in targetFrameworks)
       {
@@ -281,7 +281,7 @@ namespace Coverlet.Integration.Tests
         _output.WriteLine(standardOutput);
       }
       Assert.Contains("Passed!", standardOutput, StringComparison.Ordinal);
-      Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput, StringComparison.Ordinal);
+      Assert.Contains("| coverletsamplelib.integration.template | 50%  | 100%   | 50%    |", standardOutput, StringComparison.Ordinal);
 
       foreach (string targetFramework in targetFrameworks)
       {
@@ -307,7 +307,7 @@ namespace Coverlet.Integration.Tests
         _output.WriteLine(standardOutput);
       }
       Assert.Contains("Passed!", standardOutput, StringComparison.Ordinal);
-      Assert.Contains("| coverletsamplelib.integration.template | 100% | 100%   | 100%   |", standardOutput, StringComparison.Ordinal);
+      Assert.Contains("| coverletsamplelib.integration.template | 50%  | 100%   | 50%    |", standardOutput, StringComparison.Ordinal);
 
       foreach (string targetFramework in targetFrameworks)
       {

--- a/test/coverlet.integration.tests/coverlet.integration.tests.csproj
+++ b/test/coverlet.integration.tests/coverlet.integration.tests.csproj
@@ -29,6 +29,7 @@
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)src\coverlet.core\coverlet.core.csproj" />
+    <ProjectReference Include="$(RepoRoot)src\coverlet.console\coverlet.console.csproj" />
     <ProjectReference Include="$(RepoRoot)test\coverlet.tests.utils\coverlet.tests.utils.csproj" />
     <ProjectReference Include="$(RepoRoot)test\coverlet.integration.template\coverlet.integration.template.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Update coverlet.console for latest version of [System.CommandLine API](https://github.com/dotnet/command-line-api).

> [!Note]
> New version [2.0.0-beta5.25306.1](https://www.nuget.org/packages/System.CommandLine/2.0.0-beta5.25306.1) of **System.CommandLine** nuget package is available since 19th June 2025.

```
>coverlet.console.exe --help
Description:
  Cross platform .NET Core code coverage tool

Usage:
  coverlet.console <path> [options]

Arguments:
  <path>  Path to the test assembly or application directory.

Options:
  -?, -h, --help                                                     Show help and usage information
  --version                                                          Show version information
  -t, --target (REQUIRED)                                            Path to the test runner application.
  -a, --targetargs                                                   Arguments to be passed to the test runner.
  -o, --output                                                       Output of the generated coverage report
  -v, --verbosity <Detailed|Minimal|Normal|Quiet>                    Sets the verbosity level of the command. Allowed values are quiet, minimal, normal, detailed. [default: Normal]
  -f, --format <cobertura|json|lcov|opencover|teamcity>              Format of the generated coverage report. [default: json]
  --threshold                                                        Exits with error if the coverage % is below value.
  --threshold-type <branch|line|method>                              Coverage type to apply the threshold to. [default: line|branch|method]
  --threshold-stat <Average|Minimum|Total>                           Coverage statistic used to enforce the threshold value. [default: Minimum]
  --exclude                                                          Filter expressions to exclude specific modules and types.
  --include                                                          Filter expressions to include only specific modules and types.
  --exclude-by-file                                                  Glob patterns specifying source files to exclude.
  --include-directory                                                Include directories containing additional assemblies to be instrumented.
  --exclude-by-attribute                                             Attributes to exclude from code coverage.
  --include-test-assembly                                            Specifies whether to report code coverage of the test assembly.
  --single-hit                                                       Specifies whether to limit code coverage hit reporting to a single hit for each location
  --skipautoprops                                                    Neither track nor record auto-implemented properties.
  --merge-with                                                       Path to existing coverage result to merge.
  --use-source-link                                                  Specifies whether to use SourceLink URIs in place of file system paths.
  --does-not-return-attribute                                        Attributes that mark methods that do not return
  --exclude-assemblies-without-sources <MissingAll|MissingAny|None>  Specifies behavior of heuristic to ignore assemblies with missing source documents. [default: MissingAll]
  --source-mapping-file                                              Specifies the path to a SourceRootsMappings file.
  -?, -h, --help                                                     Show help and usage information
  --version                                                          Show version information
```