### PR TITLE
Enhance report output: summary table & console reporters

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -7,16 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## Improvements
+### Improvements
 
 - Coverlet with MTP 2 doesn't show test coverage statistic in console [#1907](https://github.com/coverlet-coverage/coverlet/issues/1907)
 - Avoid unnecessary testhost restarts [#1912](https://github.com/coverlet-coverage/coverlet/issues/1912)
 
-## Fixed
+### Fixed
 
 - [BUG] Inconsistent paths in cobertura reports [#1723](https://github.com/coverlet-coverage/coverlet/issues/1723)
 
-## Maintenance
+### Maintenance
 
 - Add architecture docs and diagrams for all integrations [#1927](https://github.com/coverlet-coverage/coverlet/pull/1927)
 - Bump dotnet-reportgenerator-globaltool from 5.5.4 to 5.5.7 [#1917](https://github.com/coverlet-coverage/coverlet/pull/1917)
@@ -28,13 +28,13 @@ coverlet.console 10.0.0
 coverlet.collector 10.0.0
 coverlet.MTP 10.0.0
 
-## Improvements
+### Improvements
 
 - Unique Report Filenames (coverlet.MTP and AzDO) [#1866](https://github.com/coverlet-coverage/coverlet/issues/1866)
 - Add `--coverlet-file-prefix` option for unique report files [#1869](https://github.com/coverlet-coverage/coverlet/pull/1869)
 - Introduce .NET 10 support [#1823](https://github.com/coverlet-coverage/coverlet/pull/1823)
 
-## Fixed
+### Fixed
 
 - Fix [BUG] Wrong branch rate on IAsyncEnumerable for generic type [#1836](https://github.com/coverlet-coverage/coverlet/issues/1836)
 - Fix [BUG] Missing Coverage after moving to MTP [#1843](https://github.com/coverlet-coverage/coverlet/issues/1843)
@@ -44,7 +44,7 @@ coverlet.MTP 10.0.0
 - Fix [BUG] Coverlet.Collector produces empty report when Mediator.SourceGenerator is referenced [#1718](https://github.com/coverlet-coverage/coverlet/issues/1718) by <https://github.com/yusyd>
 - Fix [BUG] Crash during instrumentation (Methods using LibraryImport/DllImport have no body) [#1762](https://github.com/coverlet-coverage/coverlet/issues/1762)
 
-## Maintenance
+### Maintenance
 
 - Add comprehensive async method tests and documentation for issue [#1864](https://github.com/coverlet-coverage/coverlet/pull/1864)
 - Replace Tmds.ExecFunction Package in coverlet.core.coverage.tests [#1833](https://github.com/coverlet-coverage/coverlet/issues/1833)

--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Improvements
+
+- Coverlet with MTP 2 doesn't show test coverage statistic in console [#1907](https://github.com/coverlet-coverage/coverlet/issues/1907)
+- Avoid unnecessary testhost restarts [#1912](https://github.com/coverlet-coverage/coverlet/issues/1912)
+
+## Fixed
+
+- [BUG] Inconsistent paths in cobertura reports [#1723](https://github.com/coverlet-coverage/coverlet/issues/1723)
+
+## Maintenance
+
+- Add architecture docs and diagrams for all integrations [#1927](https://github.com/coverlet-coverage/coverlet/pull/1927)
+- Bump dotnet-reportgenerator-globaltool from 5.5.4 to 5.5.7 [#1917](https://github.com/coverlet-coverage/coverlet/pull/1917)
+
 ## Release date 2026-04-17
 ### Packages
 coverlet.msbuild 10.0.0

--- a/src/coverlet.MTP/Collector/CollectorExtension.cs
+++ b/src/coverlet.MTP/Collector/CollectorExtension.cs
@@ -4,7 +4,9 @@
 #if NETSTANDARD2_0
 using System.Diagnostics;
 #endif
+using System.Globalization;
 using System.Text;
+using ConsoleTables;
 using Coverlet.Core;
 using Coverlet.Core.Abstractions;
 using Coverlet.Core.Helpers;
@@ -405,7 +407,7 @@ internal sealed class CollectorExtension : ITestHostProcessLifetimeHandler, ITes
   /// <summary>
   /// Generates coverage report files. Separated for testability.
   /// </summary>
-  internal List<string> GenerateCoverageReportFiles(
+  internal (List<string> FileReports, List<string> ConsoleOutputs) GenerateCoverageReportFiles(
     CoverageResult result,
     ISourceRootTranslator sourceRootTranslator,
     IFileSystem fileSystem,
@@ -414,6 +416,7 @@ internal sealed class CollectorExtension : ITestHostProcessLifetimeHandler, ITes
     string? filePrefix = null)
   {
     var generatedReports = new List<string>();
+    var consoleOutputs = new List<string>();
 
     foreach (string format in formats)
     {
@@ -424,7 +427,9 @@ internal sealed class CollectorExtension : ITestHostProcessLifetimeHandler, ITes
 
       if (reporter.OutputType == ReporterOutputType.Console)
       {
-        _logger.LogInformation(reporter.Report(result, sourceRootTranslator), important: true);
+        string consoleOutput = reporter.Report(result, sourceRootTranslator);
+        _logger.LogInformation(consoleOutput, important: true);
+        consoleOutputs.Add(consoleOutput);
       }
       else
       {
@@ -440,7 +445,7 @@ internal sealed class CollectorExtension : ITestHostProcessLifetimeHandler, ITes
       }
     }
 
-    return generatedReports;
+    return (generatedReports, consoleOutputs);
   }
 
   private static string InjectTimestamp(string filename, DateTime utcNow)
@@ -450,6 +455,70 @@ internal sealed class CollectorExtension : ITestHostProcessLifetimeHandler, ITes
     if (lastDot > 0)
       return filename.Insert(lastDot, $".{timestamp}");
     return $"{filename}.{timestamp}";
+  }
+
+  /// <summary>
+  /// Displays console-type reporter outputs (e.g. teamcity) directly to the output device.
+  /// An empty line is written before each output to separate it visually.
+  /// </summary>
+  private async Task DisplayConsoleReportOutputsAsync(List<string> consoleOutputs, CancellationToken cancellation)
+  {
+    foreach (string output in consoleOutputs)
+    {
+      await _outputDisplay.DisplayAsync(
+        this,
+        new TextOutputDeviceData(Environment.NewLine + output),
+        cancellation).ConfigureAwait(false);
+    }
+  }
+
+  /// <summary>
+  /// Builds a coverage summary table string matching the format used by coverlet.msbuild and coverlet.console.
+  /// </summary>
+  private static string BuildCoverageSummaryTable(CoverageResult result)
+  {
+    CoverageDetails lineCalc = CoverageSummary.CalculateLineCoverage(result.Modules);
+    CoverageDetails branchCalc = CoverageSummary.CalculateBranchCoverage(result.Modules);
+    CoverageDetails methodCalc = CoverageSummary.CalculateMethodCoverage(result.Modules);
+
+    var moduleTable = new ConsoleTable("Module", "Line", "Branch", "Method");
+    foreach (KeyValuePair<string, Documents> module in result.Modules)
+    {
+      double linePercent = CoverageSummary.CalculateLineCoverage(module.Value).Percent;
+      double branchPercent = CoverageSummary.CalculateBranchCoverage(module.Value).Percent;
+      double methodPercent = CoverageSummary.CalculateMethodCoverage(module.Value).Percent;
+      moduleTable.AddRow(
+        Path.GetFileNameWithoutExtension(module.Key),
+        $"{linePercent.ToString(CultureInfo.InvariantCulture)}%",
+        $"{branchPercent.ToString(CultureInfo.InvariantCulture)}%",
+        $"{methodPercent.ToString(CultureInfo.InvariantCulture)}%");
+    }
+
+    var summaryTable = new ConsoleTable("", "Line", "Branch", "Method");
+    summaryTable.AddRow(
+      "Total",
+      $"{lineCalc.Percent.ToString(CultureInfo.InvariantCulture)}%",
+      $"{branchCalc.Percent.ToString(CultureInfo.InvariantCulture)}%",
+      $"{methodCalc.Percent.ToString(CultureInfo.InvariantCulture)}%");
+    summaryTable.AddRow(
+      "Average",
+      $"{lineCalc.AverageModulePercent.ToString(CultureInfo.InvariantCulture)}%",
+      $"{branchCalc.AverageModulePercent.ToString(CultureInfo.InvariantCulture)}%",
+      $"{methodCalc.AverageModulePercent.ToString(CultureInfo.InvariantCulture)}%");
+
+    return moduleTable.ToStringAlternative() + Environment.NewLine + summaryTable.ToStringAlternative();
+  }
+
+  /// <summary>
+  /// Displays the coverage summary table to the output device.
+  /// </summary>
+  private async Task DisplayCoverageSummaryAsync(CoverageResult result, CancellationToken cancellation)
+  {
+    string table = BuildCoverageSummaryTable(result);
+    await _outputDisplay.DisplayAsync(
+      this,
+      new TextOutputDeviceData(Environment.NewLine + table),
+      cancellation).ConfigureAwait(false);
   }
 
   /// <summary>
@@ -500,7 +569,7 @@ internal sealed class CollectorExtension : ITestHostProcessLifetimeHandler, ITes
     IFileSystem fileSystem = _serviceProvider!.GetRequiredService<IFileSystem>();
 
     // Generate reports (now testable separately)
-    List<string> generatedReports = GenerateCoverageReportFiles(
+    (List<string> generatedReports, List<string> consoleOutputs) = GenerateCoverageReportFiles(
       result,
       sourceRootTranslator,
       fileSystem,
@@ -510,6 +579,12 @@ internal sealed class CollectorExtension : ITestHostProcessLifetimeHandler, ITes
 
     // Display results
     await DisplayGeneratedReportsAsync(generatedReports, cancellation);
+
+    // Display coverage summary table after the file artifacts list
+    await DisplayCoverageSummaryAsync(result, cancellation);
+
+    // Display console-type report output (e.g. teamcity) directly to the output device
+    await DisplayConsoleReportOutputsAsync(consoleOutputs, cancellation);
   }
 
   private string GetHitsFilePath()

--- a/src/coverlet.MTP/Collector/CollectorExtension.cs
+++ b/src/coverlet.MTP/Collector/CollectorExtension.cs
@@ -4,9 +4,7 @@
 #if NETSTANDARD2_0
 using System.Diagnostics;
 #endif
-using System.Globalization;
 using System.Text;
-using ConsoleTables;
 using Coverlet.Core;
 using Coverlet.Core.Abstractions;
 using Coverlet.Core.Helpers;
@@ -428,7 +426,6 @@ internal sealed class CollectorExtension : ITestHostProcessLifetimeHandler, ITes
       if (reporter.OutputType == ReporterOutputType.Console)
       {
         string consoleOutput = reporter.Report(result, sourceRootTranslator);
-        _logger.LogInformation(consoleOutput, important: true);
         consoleOutputs.Add(consoleOutput);
       }
       else
@@ -475,39 +472,8 @@ internal sealed class CollectorExtension : ITestHostProcessLifetimeHandler, ITes
   /// <summary>
   /// Builds a coverage summary table string matching the format used by coverlet.msbuild and coverlet.console.
   /// </summary>
-  private static string BuildCoverageSummaryTable(CoverageResult result)
-  {
-    CoverageDetails lineCalc = CoverageSummary.CalculateLineCoverage(result.Modules);
-    CoverageDetails branchCalc = CoverageSummary.CalculateBranchCoverage(result.Modules);
-    CoverageDetails methodCalc = CoverageSummary.CalculateMethodCoverage(result.Modules);
-
-    var moduleTable = new ConsoleTable("Module", "Line", "Branch", "Method");
-    foreach (KeyValuePair<string, Documents> module in result.Modules)
-    {
-      double linePercent = CoverageSummary.CalculateLineCoverage(module.Value).Percent;
-      double branchPercent = CoverageSummary.CalculateBranchCoverage(module.Value).Percent;
-      double methodPercent = CoverageSummary.CalculateMethodCoverage(module.Value).Percent;
-      moduleTable.AddRow(
-        Path.GetFileNameWithoutExtension(module.Key),
-        $"{linePercent.ToString(CultureInfo.InvariantCulture)}%",
-        $"{branchPercent.ToString(CultureInfo.InvariantCulture)}%",
-        $"{methodPercent.ToString(CultureInfo.InvariantCulture)}%");
-    }
-
-    var summaryTable = new ConsoleTable("", "Line", "Branch", "Method");
-    summaryTable.AddRow(
-      "Total",
-      $"{lineCalc.Percent.ToString(CultureInfo.InvariantCulture)}%",
-      $"{branchCalc.Percent.ToString(CultureInfo.InvariantCulture)}%",
-      $"{methodCalc.Percent.ToString(CultureInfo.InvariantCulture)}%");
-    summaryTable.AddRow(
-      "Average",
-      $"{lineCalc.AverageModulePercent.ToString(CultureInfo.InvariantCulture)}%",
-      $"{branchCalc.AverageModulePercent.ToString(CultureInfo.InvariantCulture)}%",
-      $"{methodCalc.AverageModulePercent.ToString(CultureInfo.InvariantCulture)}%");
-
-    return moduleTable.ToStringAlternative() + Environment.NewLine + summaryTable.ToStringAlternative();
-  }
+  private static string BuildCoverageSummaryTable(CoverageResult result) =>
+    CoverageSummary.BuildCoverageSummaryTable(result.Modules);
 
   /// <summary>
   /// Displays the coverage summary table to the output device.

--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -6,12 +6,10 @@ using System.Collections.Generic;
 using System.CommandLine;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using ConsoleTables;
 using Coverlet.Console.Logging;
 using Coverlet.Core;
 using Coverlet.Core.Abstractions;
@@ -326,39 +324,7 @@ namespace Coverlet.Console
           }
         }
 
-        var coverageTable = new ConsoleTable("Module", "Line", "Branch", "Method");
-
-        CoverageDetails linePercentCalculation = CoverageSummary.CalculateLineCoverage(result.Modules);
-        CoverageDetails branchPercentCalculation = CoverageSummary.CalculateBranchCoverage(result.Modules);
-        CoverageDetails methodPercentCalculation = CoverageSummary.CalculateMethodCoverage(result.Modules);
-
-        double totalLinePercent = linePercentCalculation.Percent;
-        double totalBranchPercent = branchPercentCalculation.Percent;
-        double totalMethodPercent = methodPercentCalculation.Percent;
-
-        double averageLinePercent = linePercentCalculation.AverageModulePercent;
-        double averageBranchPercent = branchPercentCalculation.AverageModulePercent;
-        double averageMethodPercent = methodPercentCalculation.AverageModulePercent;
-
-        foreach (KeyValuePair<string, Documents> _module in result.Modules)
-        {
-          double linePercent = CoverageSummary.CalculateLineCoverage(_module.Value).Percent;
-          double branchPercent = CoverageSummary.CalculateBranchCoverage(_module.Value).Percent;
-          double methodPercent = CoverageSummary.CalculateMethodCoverage(_module.Value).Percent;
-
-          coverageTable.AddRow(Path.GetFileNameWithoutExtension(_module.Key), $"{InvariantFormat(linePercent)}%", $"{InvariantFormat(branchPercent)}%", $"{InvariantFormat(methodPercent)}%");
-        }
-
-        logger.LogInformation(coverageTable.ToStringAlternative());
-
-        coverageTable.Columns.Clear();
-        coverageTable.Rows.Clear();
-
-        coverageTable.AddColumn(new[] { "", "Line", "Branch", "Method" });
-        coverageTable.AddRow("Total", $"{InvariantFormat(totalLinePercent)}%", $"{InvariantFormat(totalBranchPercent)}%", $"{InvariantFormat(totalMethodPercent)}%");
-        coverageTable.AddRow("Average", $"{InvariantFormat(averageLinePercent)}%", $"{InvariantFormat(averageBranchPercent)}%", $"{InvariantFormat(averageMethodPercent)}%");
-
-        logger.LogInformation(coverageTable.ToStringAlternative());
+        logger.LogInformation(CoverageSummary.BuildCoverageSummaryTable(result.Modules));
         if (process.ExitCode > 0)
         {
           s_exitCode = (int)CommandExitCodes.TestFailed;
@@ -402,7 +368,5 @@ namespace Coverlet.Console
       }
 
     }
-
-    static string InvariantFormat(double value) => value.ToString(CultureInfo.InvariantCulture);
   }
 }

--- a/src/coverlet.core/CoverageSummary.cs
+++ b/src/coverlet.core/CoverageSummary.cs
@@ -3,12 +3,53 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
 using System.Linq;
+using ConsoleTables;
 
 namespace Coverlet.Core
 {
   internal class CoverageSummary
   {
+    /// <summary>
+    /// Builds a two-section coverage summary string (per-module table followed by total/average table)
+    /// using the same format as coverlet.console and the legacy msbuild task.
+    /// </summary>
+    public static string BuildCoverageSummaryTable(Modules modules)
+    {
+      CoverageDetails lineCalc = CalculateLineCoverage(modules);
+      CoverageDetails branchCalc = CalculateBranchCoverage(modules);
+      CoverageDetails methodCalc = CalculateMethodCoverage(modules);
+
+      var moduleTable = new ConsoleTable("Module", "Line", "Branch", "Method");
+      foreach (KeyValuePair<string, Documents> module in modules)
+      {
+        double linePercent = CalculateLineCoverage(module.Value).Percent;
+        double branchPercent = CalculateBranchCoverage(module.Value).Percent;
+        double methodPercent = CalculateMethodCoverage(module.Value).Percent;
+        moduleTable.AddRow(
+          Path.GetFileNameWithoutExtension(module.Key),
+          $"{linePercent.ToString(CultureInfo.InvariantCulture)}%",
+          $"{branchPercent.ToString(CultureInfo.InvariantCulture)}%",
+          $"{methodPercent.ToString(CultureInfo.InvariantCulture)}%");
+      }
+
+      var summaryTable = new ConsoleTable(string.Empty, "Line", "Branch", "Method");
+      summaryTable.AddRow(
+        "Total",
+        $"{lineCalc.Percent.ToString(CultureInfo.InvariantCulture)}%",
+        $"{branchCalc.Percent.ToString(CultureInfo.InvariantCulture)}%",
+        $"{methodCalc.Percent.ToString(CultureInfo.InvariantCulture)}%");
+      summaryTable.AddRow(
+        "Average",
+        $"{lineCalc.AverageModulePercent.ToString(CultureInfo.InvariantCulture)}%",
+        $"{branchCalc.AverageModulePercent.ToString(CultureInfo.InvariantCulture)}%",
+        $"{methodCalc.AverageModulePercent.ToString(CultureInfo.InvariantCulture)}%");
+
+      return moduleTable.ToStringAlternative() + Environment.NewLine + summaryTable.ToStringAlternative();
+    }
+
     public static CoverageDetails CalculateLineCoverage(Lines lines)
     {
       var details = new CoverageDetails

--- a/src/coverlet.core/Reporters/TeamCityReporter.cs
+++ b/src/coverlet.core/Reporters/TeamCityReporter.cs
@@ -67,7 +67,7 @@ namespace Coverlet.Core.Reporters
 
     private static void OutputTeamCityServiceMessage(string key, double value, StringBuilder builder)
     {
-      builder.AppendLine($"##teamcity[buildStatisticValue key='{key}' value='{value.ToString("0.##", new CultureInfo("en-US"))}']");
+      builder.AppendLine($"##teamcity[buildStatisticValue key='{key}' value='{value.ToString("0.##", CultureInfo.InvariantCulture)}']");
     }
   }
 }

--- a/src/legacy/coverlet.msbuild.tasks/CoverageResultTask.cs
+++ b/src/legacy/coverlet.msbuild.tasks/CoverageResultTask.cs
@@ -3,11 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
-using ConsoleTables;
 using Coverlet.Core;
 using Coverlet.Core.Abstractions;
 using Coverlet.Core.Enums;
@@ -190,40 +188,8 @@ namespace Coverlet.MSbuild.Tasks
           thresholdStat = ThresholdStatistic.Total;
         }
 
-        var coverageTable = new ConsoleTable("Module", "Line", "Branch", "Method");
-
-        CoverageDetails linePercentCalculation = CoverageSummary.CalculateLineCoverage(result.Modules);
-        CoverageDetails branchPercentCalculation = CoverageSummary.CalculateBranchCoverage(result.Modules);
-        CoverageDetails methodPercentCalculation = CoverageSummary.CalculateMethodCoverage(result.Modules);
-
-        double totalLinePercent = linePercentCalculation.Percent;
-        double totalBranchPercent = branchPercentCalculation.Percent;
-        double totalMethodPercent = methodPercentCalculation.Percent;
-
-        double averageLinePercent = linePercentCalculation.AverageModulePercent;
-        double averageBranchPercent = branchPercentCalculation.AverageModulePercent;
-        double averageMethodPercent = methodPercentCalculation.AverageModulePercent;
-
-        foreach (KeyValuePair<string, Documents> module in result.Modules)
-        {
-          double linePercent = CoverageSummary.CalculateLineCoverage(module.Value).Percent;
-          double branchPercent = CoverageSummary.CalculateBranchCoverage(module.Value).Percent;
-          double methodPercent = CoverageSummary.CalculateMethodCoverage(module.Value).Percent;
-
-          coverageTable.AddRow(Path.GetFileNameWithoutExtension(module.Key), $"{InvariantFormat(linePercent)}%", $"{InvariantFormat(branchPercent)}%", $"{InvariantFormat(methodPercent)}%");
-        }
-
         Console.WriteLine();
-        Console.WriteLine(coverageTable.ToStringAlternative());
-
-        coverageTable.Columns.Clear();
-        coverageTable.Rows.Clear();
-
-        coverageTable.AddColumn(new[] { "", "Line", "Branch", "Method" });
-        coverageTable.AddRow("Total", $"{InvariantFormat(totalLinePercent)}%", $"{InvariantFormat(totalBranchPercent)}%", $"{InvariantFormat(totalMethodPercent)}%");
-        coverageTable.AddRow("Average", $"{InvariantFormat(averageLinePercent)}%", $"{InvariantFormat(averageBranchPercent)}%", $"{InvariantFormat(averageMethodPercent)}%");
-
-        Console.WriteLine(coverageTable.ToStringAlternative());
+        Console.WriteLine(CoverageSummary.BuildCoverageSummaryTable(result.Modules));
 
         ThresholdTypeFlags thresholdTypeFlags = result.GetThresholdTypesBelowThreshold(thresholdTypeFlagValues, thresholdStat);
         if (thresholdTypeFlags != ThresholdTypeFlags.None)
@@ -259,6 +225,5 @@ namespace Coverlet.MSbuild.Tasks
       return true;
     }
 
-    private static string InvariantFormat(double value) => value.ToString(CultureInfo.InvariantCulture);
-  }
-}
+      }
+    }

--- a/test/coverlet.MTP.tests/Collector/CollectorExtensionReportMethodsTests.cs
+++ b/test/coverlet.MTP.tests/Collector/CollectorExtensionReportMethodsTests.cs
@@ -165,7 +165,7 @@ public class CollectorExtensionReportMethodsTests
     collector.ReporterFactoryOverride = mockReporterFactory.Object;
 
     // Act
-    List<string> generatedReports = collector.GenerateCoverageReportFiles(
+    (List<string> generatedReports, List<string> consoleOutputs) = collector.GenerateCoverageReportFiles(
       result,
       _mockSourceRootTranslator.Object,
       _mockFileSystem.Object,
@@ -214,7 +214,7 @@ public class CollectorExtensionReportMethodsTests
     collector.ReporterFactoryOverride = mockReporterFactory.Object;
 
     // Act
-    List<string> generatedReports = collector.GenerateCoverageReportFiles(
+    (List<string> generatedReports, List<string> consoleOutputs) = collector.GenerateCoverageReportFiles(
       result,
       _mockSourceRootTranslator.Object,
       _mockFileSystem.Object,
@@ -252,7 +252,7 @@ public class CollectorExtensionReportMethodsTests
     collector.ReporterFactoryOverride = mockReporterFactory.Object;
 
     // Act
-    List<string> generatedReports = collector.GenerateCoverageReportFiles(
+    (List<string> generatedReports, List<string> consoleOutputs) = collector.GenerateCoverageReportFiles(
       result,
       _mockSourceRootTranslator.Object,
       _mockFileSystem.Object,
@@ -262,6 +262,8 @@ public class CollectorExtensionReportMethodsTests
     // Assert
     Assert.Empty(generatedReports);
     _mockFileSystem.Verify(x => x.WriteAllText(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    Assert.Single(consoleOutputs);
+    Assert.Equal("Console output", consoleOutputs[0]);
   }
 
   [Fact]
@@ -290,7 +292,7 @@ public class CollectorExtensionReportMethodsTests
     collector.ReporterFactoryOverride = mockReporterFactory.Object;
 
     // Act
-    List<string> generatedReports = collector.GenerateCoverageReportFiles(
+    (List<string> generatedReports, List<string> consoleOutputs) = collector.GenerateCoverageReportFiles(
       result,
       _mockSourceRootTranslator.Object,
       _mockFileSystem.Object,
@@ -300,6 +302,8 @@ public class CollectorExtensionReportMethodsTests
     // Assert
     Assert.Single(generatedReports);
     _mockFileSystem.Verify(x => x.WriteAllText(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+    Assert.Single(consoleOutputs);
+    Assert.Equal("Console output", consoleOutputs[0]);
   }
 
   [Fact]
@@ -338,7 +342,7 @@ public class CollectorExtensionReportMethodsTests
     string[] formats = [];
 
     // Act
-    List<string> generatedReports = collector.GenerateCoverageReportFiles(
+    (List<string> generatedReports, List<string> consoleOutputs) = collector.GenerateCoverageReportFiles(
       result,
       _mockSourceRootTranslator.Object,
       _mockFileSystem.Object,
@@ -347,6 +351,7 @@ public class CollectorExtensionReportMethodsTests
 
     // Assert
     Assert.Empty(generatedReports);
+    Assert.Empty(consoleOutputs);
     _mockFileSystem.Verify(x => x.WriteAllText(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
   }
 

--- a/test/coverlet.MTP.tests/Collector/CollectorExtensionTests.GenerateReports.cs
+++ b/test/coverlet.MTP.tests/Collector/CollectorExtensionTests.GenerateReports.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Toni Solarin-Sodara
+// Copyright (c) Toni Solarin-Sodara
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Coverlet.Core;
@@ -279,7 +279,7 @@ public class CollectorExtensionGenerateReportsTests
     string[] formats = ["json"];
 
     // Act
-    List<string> generatedReports = collector.GenerateCoverageReportFiles(
+    (List<string> generatedReports, _) = collector.GenerateCoverageReportFiles(
       coverageResult,
       mockSourceRootTranslator.Object,
       mockFileSystem.Object,
@@ -323,7 +323,7 @@ public class CollectorExtensionGenerateReportsTests
     string filePrefix = "MyProject";
 
     // Act
-    List<string> generatedReports = collector.GenerateCoverageReportFiles(
+    (List<string> generatedReports, _) = collector.GenerateCoverageReportFiles(
       coverageResult,
       mockSourceRootTranslator.Object,
       mockFileSystem.Object,
@@ -367,7 +367,7 @@ public class CollectorExtensionGenerateReportsTests
     string[] formats = ["cobertura"];
 
     // Act
-    List<string> generatedReports = collector.GenerateCoverageReportFiles(
+    (List<string> generatedReports, _) = collector.GenerateCoverageReportFiles(
       coverageResult,
       mockSourceRootTranslator.Object,
       mockFileSystem.Object,
@@ -411,7 +411,7 @@ public class CollectorExtensionGenerateReportsTests
     string[] formats = ["lcov"];
 
     // Act
-    List<string> generatedReports = collector.GenerateCoverageReportFiles(
+    (List<string> generatedReports, _) = collector.GenerateCoverageReportFiles(
       coverageResult,
       mockSourceRootTranslator.Object,
       mockFileSystem.Object,
@@ -462,7 +462,7 @@ public class CollectorExtensionGenerateReportsTests
     string filePrefix = "UnitTests";
 
     // Act
-    List<string> generatedReports = collector.GenerateCoverageReportFiles(
+    (List<string> generatedReports, _) = collector.GenerateCoverageReportFiles(
       coverageResult,
       mockSourceRootTranslator.Object,
       mockFileSystem.Object,
@@ -518,7 +518,7 @@ public class CollectorExtensionGenerateReportsTests
     string[] formats = ["json"];
 
     // Act - Pass a malicious prefix that should be rejected
-    List<string> generatedReports = collector.GenerateCoverageReportFiles(
+    (List<string> generatedReports, _) = collector.GenerateCoverageReportFiles(
       coverageResult,
       mockSourceRootTranslator.Object,
       mockFileSystem.Object,
@@ -568,7 +568,7 @@ public class CollectorExtensionGenerateReportsTests
     string[] formats = ["json"];
 
     // Act - Pass a prefix with invalid filename characters that should be rejected
-    List<string> generatedReports = collector.GenerateCoverageReportFiles(
+    (List<string> generatedReports, _) = collector.GenerateCoverageReportFiles(
       coverageResult,
       mockSourceRootTranslator.Object,
       mockFileSystem.Object,
@@ -615,7 +615,7 @@ public class CollectorExtensionGenerateReportsTests
     string[] formats = ["json"];
 
     // Act - Pass whitespace-only prefix that should be rejected
-    List<string> generatedReports = collector.GenerateCoverageReportFiles(
+    (List<string> generatedReports, _) = collector.GenerateCoverageReportFiles(
       coverageResult,
       mockSourceRootTranslator.Object,
       mockFileSystem.Object,

--- a/test/coverlet.MTP.validation.tests/CollectCoverageTests.cs
+++ b/test/coverlet.MTP.validation.tests/CollectCoverageTests.cs
@@ -285,9 +285,10 @@ public class CollectCoverageTests
 
     Assert.Empty(teamCityFiles);
 
-    // Assert - teamcity service messages appear in standard output
-    Assert.True(result.StandardOutput.Contains("##teamcity["),
-      $"Expected TeamCity service messages (##teamcity[...]) in standard output.\n\n{result.CombinedOutput}");
+    // Assert - teamcity service messages appear in standard output as standalone lines
+    Assert.True(
+      result.StandardOutput.Split('\n').Any(line => line.TrimStart().StartsWith("##teamcity[", StringComparison.Ordinal)),
+      $"Expected at least one output line starting with '##teamcity[' in standard output.\n\n{result.CombinedOutput}");
   }
 
   [Fact]
@@ -319,9 +320,10 @@ public class CollectCoverageTests
       $"Expected no coverage report files on disk for teamcity-only format, but found:\n" +
       $"{string.Join("\n", allCoverageFiles.Select(f => $"  - {f}"))}\n\n{result.CombinedOutput}");
 
-    // Assert - teamcity service messages appear in standard output
-    Assert.True(result.StandardOutput.Contains("##teamcity["),
-      $"Expected TeamCity service messages (##teamcity[...]) in standard output.\n\n{result.CombinedOutput}");
+    // Assert - teamcity service messages appear in standard output as standalone lines
+    Assert.True(
+      result.StandardOutput.Split('\n').Any(line => line.TrimStart().StartsWith("##teamcity[", StringComparison.Ordinal)),
+      $"Expected at least one output line starting with '##teamcity[' in standard output.\n\n{result.CombinedOutput}");
   }
 
   [Fact]

--- a/test/coverlet.MTP.validation.tests/CollectCoverageTests.cs
+++ b/test/coverlet.MTP.validation.tests/CollectCoverageTests.cs
@@ -250,6 +250,116 @@ public class CollectCoverageTests
   }
 
   [Fact]
+  public async Task CoverageWithTeamCityAndCoberturaFormats_TeamCityWritesToConsoleAndCoberturaToFile()
+  {
+    // Arrange
+    string testName = TestContext.Current.TestCase!.TestMethodName!;
+    using var testProject = CreateTestProject(testName, includeSimpleTest: true);
+    await BuildProject(testProject.SolutionPath);
+
+    // Act
+    var result = await RunTestsWithCoverage(
+      testProject,
+      "--coverlet --coverlet-output-format teamcity --coverlet-output-format cobertura",
+      testName);
+
+    TestContext.Current?.AddAttachment("Test Output", result.CombinedOutput);
+
+    // Assert - test run succeeded
+    Assert.True(result.ExitCode == 0, $"Expected successful test run (exit code 0) but got {result.ExitCode} -> '{result.ErrorText}'.\n\n{result.CombinedOutput}");
+
+    // Assert - cobertura file is written to disk
+    string[] coberturaFiles = Directory.GetFiles(
+      testProject.OutputDirectory,
+      CoverageCoberturaFileName.Insert(CoverageCoberturaFileName.LastIndexOf('.'), ".*"),
+      SearchOption.AllDirectories);
+
+    Assert.True(coberturaFiles.Length > 0,
+      $"No {CoverageCoberturaFileName} found in '{testProject.OutputDirectory}'.\n\n{result.CombinedOutput}");
+
+    // Assert - no teamcity file was written to disk (console reporter writes to stdout only)
+    string[] teamCityFiles = Directory.GetFiles(
+      testProject.OutputDirectory,
+      "*.teamcity*",
+      SearchOption.AllDirectories);
+
+    Assert.Empty(teamCityFiles);
+
+    // Assert - teamcity service messages appear in standard output
+    Assert.True(result.StandardOutput.Contains("##teamcity["),
+      $"Expected TeamCity service messages (##teamcity[...]) in standard output.\n\n{result.CombinedOutput}");
+  }
+
+  [Fact]
+  public async Task CoverageWithTeamCityFormatOnly_WritesServiceMessagesToConsoleWithoutReportFile()
+  {
+    // Arrange
+    string testName = TestContext.Current.TestCase!.TestMethodName!;
+    using var testProject = CreateTestProject(testName, includeSimpleTest: true);
+    await BuildProject(testProject.SolutionPath);
+
+    // Act
+    var result = await RunTestsWithCoverage(
+      testProject,
+      "--coverlet --coverlet-output-format teamcity",
+      testName);
+
+    TestContext.Current?.AddAttachment("Test Output", result.CombinedOutput);
+
+    // Assert - test run succeeded
+    Assert.True(result.ExitCode == 0, $"Expected successful test run (exit code 0) but got {result.ExitCode} -> '{result.ErrorText}'.\n\n{result.CombinedOutput}");
+
+    // Assert - no coverage report file was written to disk at all
+    string[] allCoverageFiles = Directory.GetFiles(
+      testProject.OutputDirectory,
+      "coverage.*",
+      SearchOption.AllDirectories);
+
+    Assert.True(allCoverageFiles.Length == 0,
+      $"Expected no coverage report files on disk for teamcity-only format, but found:\n" +
+      $"{string.Join("\n", allCoverageFiles.Select(f => $"  - {f}"))}\n\n{result.CombinedOutput}");
+
+    // Assert - teamcity service messages appear in standard output
+    Assert.True(result.StandardOutput.Contains("##teamcity["),
+      $"Expected TeamCity service messages (##teamcity[...]) in standard output.\n\n{result.CombinedOutput}");
+  }
+
+  [Fact]
+  public async Task CoverageWithJsonFormat_SummaryTableAppearsInConsoleOutput()
+  {
+    // Arrange
+    string testName = TestContext.Current.TestCase!.TestMethodName!;
+    using var testProject = CreateTestProject(testName, includeSimpleTest: true);
+    await BuildProject(testProject.SolutionPath);
+
+    // Act
+    var result = await RunTestsWithCoverage(
+      testProject,
+      "--coverlet --coverlet-output-format json",
+      testName);
+
+    TestContext.Current?.AddAttachment("Test Output", result.CombinedOutput);
+
+    // Assert - test run succeeded
+    Assert.True(result.ExitCode == 0, $"Expected successful test run (exit code 0) but got {result.ExitCode} -> '{result.ErrorText}'.\n\n{result.CombinedOutput}");
+
+    // Assert - module table header appears in output
+    Assert.True(result.StandardOutput.Contains("| Module"),
+      $"Expected coverage summary module table (| Module |) in standard output.\n\n{result.CombinedOutput}");
+
+    // Assert - SUT module name appears in the table
+    Assert.True(result.StandardOutput.Contains("SampleLibrary"),
+      $"Expected SUT module 'SampleLibrary' in coverage summary table.\n\n{result.CombinedOutput}");
+
+    // Assert - total/average summary table appears
+    Assert.True(result.StandardOutput.Contains("| Total"),
+      $"Expected '| Total' row in coverage summary table.\n\n{result.CombinedOutput}");
+
+    Assert.True(result.StandardOutput.Contains("| Average"),
+      $"Expected '| Average' row in coverage summary table.\n\n{result.CombinedOutput}");
+  }
+
+  [Fact]
   public async Task MultipleCoverageFormats_WithResultsDirectory()
   {
     // Arrange

--- a/test/coverlet.core.tests/Coverage/CoverageSummaryTests.cs
+++ b/test/coverlet.core.tests/Coverage/CoverageSummaryTests.cs
@@ -302,5 +302,68 @@ namespace Coverlet.Core.Tests
       Assert.Equal(50, CoverageSummary.CalculateBranchCoverage(methods).Percent);
       Assert.Equal(50, CoverageSummary.CalculateBranchCoverage(branches).Percent);
     }
+
+    [Fact]
+    public void BuildCoverageSummaryTable_EmptyModules_ContainsTotalAndAverageRowsWithZeroPercent()
+    {
+      var modules = new Modules();
+
+      string result = CoverageSummary.BuildCoverageSummaryTable(modules);
+
+      Assert.Contains("| Module", result);
+      Assert.Contains("| Total", result);
+      Assert.Contains("| Average", result);
+      Assert.Contains("0%", result);
+    }
+
+    [Fact]
+    public void BuildCoverageSummaryTable_SingleModule_ContainsModuleNameAndPercentages()
+    {
+      string result = CoverageSummary.BuildCoverageSummaryTable(_averageCalculationSingleModule);
+
+      // Module name without extension appears in the per-module table
+      Assert.Contains("module", result);
+
+      // Header columns
+      Assert.Contains("| Module", result);
+      Assert.Contains("Line", result);
+      Assert.Contains("Branch", result);
+      Assert.Contains("Method", result);
+
+      // Summary rows
+      Assert.Contains("| Total", result);
+      Assert.Contains("| Average", result);
+
+      // Two table sections are present (the separator between them)
+      Assert.Contains("50%", result);
+      Assert.Contains("100%", result);
+    }
+
+    [Fact]
+    public void BuildCoverageSummaryTable_MultipleModules_ContainsAllModuleNamesAndSummaryRows()
+    {
+      string result = CoverageSummary.BuildCoverageSummaryTable(_averageCalculationMultiModule);
+
+      // Both module names appear in the output
+      Assert.Contains("module", result);
+      Assert.Contains("additionalModule", result);
+
+      // Summary rows are present
+      Assert.Contains("| Total", result);
+      Assert.Contains("| Average", result);
+    }
+
+    [Fact]
+    public void BuildCoverageSummaryTable_SingleModule_TwoSectionsSeparatedByNewLine()
+    {
+      string result = CoverageSummary.BuildCoverageSummaryTable(_averageCalculationSingleModule);
+
+      // The two tables are joined by Environment.NewLine, so at least two table sections exist
+      int firstTableEnd = result.IndexOf("| Total", System.StringComparison.Ordinal);
+      int moduleHeaderPos = result.IndexOf("| Module", System.StringComparison.Ordinal);
+
+      Assert.True(moduleHeaderPos >= 0, "Module table header not found");
+      Assert.True(firstTableEnd > moduleHeaderPos, "Summary table must follow the module table");
+    }
   }
 }


### PR DESCRIPTION
Refactor CollectorExtension to return both file and console outputs from GenerateCoverageReportFiles, enabling correct handling of console-only reporters (e.g., TeamCity). Add methods to display a coverage summary table and console outputs. Update TeamCity reporter to use invariant culture for number formatting. Adjust all affected tests for the new API and add end-to-end tests verifying correct output destinations and summary table display.

#1907 
