### PR TITLE
remove serialization of CoverletException

### DIFF
--- a/src/coverlet.core/Exceptions.cs
+++ b/src/coverlet.core/Exceptions.cs
@@ -5,25 +5,17 @@ using System;
 
 namespace Coverlet.Core.Exceptions
 {
-  [Serializable]
   public class CoverletException : Exception
   {
     public CoverletException() { }
     public CoverletException(string message) : base(message) { }
-    public CoverletException(string message, System.Exception inner) : base(message, inner) { }
-    protected CoverletException(
-      System.Runtime.Serialization.SerializationInfo info,
-      System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+    public CoverletException(string message, Exception inner) : base(message, inner) { }
   }
 
-  [Serializable]
   internal class CecilAssemblyResolutionException : CoverletException
   {
     public CecilAssemblyResolutionException() { }
     public CecilAssemblyResolutionException(string message) : base(message) { }
-    public CecilAssemblyResolutionException(string message, System.Exception inner) : base(message, inner) { }
-    protected CecilAssemblyResolutionException(
-      System.Runtime.Serialization.SerializationInfo info,
-      System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+    public CecilAssemblyResolutionException(string message, Exception inner) : base(message, inner) { }
   }
 }


### PR DESCRIPTION
[BinaryFormatter removed from .NET 9](https://devblogs.microsoft.com/dotnet/binaryformatter-removed-from-dotnet-9/?hide_banner=true)

[SYSLIB0051: Legacy serialization support APIs are obsolete](https://learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0051)

>If you created a custom type derived from [System.Exception](https://learn.microsoft.com/en-us/dotnet/api/system.exception), consider whether you really need it to be serializable. It's likely that you don't need it to be serializable, as exception serialization is primarily intended to support remoting, and support for remoting was dropped in .NET Core 1.0.