### PR TITLE
Use ReportGenerator V5.3.6

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-reportgenerator-globaltool": {
-      "version": "5.2.1",
+      "version": "5.3.6",
       "commands": [
         "reportgenerator"
       ]

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,7 +35,7 @@
     <PackageVersion Include="NuGet.Versioning" Version="6.8.0" />
     <PackageVersion Include="Mono.Cecil" Version="0.11.5" />
     <PackageVersion Include="Moq" Version="4.20.70" />
-    <PackageVersion Include="ReportGenerator.Core" Version="5.2.1" />
+    <PackageVersion Include="ReportGenerator.Core" Version="5.3.6" />
     <!--For test issue 809 https://github.com/coverlet-coverage/coverlet/issues/809-->
     <PackageVersion Include="LinqKit.Microsoft.EntityFrameworkCore" Version="7.1.4" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />


### PR DESCRIPTION
The new ReportGenerator version [Fixed issue with Cobertura files with empty class names](https://github.com/danielpalme/ReportGenerator/issues/676)