### PR TITLE
Handle FieldReference in delegate cache branch detection

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fix Regression in branch coverage for lambda expressions [#1937](https://github.com/coverlet-coverage/coverlet/issues/1937)
+
 ## Release date 2026-05-18
 
 ### Improvements

--- a/src/coverlet.core/Symbols/CecilSymbolHelper.cs
+++ b/src/coverlet.core/Symbols/CecilSymbolHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Toni Solarin-Sodara
+﻿// Copyright (c) Toni Solarin-Sodara
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -256,17 +256,25 @@ namespace Coverlet.Core.Symbols
       Instruction current = instruction.Previous;
       for (int instructionBefore = 2; instructionBefore > 0 && current.Previous != null; current = current.Previous, instructionBefore--)
       {
-        if (current.OpCode == OpCodes.Ldsfld && current.Operand is FieldDefinition fd &&
-            // LambdaCacheField  https://github.com/dotnet/roslyn/blob/e704ca635bd6de70a0250e34c4567c7a28fa9f6d/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNameKind.cs#L31
-            // https://github.com/dotnet/roslyn/blob/master/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNames.cs#L145
-            fd.Name.StartsWith("<>9_") &&
-            IsCompilerGenerated(fd))
+        // LambdaCacheField  https://github.com/dotnet/roslyn/blob/e704ca635bd6de70a0250e34c4567c7a28fa9f6d/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNameKind.cs#L31
+        // https://github.com/dotnet/roslyn/blob/master/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNames.cs#L145
+        // Cecil may surface the operand as FieldDefinition or FieldReference depending on whether the type is in the
+        // same module (FieldDefinition) or referenced from another assembly (FieldReference). Both must be handled.
+        if (current.OpCode == OpCodes.Ldsfld && IsLambdaCachedField(current.Operand))
         {
           return true;
         }
       }
       return false;
     }
+
+    private static bool IsLambdaCachedField(object operand) =>
+      operand switch
+      {
+        FieldDefinition fd when fd.Name.StartsWith("<>9_") && IsCompilerGenerated(fd) => true,
+        FieldReference fr when fr.Name.StartsWith("<>9_") && IsCompilerGenerated(fr.Resolve()) => true,
+        _ => false
+      };
 
     private static bool SkipDelegateCacheField(Instruction instruction)
     {
@@ -297,16 +305,23 @@ namespace Coverlet.Core.Symbols
       Instruction current = instruction.Previous;
       for (int instructionBefore = 2; instructionBefore > 0 && current.Previous != null; current = current.Previous, instructionBefore--)
       {
-        if (current.OpCode == OpCodes.Ldsfld && current.Operand is FieldDefinition fd &&
-            // https://github.com/dotnet/roslyn/blob/main/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNames.cs#L513
-            Regex.IsMatch(fd.Name, "^<\\d+>__") &&
-            IsCompilerGenerated(fd))
+        // https://github.com/dotnet/roslyn/blob/main/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNames.cs#L513
+        // Cecil may surface the operand as FieldDefinition or FieldReference. Both must be handled.
+        if (current.OpCode == OpCodes.Ldsfld && IsDelegateCachedField(current.Operand))
         {
           return true;
         }
       }
       return false;
     }
+
+    private static bool IsDelegateCachedField(object operand) =>
+      operand switch
+      {
+        FieldDefinition fd when Regex.IsMatch(fd.Name, "^<\\d+>__") && IsCompilerGenerated(fd) => true,
+        FieldReference fr when Regex.IsMatch(fr.Name, "^<\\d+>__") && IsCompilerGenerated(fr.Resolve()) => true,
+        _ => false
+      };
 
     private static bool SkipGeneratedBranchForExceptionRethrown(List<Instruction> instructions, Instruction instruction)
     {

--- a/test/coverlet.core.coverage.tests/Coverage/CoverageTests.Lambda.cs
+++ b/test/coverlet.core.coverage.tests/Coverage/CoverageTests.Lambda.cs
@@ -167,5 +167,37 @@ namespace Coverlet.CoreCoverage.Tests
         File.Delete(path);
       }
     }
