### PR TITLE
Update SDK and NuGet dependencies to latest patch versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,29 +11,29 @@
     <MicrosoftCodeAnalysisVersion>5.3.0</MicrosoftCodeAnalysisVersion> <!-- .NET 8.0 support -->
     <NugetPackageVersion>7.3.1</NugetPackageVersion>
     <!-- Test Platform, .NET Test SDK and Object Model  -->
-    <MicrosoftNETTestSdkVersion>18.4.0</MicrosoftNETTestSdkVersion>
+    <MicrosoftNETTestSdkVersion>18.5.1</MicrosoftNETTestSdkVersion>
     <XunitV3Version>3.2.2</XunitV3Version>
     <XunitRunnerVisualstudioVersion>3.1.5</XunitRunnerVisualstudioVersion>
-    <MicrosoftTestingPlatformVersion>2.2.1</MicrosoftTestingPlatformVersion>
+    <MicrosoftTestingPlatformVersion>2.2.2</MicrosoftTestingPlatformVersion>
     <MoqVersion>4.20.72</MoqVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="DotNetConfig" Version="1.2.0" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.6" /> <!-- latest stable version netstandard2.0, netstandard2.1, net462 -->
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.7" /> <!-- latest stable version netstandard2.0, netstandard2.1, net462 -->
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.11.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="5.0.0-1.25277.114" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" /> <!-- latest stable version net10.0, net9.0, net8.0 -->
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" /> <!-- latest stable version net10.0, net9.0, net8.0 -->
+    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" /> <!-- latest stable version net10.0, net9.0, net8.0 -->
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" /> <!-- latest stable version net10.0, net9.0, net8.0 -->
      <!-- For test TestInstrument_NetstandardAwareAssemblyResolver_PreserveCompilationContext -->
-    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.7" />
     <!--For test TestInstrument_NetstandardAwareAssemblyResolver_PreserveCompilationContext-->
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageVersion Include="Microsoft.Sbom.Targets" Version="4.1.5" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="$(MicrosoftNETTestSdkVersion)" />
@@ -44,37 +44,37 @@
     <PackageVersion Include="Microsoft.Testing.Extensions.CrashDump" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="Microsoft.Testing.Platform.MSBuild" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="$(MicrosoftTestingPlatformVersion)" />
-    <PackageVersion Include="MSTest" Version="4.2.1" />
-    <PackageVersion Include="MSTest.TestFramework" Version="4.2.1" />
+    <PackageVersion Include="MSTest" Version="4.2.2" />
+    <PackageVersion Include="MSTest.TestFramework" Version="4.2.2" />
     <!-- Nuget -->
     <PackageVersion Include="NuGet.Frameworks" Version="$(NugetPackageVersion)" />
     <PackageVersion Include="NuGet.Packaging" Version="$(NugetPackageVersion)" />
     <PackageVersion Include="NuGet.Versioning" Version="$(NugetPackageVersion)" />
     <PackageVersion Include="Mono.Cecil" Version="0.11.6" />
     <PackageVersion Include="Moq" Version="$(MoqVersion)" />
-    <PackageVersion Include="ReportGenerator.Core" Version="5.5.4" />
+    <PackageVersion Include="ReportGenerator.Core" Version="5.5.7" />
     <!--For test issue 809 https://github.com/coverlet-coverage/coverlet/issues/809-->
     <PackageVersion Include="LinqKit.Microsoft.EntityFrameworkCore" Version="10.0.11" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.6" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.7" />
     <PackageVersion Include="xunit.v3" Version="$(XunitV3Version)" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="$(XunitV3Version)" />
     <PackageVersion Include="xunit.v3.runner.msbuild" Version="$(XunitV3Version)" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="$(XunitRunnerVisualstudioVersion)" />
     <PackageVersion Include="System.Buffers" Version="4.6.1" />
