### PR TITLE
Add netstandard2.0 target to coverlet.collector.csproj

### DIFF
--- a/src/legacy/coverlet.collector/coverlet.collector.csproj
+++ b/src/legacy/coverlet.collector/coverlet.collector.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(LEGACY)' == ''">$(NetMinimum);net9.0;$(NetCurrent)</TargetFrameworks>
-    <TargetFrameworks Condition="'$(LEGACY)' != ''">$(NetMinimum);$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(LEGACY)' == ''">$(NetMinimum);net9.0;$(NetCurrent);netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(LEGACY)' != ''">$(NetMinimum);$(NetCurrent);netstandard2.0</TargetFrameworks>
     <AssemblyTitle>coverlet.collector</AssemblyTitle>
     <DevelopmentDependency>true</DevelopmentDependency>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>


### PR DESCRIPTION
Added netstandard2.0 as a target framework for both legacy and non-legacy builds in coverlet.collector.csproj. This enables building the project for .NET Standard 2.0 alongside existing target frameworks.