### PR TITLE
Extra logging in module selection

### DIFF
--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -137,12 +137,20 @@ namespace Coverlet.Core
               _results.Add(result);
               _logger.LogVerbose($"Instrumented module: '{module}'");
             }
+            else
+            {
+              _logger.LogVerbose($"Skipped module: '{module}'");
+            }
           }
           catch (Exception ex)
           {
             _logger.LogWarning($"Unable to instrument module: {module}\n{ex}");
             _instrumentationHelper.RestoreOriginalModule(module, Identifier);
           }
+        }
+        else
+        {
+          _logger.LogVerbose($"Unable to instrument module: '{module}'");
         }
       }
 


### PR DESCRIPTION
I had some trouble debugging why my assembly wasn't picked up by coverlet. I enabled verbose logging but only saw expected modules being excluded. The module I was interested in didn't appear in the output at all. I now know that the pdb file was missing, but having some log output on it would have saved me a lot of debugging time.