-    <PackageVersion Include="System.Collections.Immutable" Version="10.0.6" />
-    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.6" />
-    <PackageVersion Include="System.Diagnostics.EventLog" Version="10.0.6" />
-    <PackageVersion Include="System.Formats.Asn1" Version="10.0.6" />
-    <PackageVersion Include="System.IO.Pipelines" Version="10.0.6" />
-    <PackageVersion Include="System.Linq.Async" Version="7.0.0" />
+    <PackageVersion Include="System.Collections.Immutable" Version="10.0.7" />
+    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.7" />
+    <PackageVersion Include="System.Diagnostics.EventLog" Version="10.0.7" />
+    <PackageVersion Include="System.Formats.Asn1" Version="10.0.7" />
+    <PackageVersion Include="System.IO.Pipelines" Version="10.0.7" />
+    <PackageVersion Include="System.Linq.Async" Version="7.0.1" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-    <PackageVersion Include="System.Reflection.Metadata" Version="10.0.6" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="10.0.7" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
     <PackageVersion Include="System.Security.AccessControl" Version="6.0.1" />
-    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.6" />
-    <PackageVersion Include="System.Text.Encoding.CodePages" Version="10.0.6" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.6" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.7" />
+    <PackageVersion Include="System.Text.Encoding.CodePages" Version="10.0.7" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.7" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
   </ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.202",
