### PR TITLE
remove netstandard2.0 referenced packages from Directory.Packages.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
     <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <LangVersion>preview</LangVersion>
-    <NoWarn>$(NoWarn);NU1507;NU5105;CS1591</NoWarn>
+    <NoWarn>$(NoWarn);NU1507;NU5105;CS1591;IDE0008;IDE2000</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RestoreSources>
       https://api.nuget.org/v3/index.json;

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -49,11 +49,7 @@
     <PackageVersion Include="xunit.assemblyfixture" Version="2.2.0" />
     <PackageVersion Include="xunit.assert" Version="2.6.6" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.6" />
-    <PackageVersion Include="System.Buffers" Version="4.5.1" />
-    <PackageVersion Include="System.Memory" Version="4.5.5" />
-    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="6.0.4" />
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="8.0.0" />
-    <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 </Project>

--- a/src/coverlet.collector/coverlet.collector.csproj
+++ b/src/coverlet.collector/coverlet.collector.csproj
@@ -27,7 +27,6 @@
     <Authors>tonerdo</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/coverlet-coverage/coverlet</PackageProjectUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/tonerdo/coverlet/master/_assets/coverlet-icon.svg?sanitize=true</PackageIconUrl>
     <PackageIcon>coverlet-icon.png</PackageIcon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Description>Coverlet is a cross platform code coverage library for .NET, with support for line, branch and method coverage.</Description>

--- a/src/coverlet.console/coverlet.console.csproj
+++ b/src/coverlet.console/coverlet.console.csproj
@@ -16,7 +16,6 @@
     <PackageTags>coverage;testing;unit-test;lcov;opencover;quality</PackageTags>
     <PackageReadmeFile>GlobalTool.md</PackageReadmeFile>
     <PackageReleaseNotes>https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/Changelog.md</PackageReleaseNotes>
-    <PackageIconUrl>https://raw.githubusercontent.com/tonerdo/coverlet/master/_assets/coverlet-icon.svg?sanitize=true</PackageIconUrl>
     <PackageIcon>coverlet-icon.png</PackageIcon>
     <PackageProjectUrl>https://github.com/coverlet-coverage/coverlet</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/coverlet.msbuild.tasks/coverlet.msbuild.tasks.csproj
+++ b/src/coverlet.msbuild.tasks/coverlet.msbuild.tasks.csproj
@@ -28,7 +28,6 @@
     <Authors>tonerdo</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/coverlet-coverage/coverlet</PackageProjectUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/tonerdo/coverlet/master/_assets/coverlet-icon.svg?sanitize=true</PackageIconUrl>
     <PackageIcon>coverlet-icon.png</PackageIcon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <DevelopmentDependency>true</DevelopmentDependency>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -3,6 +3,6 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
     <IsTestProject>true</IsTestProject>
-    <NoWarn>$(NoWarn);NU1301</NoWarn>
+    <NoWarn>$(NoWarn);NU1301;IDE0007</NoWarn>
   </PropertyGroup>
 </Project>

--- a/test/coverlet.core.tests/coverlet.core.tests.csproj
+++ b/test/coverlet.core.tests/coverlet.core.tests.csproj
@@ -27,8 +27,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.Collections.Immutable" />
-    <PackageReference Include="System.Buffers" />
-    <PackageReference Include="System.Memory" />
     <PackageReference Include="System.Text.Encoding.CodePages" />
   </ItemGroup>
 

--- a/test/coverlet.integration.determisticbuild/coverlet.integration.determisticbuild.csproj
+++ b/test/coverlet.integration.determisticbuild/coverlet.integration.determisticbuild.csproj
@@ -26,8 +26,6 @@
     </PackageReference>
     <PackageReference Include="xunit" Version="2.6.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="6.0.4" />
   </ItemGroup>
 </Project>

--- a/test/coverlet.integration.tests/coverlet.integration.tests.csproj
+++ b/test/coverlet.integration.tests/coverlet.integration.tests.csproj
@@ -13,8 +13,6 @@
     <PackageReference Include="NuGet.Packaging" Version="6.6.2"/>
     <PackageReference Include="xunit" Version="2.6.6"/>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6"/>
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="6.0.4" />
   </ItemGroup>
 


### PR DESCRIPTION
The assemblies System.Buffers, System.Net.Http, System.Memory and System.Text.RegularExpressions are referenced with TargetFramework **netstandard2.0** (coverlet.collector, coverlet.msbuild.tasks).