+
+    [Fact]
+    public void Issue_1937()
+    {
+      // Regression test: the compiler-generated delegate-cache null-check branch (brtrue.s on the
+      // <>9__ cached-lambda field) must NOT appear as a phantom branch in coverage results.
+      // Only the real user-code `if` branch inside the lambda should be reported.
+      string path = Path.GetTempFileName();
+      try
+      {
+        FunctionExecutor.Run(async (string[] pathSerialize) =>
+        {
+          CoveragePrepareResult coveragePrepareResult = await TestInstrumentationHelper.Run<Issue_1937>(instance =>
+            {
+              instance.Test();
+              return Task.CompletedTask;
+            },
+            persistPrepareResultToFile: pathSerialize[0]);
+
+          return 0;
+        }, [path]);
+
+        TestInstrumentationHelper.GetCoverageResult(path)
+          .Document("Instrumentation.Lambda.cs")
+          // Only the real if/else branch inside the lambda must be reported (2 paths, both covered).
+          .ExpectedTotalNumberOfBranches(BuildConfiguration.Debug, 1);
+      }
+      finally
+      {
+        File.Delete(path);
+      }
+    }
   }
 }

--- a/test/coverlet.core.coverage.tests/Coverage/CoverageTests.Lambda.cs
+++ b/test/coverlet.core.coverage.tests/Coverage/CoverageTests.Lambda.cs
@@ -173,7 +173,9 @@ namespace Coverlet.CoreCoverage.Tests
     {
       // Regression test: the compiler-generated delegate-cache null-check branch (brtrue.s on the
       // <>9__ cached-lambda field) must NOT appear as a phantom branch in coverage results.
-      // Only the real user-code `if` branch inside the lambda should be reported.
+      // Only the real user-code `if` branch inside the lambda (line 160) should be reported,
+      // with both paths hit: ordinal 0 (false/fall-through, "other" input) and
+      // ordinal 1 (true/taken, "prefix_test" input).
       string path = Path.GetTempFileName();
       try
       {
@@ -191,8 +193,11 @@ namespace Coverlet.CoreCoverage.Tests
 
         TestInstrumentationHelper.GetCoverageResult(path)
           .Document("Instrumentation.Lambda.cs")
-          // Only the real if/else branch inside the lambda must be reported (2 paths, both covered).
-          .ExpectedTotalNumberOfBranches(BuildConfiguration.Debug, 1);
+          // Exactly one branch point: the user-code `if` on line 160.
+          // No phantom branch from the compiler-generated delegate-cache null-check.
+          .ExpectedTotalNumberOfBranches(BuildConfiguration.Debug, 1)
+          // Both paths of the `if` must be hit exactly once.
+          .AssertBranchesCovered(BuildConfiguration.Debug, (160, 0, 1), (160, 1, 1));
       }
       finally
       {

--- a/test/coverlet.core.coverage.tests/Samples/Instrumentation.Lambda.cs
+++ b/test/coverlet.core.coverage.tests/Samples/Instrumentation.Lambda.cs
@@ -145,4 +145,29 @@ namespace Coverlet.Core.CoverageSamples.Tests
 
     private static int Map(int row) => row + 1;
   }
+
+  // Regression test sample for https://github.com/coverlet-coverage/coverlet/issues/1937
+  // A lambda with a real branch assigned to a delegate property must not generate a phantom
+  // branch from the compiler-generated delegate-cache null-check (brtrue.s on the <>9__ field).
+  public class Issue_1937
+  {
+    public System.Func<string, bool> SecretFilter { get; set; }
+
+    public void Configure()
+    {
+      SecretFilter = (secret) =>
+      {
+        if (secret.StartsWith("prefix_"))
+          return true;
+        return false;
+      };
+    }
+
+    public void Test()
+    {
+      Configure();
+      SecretFilter("prefix_test");
+      SecretFilter("other");
+    }
+  }
 }


### PR DESCRIPTION
Improve CecilSymbolHelper to detect both FieldDefinition and FieldReference for compiler-generated delegate cache fields, preventing phantom branches in coverage. Add regression test and sample for issue #1937 to ensure only real user-code branches are reported.