+    "version": "10.0.203",
     "rollForward": "latestFeature"
   },
   "test": {

--- a/test/coverlet.MTP.validation.tests/CollectCoverageTests.cs
+++ b/test/coverlet.MTP.validation.tests/CollectCoverageTests.cs
@@ -736,7 +736,7 @@ public class AsyncDataFetcher
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include=""xunit.v3.mtp-v2"" Version=""3.2.2"" />
-    <PackageReference Include=""Microsoft.Testing.Platform"" Version=""2.2.1"" />
+    <PackageReference Include=""Microsoft.Testing.Platform"" Version=""2.2.2"" />
     <PackageReference Include=""coverlet.MTP"" Version=""{coverletMtpVersion}"" />
     <PackageReference Include=""Microsoft.Testing.Extensions.TrxReport"" Version=""2.2.1"" />
   </ItemGroup>
@@ -885,7 +885,7 @@ public class IntegerFormatter
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include=""xunit.v3.mtp-v2"" Version=""3.2.2"" />
-    <PackageReference Include=""Microsoft.Testing.Platform"" Version=""2.2.1"" />
+    <PackageReference Include=""Microsoft.Testing.Platform"" Version=""2.2.2"" />
     <PackageReference Include=""coverlet.MTP"" Version=""{coverletMtpVersion}"" />
     <PackageReference Include=""Microsoft.Testing.Extensions.TrxReport"" Version=""2.2.1"" />
   </ItemGroup>
@@ -1066,7 +1066,7 @@ public class Issue1843Tests
   <ItemGroup>
     <!-- Use xunit.v3.mtp-v2 which is designed for MTP v2.x -->
     <PackageReference Include=""xunit.v3.mtp-v2"" Version=""3.2.2"" />
-    <PackageReference Include=""Microsoft.Testing.Platform"" Version=""2.2.1"" />
+    <PackageReference Include=""Microsoft.Testing.Platform"" Version=""2.2.2"" />
     <PackageReference Include=""coverlet.MTP"" Version=""{coverletMtpVersion}"" />
     <PackageReference Include=""Microsoft.Testing.Extensions.TrxReport"" Version=""2.2.1"" />
   </ItemGroup>

--- a/test/coverlet.MTP.validation.tests/CollectCoverageTests.cs
+++ b/test/coverlet.MTP.validation.tests/CollectCoverageTests.cs
@@ -738,7 +738,7 @@ public class AsyncDataFetcher
     <PackageReference Include=""xunit.v3.mtp-v2"" Version=""3.2.2"" />
     <PackageReference Include=""Microsoft.Testing.Platform"" Version=""2.2.2"" />
     <PackageReference Include=""coverlet.MTP"" Version=""{coverletMtpVersion}"" />
-    <PackageReference Include=""Microsoft.Testing.Extensions.TrxReport"" Version=""2.2.1"" />
+    <PackageReference Include=""Microsoft.Testing.Extensions.TrxReport"" Version=""2.2.2"" />
   </ItemGroup>
 </Project>");
 
@@ -887,7 +887,7 @@ public class IntegerFormatter
     <PackageReference Include=""xunit.v3.mtp-v2"" Version=""3.2.2"" />
     <PackageReference Include=""Microsoft.Testing.Platform"" Version=""2.2.2"" />
     <PackageReference Include=""coverlet.MTP"" Version=""{coverletMtpVersion}"" />
-    <PackageReference Include=""Microsoft.Testing.Extensions.TrxReport"" Version=""2.2.1"" />
+    <PackageReference Include=""Microsoft.Testing.Extensions.TrxReport"" Version=""2.2.2"" />
   </ItemGroup>
 </Project>");
 
@@ -1068,7 +1068,7 @@ public class Issue1843Tests
     <PackageReference Include=""xunit.v3.mtp-v2"" Version=""3.2.2"" />
     <PackageReference Include=""Microsoft.Testing.Platform"" Version=""2.2.2"" />
     <PackageReference Include=""coverlet.MTP"" Version=""{coverletMtpVersion}"" />
-    <PackageReference Include=""Microsoft.Testing.Extensions.TrxReport"" Version=""2.2.1"" />
+    <PackageReference Include=""Microsoft.Testing.Extensions.TrxReport"" Version=""2.2.2"" />
   </ItemGroup>
 </Project>");
 

--- a/test/coverlet.MTP.validation.tests/ConfigurationFileTests.cs
+++ b/test/coverlet.MTP.validation.tests/ConfigurationFileTests.cs
@@ -751,7 +751,7 @@ public class StringUtils
     <PackageReference Include=""xunit.v3.mtp-v2"" Version=""3.2.2"" />
     <PackageReference Include=""Microsoft.Testing.Platform"" Version=""2.2.2"" />
     <PackageReference Include=""coverlet.MTP"" Version=""{coverletMtpVersion}"" />
-    <PackageReference Include=""Microsoft.Testing.Extensions.TrxReport"" Version=""2.2.1"" />
+    <PackageReference Include=""Microsoft.Testing.Extensions.TrxReport"" Version=""2.2.2"" />
   </ItemGroup>
   <!-- Configuration file must be copied to output directory per documentation -->
   <ItemGroup>
@@ -997,7 +997,7 @@ public class StringUtilsTests
     <PackageReference Include=""xunit.v3.mtp-v2"" Version=""3.2.2"" />
     <PackageReference Include=""Microsoft.Testing.Platform"" Version=""2.2.2"" />
     <PackageReference Include=""coverlet.MTP"" Version=""{coverletMtpVersion}"" />
-    <PackageReference Include=""Microsoft.Testing.Extensions.TrxReport"" Version=""2.2.1"" />
+    <PackageReference Include=""Microsoft.Testing.Extensions.TrxReport"" Version=""2.2.2"" />
   </ItemGroup>
   <!-- testconfig.json must be copied to output directory -->
   <ItemGroup>
@@ -1052,7 +1052,7 @@ public class StringUtilsTests
     <PackageReference Include=""xunit.v3.mtp-v2"" Version=""3.2.2"" />
     <PackageReference Include=""Microsoft.Testing.Platform"" Version=""2.2.2"" />
     <PackageReference Include=""coverlet.MTP"" Version=""{coverletMtpVersion}"" />
-    <PackageReference Include=""Microsoft.Testing.Extensions.TrxReport"" Version=""2.2.1"" />
+    <PackageReference Include=""Microsoft.Testing.Extensions.TrxReport"" Version=""2.2.2"" />
   </ItemGroup>
   <!-- Both config files must be copied to output directory -->
   <ItemGroup>
@@ -1111,7 +1111,7 @@ public class StringUtilsTests
     <PackageReference Include=""xunit.v3.mtp-v2"" Version=""3.2.2"" />
     <PackageReference Include=""Microsoft.Testing.Platform"" Version=""2.2.2"" />
     <PackageReference Include=""coverlet.MTP"" Version=""{coverletMtpVersion}"" />
-    <PackageReference Include=""Microsoft.Testing.Extensions.TrxReport"" Version=""2.2.1"" />
+    <PackageReference Include=""Microsoft.Testing.Extensions.TrxReport"" Version=""2.2.2"" />
   </ItemGroup>
   <!-- Both app-specific and generic testconfig.json must be copied -->
   <ItemGroup>

--- a/test/coverlet.MTP.validation.tests/ConfigurationFileTests.cs
+++ b/test/coverlet.MTP.validation.tests/ConfigurationFileTests.cs
@@ -749,7 +749,7 @@ public class StringUtils
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include=""xunit.v3.mtp-v2"" Version=""3.2.2"" />
-    <PackageReference Include=""Microsoft.Testing.Platform"" Version=""2.2.1"" />
+    <PackageReference Include=""Microsoft.Testing.Platform"" Version=""2.2.2"" />
     <PackageReference Include=""coverlet.MTP"" Version=""{coverletMtpVersion}"" />
     <PackageReference Include=""Microsoft.Testing.Extensions.TrxReport"" Version=""2.2.1"" />
   </ItemGroup>
@@ -995,7 +995,7 @@ public class StringUtilsTests
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include=""xunit.v3.mtp-v2"" Version=""3.2.2"" />
-    <PackageReference Include=""Microsoft.Testing.Platform"" Version=""2.2.1"" />
+    <PackageReference Include=""Microsoft.Testing.Platform"" Version=""2.2.2"" />
     <PackageReference Include=""coverlet.MTP"" Version=""{coverletMtpVersion}"" />
     <PackageReference Include=""Microsoft.Testing.Extensions.TrxReport"" Version=""2.2.1"" />
   </ItemGroup>
@@ -1050,7 +1050,7 @@ public class StringUtilsTests
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include=""xunit.v3.mtp-v2"" Version=""3.2.2"" />
-    <PackageReference Include=""Microsoft.Testing.Platform"" Version=""2.2.1"" />
+    <PackageReference Include=""Microsoft.Testing.Platform"" Version=""2.2.2"" />
     <PackageReference Include=""coverlet.MTP"" Version=""{coverletMtpVersion}"" />
     <PackageReference Include=""Microsoft.Testing.Extensions.TrxReport"" Version=""2.2.1"" />
   </ItemGroup>
@@ -1109,7 +1109,7 @@ public class StringUtilsTests
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include=""xunit.v3.mtp-v2"" Version=""3.2.2"" />
-    <PackageReference Include=""Microsoft.Testing.Platform"" Version=""2.2.1"" />
+    <PackageReference Include=""Microsoft.Testing.Platform"" Version=""2.2.2"" />
     <PackageReference Include=""coverlet.MTP"" Version=""{coverletMtpVersion}"" />
     <PackageReference Include=""Microsoft.Testing.Extensions.TrxReport"" Version=""2.2.1"" />
   </ItemGroup>

--- a/test/coverlet.integration.MTP.tests/coverlet.integration.MTP.tests.csproj
+++ b/test/coverlet.integration.MTP.tests/coverlet.integration.MTP.tests.csproj
@@ -10,15 +10,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
     <!-- Microsoft.TestPlatform.TestHost depends on Newtonsoft.Json -->
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.7" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NuGet.Packaging" Version="$(NugetPackageVersion)" />
     <PackageReference Include="NuGet.Versioning" Version="$(NugetPackageVersion)" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="$(XunitV3Version)" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.6"/>
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.7"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/coverlet.integration.MTP.tests/coverlet.integration.MTP.tests.csproj
+++ b/test/coverlet.integration.MTP.tests/coverlet.integration.MTP.tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="NuGet.Packaging" Version="$(NugetPackageVersion)" />
     <PackageReference Include="NuGet.Versioning" Version="$(NugetPackageVersion)" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="$(XunitV3Version)" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.7"/>
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/coverlet.integration.template/coverlet.integration.template.csproj
+++ b/test/coverlet.integration.template/coverlet.integration.template.csproj
@@ -21,7 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Text.Json" Version="10.0.6"/>
+    <PackageReference Include="System.Text.Json" Version="10.0.7"/>
     <PackageReference Include="Microsoft.Testing.Platform.MSBuild" Version="2.2.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Upgraded .NET SDK to 10.0.203 and updated multiple NuGet packages to their latest patch releases, including Microsoft.NET.Test.Sdk, Microsoft.Testing.Platform (2.2.2), Microsoft.Extensions.*, MSTest, Moq, ReportGenerator.Core, System.CommandLine, and several System.* libraries. Updated all project and test references to Microsoft.Testing.Platform for version consistency.