### PR TITLE
Add ThresholdAct option to MSBuild task

### DIFF
--- a/Documentation/MSBuildIntegration.md
+++ b/Documentation/MSBuildIntegration.md
@@ -132,6 +132,17 @@ The following command will compare the threshold value with the overall total co
 dotnet test /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line /p:ThresholdStat=total
 ```
 
+You can also specify what action to take when the the coverage is below the threshold value using the `/p:ThresholdAct` option. The accepted values are:
+
+* `fail`: which fails the build and is the default option
+* `warning`: which will not stop the build and only gives a warning console message
+
+The following will give a warning (but let's the build to continue) when the threshold value is below 80:
+
+```bash
+dotnet test /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdAct=warning
+```
+
 ## Excluding From Coverage
 
 ### Attributes

--- a/Documentation/MSBuildIntegration.md
+++ b/Documentation/MSBuildIntegration.md
@@ -132,12 +132,12 @@ The following command will compare the threshold value with the overall total co
 dotnet test /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line /p:ThresholdStat=total
 ```
 
-You can also specify what action to take when the the coverage is below the threshold value using the `/p:ThresholdAct` option. The accepted values are:
+You can also specify what action to take when the coverage is below the threshold value using the `/p:ThresholdAct` option. The accepted values are:
 
 * `fail`: which fails the build and is the default option
 * `warning`: which will not stop the build and only gives a warning console message
 
-The following will give a warning (but let's the build to continue) when the threshold value is below 80:
+The following will give a warning, but allows the build to continue when the threshold value is below 80:
 
 ```bash
 dotnet test /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdAct=warning

--- a/src/coverlet.core/Enums/ThresholdAction.cs
+++ b/src/coverlet.core/Enums/ThresholdAction.cs
@@ -1,0 +1,8 @@
+﻿namespace Coverlet.Core.Enums
+{
+    internal enum ThresholdAction
+    {
+        Fail,
+        Warning
+    }
+}

--- a/src/coverlet.core/Enums/ThresholdAction.cs
+++ b/src/coverlet.core/Enums/ThresholdAction.cs
@@ -1,4 +1,7 @@
-﻿namespace Coverlet.Core.Enums
+// Copyright (c) Toni Solarin-Sodara
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Coverlet.Core.Enums
 {
     internal enum ThresholdAction
     {

--- a/src/coverlet.msbuild.tasks/CoverageResultTask.cs
+++ b/src/coverlet.msbuild.tasks/CoverageResultTask.cs
@@ -38,6 +38,9 @@ namespace Coverlet.MSbuild.Tasks
     public string ThresholdStat { get; set; }
 
     [Required]
+    public string ThresholdAct { get; set; }
+
+    [Required]
     public ITaskItem InstrumenterState { get; set; }
 
     public string CoverletMultiTargetFrameworksCurrentTFM { get; set; }
@@ -190,6 +193,16 @@ namespace Coverlet.MSbuild.Tasks
           thresholdStat = ThresholdStatistic.Total;
         }
 
+        ThresholdAction thresholdAct = ThresholdAction.Fail;
+        if (ThresholdAct.Equals("fail", StringComparison.OrdinalIgnoreCase))
+        {
+          thresholdAct = ThresholdAction.Fail;
+        }
+        else if (ThresholdAct.Equals("warning", StringComparison.OrdinalIgnoreCase))
+        {
+          thresholdAct = ThresholdAction.Warning;
+        }
+
         var coverageTable = new ConsoleTable("Module", "Line", "Branch", "Method");
         var summary = new CoverageSummary();
 
@@ -248,7 +261,16 @@ namespace Coverlet.MSbuild.Tasks
                 $"The {thresholdStat.ToString().ToLower()} method coverage is below the specified {thresholdTypeFlagValues[ThresholdTypeFlags.Method]}");
           }
 
-          throw new Exception(exceptionMessageBuilder.ToString());
+          switch (thresholdAct)
+          {
+            case ThresholdAction.Warning:
+              _logger.LogWarning(exceptionMessageBuilder.ToString());
+              break;
+            case ThresholdAction.Fail:
+              throw new Exception(exceptionMessageBuilder.ToString());
+            default:
+              throw new ArgumentOutOfRangeException(nameof(thresholdAct), thresholdAct, "Unhandled threshold action");
+          }
         }
       }
       catch (Exception ex)

--- a/src/coverlet.msbuild.tasks/coverlet.msbuild.props
+++ b/src/coverlet.msbuild.tasks/coverlet.msbuild.props
@@ -16,6 +16,7 @@
     <Threshold Condition="$(Threshold) == ''">0</Threshold>
     <ThresholdType Condition="$(ThresholdType) == ''">line,branch,method</ThresholdType>
     <ThresholdStat Condition="$(ThresholdStat) == ''">minimum</ThresholdStat>
+    <ThresholdAct Condition="$(ThresholdAct) == ''">fail</ThresholdAct>
     <ExcludeAssembliesWithoutSources Condition="$(ExcludeAssembliesWithoutSources) == ''"></ExcludeAssembliesWithoutSources>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/coverlet.msbuild.tasks/coverlet.msbuild.targets
+++ b/src/coverlet.msbuild.tasks/coverlet.msbuild.targets
@@ -75,6 +75,7 @@
       Threshold="$(Threshold)"
       ThresholdType="$(ThresholdType)"
       ThresholdStat="$(ThresholdStat)"
+      ThresholdAct="$(ThresholdAct)"
       InstrumenterState="$(InstrumenterState)"
       CoverletMultiTargetFrameworksCurrentTFM="$(_coverletMultiTargetFrameworksCurrentTFM)">
       <Output TaskParameter="ReportItems" ItemName="CoverletReport" />

--- a/test/coverlet.msbuild.tasks.tests/CoverageResultTaskTests.cs
+++ b/test/coverlet.msbuild.tasks.tests/CoverageResultTaskTests.cs
@@ -98,6 +98,7 @@ namespace coverlet.msbuild.tasks.tests
         Threshold = "50",
         ThresholdType = "total",
         ThresholdStat = "total",
+        ThresholdAct = "fail",
         InstrumenterState = InstrumenterState
       };
       coverageResultTask.BuildEngine = _buildEngine.Object;


### PR DESCRIPTION
- This will enable the option to choose if the build should fail when the coverage is below the threshold or just give a warning about it
- Based on the initial idea that started here: https://github.com/coverlet-coverage/coverlet/issues/701