### PR TITLE
Add architecture docs and diagrams for all integrations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,9 +25,12 @@
         "reportgenerator",
         "reporttypes",
         "runsettings",
+        "targetargs",
+        "TARGETARGS",
         "targetdir",
         "targetframework",
         "teamcity",
+        "testconfig",
         "vstest",
         "xunit"
     ],

--- a/Documentation/Coverlet.Architecture.md
+++ b/Documentation/Coverlet.Architecture.md
@@ -1,0 +1,53 @@
+# Coverlet Architecture Overview
+
+This document summarizes dependencies, responsibilities, and constraints for the main Coverlet packages:
+
+- `coverlet.core`
+- `coverlet.collector`
+- `coverlet.msbuild`
+- `coverlet.console`
+- `coverlet.MTP`
+
+## Package dependency map
+
+```mermaid
+flowchart TB
+    CORE["coverlet.core\n(instrumentation + reporting engine)"]
+
+    COL["coverlet.collector\n(VSTest integration)"] --> CORE
+    MSB["coverlet.msbuild\n(MSBuild integration)"] --> CORE
+    CON["coverlet.console\n(Global tool)"] --> CORE
+    MTP["coverlet.MTP\n(Microsoft Testing Platform integration)"] --> CORE
+
+    VST["VSTest platform"] --> COL
+    BUILD["MSBuild / dotnet test"] --> MSB
+    CLI["CLI process wrapper"] --> CON
+    MTPP["Microsoft.Testing.Platform"] --> MTP
+```
+
+## Responsibilities and constraints by package
+
+| Package | Primary dependencies | Main functionality | Key limitations / constraints |
+| :-- | :-- | :-- | :-- |
+| `coverlet.core` | `Mono.Cecil`, globbing and reporting dependencies | Assembly instrumentation, hit tracking, filtering, line/branch/method coverage aggregation, multi-format report generation | Must operate on assemblies with symbols/PDBs; instrumentation modifies binaries during run; source resolution affects report quality |
+| `coverlet.collector` | `coverlet.core`, VSTest Data Collector APIs | Hooks VSTest collector lifecycle, instruments before test execution, collects hits, emits attachments | Controlled by VSTest lifecycle and output layout (`TestResults/<guid>`); narrower feature set than msbuild/console in some scenarios |
+| `coverlet.msbuild` | `coverlet.core`, MSBuild task APIs | Integrates through targets/tasks before and after tests, report generation, threshold enforcement, merge support | Sensitive to target ordering and command-line escaping; rebuilds between instrumentation and execution can invalidate coverage |
+| `coverlet.console` | `coverlet.core`, `System.CommandLine` | Standalone orchestration around an external target command/process; instrumentation and report output | Requires no-rebuild execution flow; relies on graceful process shutdown for complete hit flushing |
+| `coverlet.MTP` | `coverlet.core`, `Microsoft.Testing.Platform`, configuration stack | Extends MTP runner, instruments assemblies, exchanges state via environment/process lifecycle, generates reports | Architecture is tightly bound to MTP extension model and process lifecycle; current feature set has documented gaps (for example threshold/merge in current docs) |
+
+## Integration execution pattern
+
+```mermaid
+sequenceDiagram
+    participant I as Integration package
+    participant C as coverlet.core
+    participant T as Test execution host
+
+    I->>C: Prepare instrumentation plan
+    C->>C: Rewrite IL + create tracker metadata
+    I->>T: Start test execution
+    T-->>C: Persist hit data (during/after run)
+    I->>C: Load hits + calculate coverage
+    C-->>I: Coverage result(s)
+    I-->>I: Write reports / apply integration-specific behavior
+```

--- a/Documentation/Coverlet.MTP.Integration.md
+++ b/Documentation/Coverlet.MTP.Integration.md
@@ -127,6 +127,7 @@ Coverlet.MTP supports two configuration file formats:
 The `testconfig.json` format is the standard configuration file for Microsoft Testing Platform extensions. Coverlet settings are placed under `platformOptions.Coverlet`:
 
 **File Location Priority:**
+
 - `[appname].testconfig.json` - App-specific configuration (e.g., `MyTests.testconfig.json`)
 - `testconfig.json` - Generic configuration
 
@@ -252,7 +253,7 @@ The legacy `coverlet.mtp.appsettings.json` format is still supported for backwar
 
 Coverlet.MTP uses the following precedence order when determining configuration values:
 
-```
+```text
 Priority 1: Command line options (always take precedence)
 Priority 2: testconfig.json (app-specific > generic)
 Priority 3: coverlet.mtp.appsettings.json (legacy)
@@ -267,6 +268,7 @@ Priority 4: Built-in defaults (only when no configuration file exists)
 - **Defaults apply only without config files:** Built-in defaults are only used when no configuration file is present
 
 **File Priority for testconfig.json:**
+
 1. `[appname].testconfig.json` (e.g., `MyTests.testconfig.json`)
 2. `testconfig.json`
 
@@ -282,6 +284,7 @@ If you prefer to define coverlet options in your `.csproj` file and leverage MSB
 ```
 
 This approach is useful when you want to:
+
 - Use MSBuild variables like `$(AssemblyName)`, `$(MSBuildProjectName)`, or `$(Configuration)`
 - Define configuration at the solution level via `Directory.Build.props`
 - Ensure each test project uses its assembly name as the file prefix automatically
@@ -420,7 +423,7 @@ The `coverlet.MTP` extension integrates with the Microsoft Testing Platform usin
 
 - Threshold validation is not yet supported (planned for future releases)
 - Report merging is not yet supported (use external tools like `dotnet-coverage` or `reportgenerator`)
-- **--coverlet-include-test-assembly is not supported**: In the MTP model the test assembly is also the controller process. Coverlet uses static (ahead-of-time) instrumentation and must rewrite the binary on disk before it is loaded. Because the controller executable is already in use when instrumentation runs, attempting to rewrite it causes a file-sharing violation and the instrumentation of the test assembly fails silently. This is a fundamental architectural constraint of the MTP in-process model, not a bug. See [issue #1911](https://github.com/coverlet-coverage/coverlet/issues/1911) for details. Use coverlet.collector (VSTest) or coverlet.msbuild if you need to measure coverage of the test assembly itself.
+- **`--coverlet-include-test-assembly` may be accepted, but the MTP test assembly itself cannot be instrumented**: In the MTP model the test assembly is also the controller process. Coverlet uses static (ahead-of-time) instrumentation and must rewrite the binary on disk before it is loaded. Because the controller executable is already in use when instrumentation runs, attempting to rewrite that assembly causes instrumentation of the test/controller assembly to fail. Coverlet logs a warning for that module and continues processing other eligible modules; it does not fail silently. This is a fundamental architectural constraint of the MTP in-process model, not a bug. See [issue #1911](https://github.com/coverlet-coverage/coverlet/issues/1911) for details. Use coverlet.collector (VSTest) or coverlet.msbuild if you need to measure coverage of the test assembly itself.
 
 > [!TIP]
 > **Merging coverage files from multiple test runs:**

--- a/Documentation/Coverlet.MTP.Integration.md
+++ b/Documentation/Coverlet.MTP.Integration.md
@@ -420,6 +420,7 @@ The `coverlet.MTP` extension integrates with the Microsoft Testing Platform usin
 
 - Threshold validation is not yet supported (planned for future releases)
 - Report merging is not yet supported (use external tools like `dotnet-coverage` or `reportgenerator`)
+- **--coverlet-include-test-assembly is not supported**: In the MTP model the test assembly is also the controller process. Coverlet uses static (ahead-of-time) instrumentation and must rewrite the binary on disk before it is loaded. Because the controller executable is already in use when instrumentation runs, attempting to rewrite it causes a file-sharing violation and the instrumentation of the test assembly fails silently. This is a fundamental architectural constraint of the MTP in-process model, not a bug. See [issue #1911](https://github.com/coverlet-coverage/coverlet/issues/1911) for details. Use coverlet.collector (VSTest) or coverlet.msbuild if you need to measure coverage of the test assembly itself.
 
 > [!TIP]
 > **Merging coverage files from multiple test runs:**

--- a/Documentation/GlobalTool.md
+++ b/Documentation/GlobalTool.md
@@ -265,6 +265,34 @@ The value for `--source-mapping-file` should be a file with each line being in t
 
 During coverage collection, Coverlet will translate any path that starts with `/_/` to `C:\git\coverlet\` allowing the collector to find the source file.
 
+## Architecture
+
+`coverlet.console` is a host-driven model where the tool owns the orchestration around an external target process.
+
+### Dependencies and functionality
+
+| Component | Dependencies | Functionality |
+| :-- | :-- | :-- |
+| `coverlet.console` | `System.CommandLine`, `coverlet.core` | Parses CLI arguments, instruments target assembly/folder, launches target process, restores binaries, writes reports and exit codes |
+| `coverlet.core` | `Mono.Cecil`, filtering/reporting infrastructure | Performs IL instrumentation, hit tracking, and report generation |
+
+```mermaid
+flowchart LR
+    USER["coverlet <path> --target <runner>"] --> CLI["coverlet.console"]
+    CLI --> CORE["coverlet.core"]
+    CORE --> INST["Instrument assemblies"]
+    CLI --> RUN["Launch target process"]
+    RUN --> HITS["Hit files flushed on graceful shutdown"]
+    CLI --> CORE
+    CORE --> REPORT["coverage outputs"]
+```
+
+### Limitations and constraints
+
+- Target execution must avoid rebuilding instrumented binaries (`--no-build` pattern is required in common workflows).
+- Hit flushing relies on graceful process shutdown; forceful termination can produce incomplete results.
+- The tool has no direct test-platform controller; it only wraps an external command/process.
+- Path and quoting behavior are shell-dependent, especially for multiple filters and arguments.
 ## Exit Codes
 
 Coverlet outputs specific exit codes to better support build automation systems for determining the kind of failure so the appropriate action can be taken.

--- a/Documentation/GlobalTool.md
+++ b/Documentation/GlobalTool.md
@@ -289,10 +289,11 @@ flowchart LR
 
 ### Limitations and constraints
 
-- Target execution must avoid rebuilding instrumented binaries (`--no-build` pattern is required in common workflows).
-- Hit flushing relies on graceful process shutdown; forceful termination can produce incomplete results.
-- The tool has no direct test-platform controller; it only wraps an external command/process.
-- Path and quoting behavior are shell-dependent, especially for multiple filters and arguments.
+* Target execution must avoid rebuilding instrumented binaries (`--no-build` pattern is required in common workflows).
+* Hit flushing relies on graceful process shutdown; forceful termination can produce incomplete results.
+* The tool has no direct test-platform controller; it only wraps an external command/process.
+* Path and quoting behavior are shell-dependent, especially for multiple filters and arguments.
+
 ## Exit Codes
 
 Coverlet outputs specific exit codes to better support build automation systems for determining the kind of failure so the appropriate action can be taken.

--- a/Documentation/MSBuildIntegration.md
+++ b/Documentation/MSBuildIntegration.md
@@ -290,3 +290,32 @@ This setting is particularly helpful when troubleshooting instrumentation issues
 
 > [!NOTE]
 > Make sure instrumented binaries are not deployed into production.
+## Architecture
+
+`coverlet.msbuild` integrates through MSBuild targets/tasks and wraps test execution with instrumentation and report generation steps.
+
+### Dependencies and functionality
+
+| Component | Dependencies | Functionality |
+| :-- | :-- | :-- |
+| `coverlet.msbuild` | MSBuild task APIs (`Microsoft.Build.Utilities.Core`), `coverlet.core` | Adds targets before/after test execution, drives instrumentation, restores binaries, evaluates thresholds, writes reports |
+| `coverlet.core` | `Mono.Cecil`, filtering/reporting infrastructure | Instruments assemblies, collects hits, computes metrics, produces output formats |
+
+```mermaid
+flowchart LR
+    CLI["dotnet test"] --> MSB["MSBuild pipeline"]
+    MSB --> PRE["InstrumentationTask\n(before test target)"]
+    PRE --> CORE["coverlet.core"]
+    MSB --> TEST["VSTest/TestHost execution"]
+    TEST --> POST["CoverageResultTask\n(after test target)"]
+    POST --> CORE
+    CORE --> OUT["coverage.json/xml/etc."]
+    POST --> THR["Threshold evaluation\n(build pass/fail)"]
+```
+
+### Limitations and constraints
+
+- This mode depends on MSBuild target ordering; custom targets can alter expected behavior.
+- Instrumented binaries are modified on disk during test run and then restored (unless restore is explicitly disabled).
+- Quoting/escaping of multi-value properties can vary by shell and OS (notably Linux MSBuild escaping behavior).
+- If projects are rebuilt between instrumentation and execution, collected coverage can be invalid.

--- a/Documentation/MSBuildIntegration.md
+++ b/Documentation/MSBuildIntegration.md
@@ -290,6 +290,7 @@ This setting is particularly helpful when troubleshooting instrumentation issues
 
 > [!NOTE]
 > Make sure instrumented binaries are not deployed into production.
+
 ## Architecture
 
 `coverlet.msbuild` integrates through MSBuild targets/tasks and wraps test execution with instrumentation and report generation steps.
@@ -315,7 +316,7 @@ flowchart LR
 
 ### Limitations and constraints
 
-- This mode depends on MSBuild target ordering; custom targets can alter expected behavior.
-- Instrumented binaries are modified on disk during test run and then restored (unless restore is explicitly disabled).
-- Quoting/escaping of multi-value properties can vary by shell and OS (notably Linux MSBuild escaping behavior).
-- If projects are rebuilt between instrumentation and execution, collected coverage can be invalid.
+* This mode depends on MSBuild target ordering; custom targets can alter expected behavior.
+* Instrumented binaries are modified on disk during test run and then restored (unless restore is explicitly disabled).
+* Quoting/escaping of multi-value properties can vary by shell and OS (notably Linux MSBuild escaping behavior).
+* If projects are rebuilt between instrumentation and execution, collected coverage can be invalid.

--- a/Documentation/VSTestIntegration.md
+++ b/Documentation/VSTestIntegration.md
@@ -180,6 +180,35 @@ When we specify `--collect:"XPlat Code Coverage"` VSTest platform tries to load 
 
 1. In-proc Datacollector: The in-proc collector is loaded in the testhost process executing the tests. This collector will be needed to remove the dependency on the process exit handler to flush the hit files and avoid to hit this [serious known issue](KnownIssues.md#1-vstest-stops-process-execution-earlydotnet-test)
 
+## Architecture
+
+`coverlet.collector` uses a controller-style integration where VSTest remains the orchestrator and Coverlet hooks into collector lifecycle callbacks.
+
+### Dependencies and functionality
+
+| Component | Dependencies | Functionality |
+| :-- | :-- | :-- |
+| `coverlet.collector` | VSTest Data Collector APIs (`Microsoft.TestPlatform.ObjectModel`), `coverlet.core` | Coordinates pre/post test collection, instruments targets, collects hit files, publishes coverage as test attachments |
+| `coverlet.core` | `Mono.Cecil`, filtering/reporting infrastructure | IL instrumentation, hit tracking, coverage aggregation, report generation |
+
+```mermaid
+flowchart LR
+    VS["vstest.console / dotnet test"] --> OOP["Out-of-proc Data Collector\ncoverlet.collector"]
+    VS --> TH["testhost"]
+    TH --> IP["In-proc Data Collector\ncoverlet.collector"]
+    OOP --> CORE["coverlet.core"]
+    IP --> CORE
+    CORE --> REP["coverage reports"]
+    OOP --> ATT["VSTest attachments\nTestResults/<guid>"]
+```
+
+### Limitations and constraints
+
+- Output files are attached under `TestResults/<guid>` (platform-controlled, non-deterministic folder names).
+- Feature parity with other modes is partial (for example, threshold validation and built-in merge are not provided by this integration mode).
+- Coverage collection depends on VSTest data-collector lifecycle and testhost behavior.
+- Requires compatible `Microsoft.NET.Test.Sdk` and collector setup.
+
 ## Known Issues
 
 For a comprehensive list of known issues check the detailed documentation [KnownIssues.md](KnownIssues.md)


### PR DESCRIPTION
Expanded documentation with architecture overviews, Mermaid diagrams, and tables for core, collector, msbuild, console, and MTP packages. Clarified integration responsibilities, constraints, and limitations (including MTP test assembly coverage). No code changes; documentation only.

#1911 