### PR TITLE
Enhance benchmark results and optimize instrumentation performance

### DIFF
--- a/scripts/Update-BenchmarkHistory.ps1
+++ b/scripts/Update-BenchmarkHistory.ps1
@@ -282,6 +282,52 @@ function Compare-CoverletVersion([string] $a, [string] $b) {
     # Split off pre-release tag
     $splitVersion = {
         param([string] $v)
+        if ($v -match '^(\d+\.\d+\.\d+)(?:-(.+))?$') {
+            [pscustomobject]@{ Core = [version]$Matches[1]; Pre = $Matches[2] }
+        } else {
+            [pscustomobject]@{ Core = [version]'0.0.0'; Pre = $v }
+        }
+    }
+
+    $va = & $splitVersion $a
+    $vb = & $splitVersion $b
+
+    $cmp = $va.Core.CompareTo($vb.Core)
+    if ($cmp -ne 0) { return $cmp }
+
+    # Same core: release beats pre-release
+    if (-not $va.Pre -and $vb.Pre)  { return  1 }   # a is release, b is pre
+    if ($va.Pre  -and -not $vb.Pre) { return -1 }   # a is pre, b is release
+    if (-not $va.Pre -and -not $vb.Pre) { return 0 }
+
+    # Both pre-release: compare label text, then trailing integer
+    $labelCmp = [string]::Compare($va.Pre, $vb.Pre, [System.StringComparison]::OrdinalIgnoreCase)
+    if ($labelCmp -ne 0) {
+        # Try to extract and compare trailing integers for labels like "p0", "p1", "rc2"
+        $numA = if ($va.Pre -match '(\d+)$') { [int]$Matches[1] } else { $null }
+        $numB = if ($vb.Pre -match '(\d+)$') { [int]$Matches[1] } else { $null }
+        $prefA = if ($va.Pre -match '^(\D+)') { $Matches[1] } else { '' }
+        $prefB = if ($vb.Pre -match '^(\D+)') { $Matches[1] } else { '' }
+        if ($prefA -eq $prefB -and $null -ne $numA -and $null -ne $numB) {
+            return $numA.CompareTo($numB)
+        }
+        return $labelCmp
+    }
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Helper: compare two coverlet version strings.
+# Format: major.minor.patch  or  major.minor.patch-prelabel+buildN
+# Release > pre-release ("6.0.0" > "6.0.0-p1").
+# Pre-release labels compared lexically by suffix after the last '-' then by
+# any trailing integer (so "p1" > "p0", "rc2" > "rc1").
+# Returns  1 if $a > $b,  -1 if $a < $b,  0 if equal.
+# ---------------------------------------------------------------------------
+function Compare-CoverletVersion([string] $a, [string] $b) {
+    # Split off pre-release tag
+    $splitVersion = {
+        param([string] $v)
         # Ignore SemVer build metadata (e.g. "+build.123") when ordering versions.
         $v = $v -replace '\+.*$', ''
         if ($v -match '^(\d+\.\d+\.\d+)(?:-(.+))?$') {

--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -253,6 +253,15 @@ namespace Coverlet.Core
         _instrumentationHelper.RestoreOriginalModule(result.ModulePath, Identifier);
       }
 
+      // P11: build a HashSet once across all results so BranchInCompilerGeneratedClass is O(1)
+      // instead of O(modules × array-length) per branch lookup.
+      var branchesInGeneratedClassSet = new HashSet<string>(StringComparer.Ordinal);
+      foreach (InstrumenterResult r in _results)
+      {
+        foreach (string m in r.BranchesInCompiledGeneratedClass)
+          branchesInGeneratedClassSet.Add(m);
+      }
+
       // In case of anonymous delegate compiler generate a custom class and passes it as type.method delegate.
       // If in delegate method we've a branches we need to move these to "actual" class/method that use it.
       // We search "method" with same "Line" of closure class method and add missing branches to it,
@@ -275,7 +284,7 @@ namespace Coverlet.Core
             {
               foreach (BranchInfo branch in method.Value.Branches)
               {
-                if (BranchInCompilerGeneratedClass(method.Key))
+                if (branchesInGeneratedClassSet.Contains(method.Key))
                 {
                   Method actualMethod = GetMethodWithSameLineInSameDocument(document.Value, @class.Key, branch.Line);
 
@@ -333,18 +342,6 @@ namespace Coverlet.Core
       return coverageResult;
     }
 
-    private bool BranchInCompilerGeneratedClass(string methodName)
-    {
-      foreach (InstrumenterResult instrumentedResult in _results)
-      {
-        if (instrumentedResult.BranchesInCompiledGeneratedClass.Contains(methodName))
-        {
-          return true;
-        }
-      }
-      return false;
-    }
-
     private static Method GetMethodWithSameLineInSameDocument(Classes documentClasses, string compilerGeneratedClassName, int branchLine)
     {
       foreach (KeyValuePair<string, Methods> @class in documentClasses)
@@ -395,6 +392,8 @@ namespace Coverlet.Core
 
         // Calculate lines to skip for every hits start/end candidate
         // Nested ranges win on outermost one
+        // P9: pre-group by docIndex once (O(N)) so the inner loop is O(group) instead of O(N)
+        ILookup<int, HitCandidate> hitCandidatesByDoc = result.HitCandidates.ToLookup(x => x.docIndex);
         foreach (HitCandidate hitCandidate in result.HitCandidates)
         {
           if (hitCandidate.isBranch || hitCandidate.end == hitCandidate.start)
@@ -402,7 +401,7 @@ namespace Coverlet.Core
             continue;
           }
 
-          foreach (HitCandidate hitCandidateToCompare in result.HitCandidates.Where(x => x.docIndex.Equals(hitCandidate.docIndex)))
+          foreach (HitCandidate hitCandidateToCompare in hitCandidatesByDoc[hitCandidate.docIndex])
           {
             if (hitCandidate != hitCandidateToCompare && !hitCandidateToCompare.isBranch && hitCandidateToCompare.start > hitCandidate.start &&
                  hitCandidateToCompare.end < hitCandidate.end)

--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -258,6 +258,8 @@ namespace Coverlet.Core
       var branchesInGeneratedClassSet = new HashSet<string>(StringComparer.Ordinal);
       foreach (InstrumenterResult r in _results)
       {
+        if (r.BranchesInCompiledGeneratedClass is null)
+          continue;
         foreach (string m in r.BranchesInCompiledGeneratedClass)
           branchesInGeneratedClassSet.Add(m);
       }

--- a/src/coverlet.core/CoverageSummary.cs
+++ b/src/coverlet.core/CoverageSummary.cs
@@ -52,12 +52,14 @@ namespace Coverlet.Core
 
     public static CoverageDetails CalculateLineCoverage(Lines lines)
     {
-      var details = new CoverageDetails
+      // P8: single-pass foreach avoids LINQ state-machine allocation
+      int covered = 0;
+      foreach (KeyValuePair<int, int> l in lines)
       {
-        Covered = lines.Count(l => l.Value > 0),
-        Total = lines.Count
-      };
-      return details;
+        if (l.Value > 0)
+          covered++;
+      }
+      return new CoverageDetails { Covered = covered, Total = lines.Count };
     }
 
     public static CoverageDetails CalculateLineCoverage(Methods methods)
@@ -266,14 +268,16 @@ namespace Coverlet.Core
 
     public static CoverageDetails CalculateMethodCoverage(Methods methods)
     {
+      // P8: single pass – accumulate Total inside the loop to avoid re-enumerating the Where() query
       var details = new CoverageDetails();
-      IEnumerable<KeyValuePair<string, Method>> methodsWithLines = methods.Where(m => m.Value.Lines.Count > 0);
-      foreach (KeyValuePair<string, Method> method in methodsWithLines)
+      foreach (KeyValuePair<string, Method> method in methods)
       {
+        if (method.Value.Lines.Count == 0)
+          continue;
+        details.Total++;
         CoverageDetails methodCoverage = CalculateMethodCoverage(method.Value.Lines);
         details.Covered += methodCoverage.Covered;
       }
-      details.Total = methodsWithLines.Count();
       return details;
     }
 

--- a/src/coverlet.core/Helpers/InstrumentationHelper.cs
+++ b/src/coverlet.core/Helpers/InstrumentationHelper.cs
@@ -29,6 +29,12 @@ namespace Coverlet.Core.Helpers
 
     // P6: cache compiled (moduleRegex, typeRegex) pairs keyed on the raw filter string so
     // WildcardToRegex + Regex construction runs at most once per unique filter expression.
+    // The cache is capped at MaxFilterCacheEntries: filter strings come from user configuration
+    // (a handful of [Assembly]*Type patterns per run) so growth is bounded in practice, but a
+    // hard ceiling prevents unbounded memory accumulation in long-running hosts (e.g. collectors)
+    // that could theoretically see many distinct filter sets over their lifetime.
+    // Once the cap is reached new patterns are compiled on the fly without caching (safe fall-through).
+    private const int MaxFilterCacheEntries = 512;
     private static readonly ConcurrentDictionary<string, (Regex moduleRegex, Regex typeRegex)> s_filterRegexCache = new();
 
     public InstrumentationHelper(IProcessExitHandler processExitHandler, IRetryHelper retryHelper, IFileSystem fileSystem, ILogger logger, ISourceRootTranslator sourceRootTranslator)
@@ -507,6 +513,16 @@ namespace Coverlet.Core.Helpers
       _logger = logger;
     }
 
+    private static (Regex moduleRegex, Regex typeRegex) CompileFilter(string filter)
+    {
+      string typePattern   = filter.Substring(filter.IndexOf(']') + 1);
+      string modulePattern = filter.Substring(1, filter.IndexOf(']') - 1);
+      return (
+        new Regex(WildcardToRegex(modulePattern), RegexOptions.Compiled, TimeSpan.FromSeconds(10)),
+        new Regex(WildcardToRegex(typePattern),   RegexOptions.Compiled, TimeSpan.FromSeconds(10))
+      );
+    }
+
     private static bool IsTypeFilterMatch(string module, string type, string[] filters)
     {
       Debug.Assert(module != null);
@@ -515,15 +531,13 @@ namespace Coverlet.Core.Helpers
       foreach (string filter in filters)
       {
         // P6: compile each filter expression once; reuse on subsequent calls.
-        (Regex moduleRegex, Regex typeRegex) = s_filterRegexCache.GetOrAdd(filter, static f =>
-        {
-          string typePattern   = f.Substring(f.IndexOf(']') + 1);
-          string modulePattern = f.Substring(1, f.IndexOf(']') - 1);
-          return (
-            new Regex(WildcardToRegex(modulePattern), RegexOptions.Compiled, TimeSpan.FromSeconds(10)),
-            new Regex(WildcardToRegex(typePattern),   RegexOptions.Compiled, TimeSpan.FromSeconds(10))
-          );
-        });
+        // Fall back to compiling without caching when the cap is reached to prevent
+        // unbounded memory growth in long-running hosts that see many distinct filter sets.
+        (Regex moduleRegex, Regex typeRegex) = s_filterRegexCache.TryGetValue(filter, out (Regex moduleRegex, Regex typeRegex) cached)
+          ? cached
+          : s_filterRegexCache.Count < MaxFilterCacheEntries
+            ? s_filterRegexCache.GetOrAdd(filter, static f => CompileFilter(f))
+            : CompileFilter(filter);
 
         if (moduleRegex.IsMatch(module) && typeRegex.IsMatch(type))
           return true;

--- a/src/coverlet.core/Helpers/InstrumentationHelper.cs
+++ b/src/coverlet.core/Helpers/InstrumentationHelper.cs
@@ -27,6 +27,11 @@ namespace Coverlet.Core.Helpers
     private static readonly RegexOptions s_regexOptions =
       RegexOptions.Multiline | RegexOptions.Compiled;
 
+    // P10: cache the validation regex – the pattern never changes so there is no reason to
+    // allocate a new compiled Regex on every IsValidFilterExpression call.
+    private static readonly Regex s_invalidFilterCharsRegex =
+      new(@"[^\w*]", s_regexOptions, TimeSpan.FromSeconds(10));
+
     // P6: cache compiled (moduleRegex, typeRegex) pairs keyed on the raw filter string so
     // WildcardToRegex + Regex construction runs at most once per unique filter expression.
     // The cache is capped at MaxFilterCacheEntries: filter strings come from user configuration
@@ -385,11 +390,15 @@ namespace Coverlet.Core.Helpers
       if (!filter.Contains("]"))
         return false;
 
-      if (filter.Count(f => f == '[') > 1)
-        return false;
-
-      if (filter.Count(f => f == ']') > 1)
-        return false;
+      // P10: single pass over the string to count '[' and ']' simultaneously
+      int openCount = 0, closeCount = 0;
+      foreach (char c in filter)
+      {
+        if (c == '[') openCount++;
+        else if (c == ']') closeCount++;
+        if (openCount > 1 || closeCount > 1)
+          return false;
+      }
 
       if (filter.IndexOf(']') < filter.IndexOf('['))
         return false;
@@ -400,7 +409,8 @@ namespace Coverlet.Core.Helpers
       if (filter.EndsWith("]"))
         return false;
 
-      if (new Regex(@"[^\w*]", s_regexOptions, TimeSpan.FromSeconds(10)).IsMatch(filter.Replace(".", "").Replace("?", "").Replace("[", "").Replace("]", "")))
+      // P10: use the cached compiled regex instead of allocating a new one per call
+      if (s_invalidFilterCharsRegex.IsMatch(filter.Replace(".", "").Replace("?", "").Replace("[", "").Replace("]", "")))
         return false;
 
       return true;

--- a/src/coverlet.core/Helpers/InstrumentationHelper.cs
+++ b/src/coverlet.core/Helpers/InstrumentationHelper.cs
@@ -27,6 +27,10 @@ namespace Coverlet.Core.Helpers
     private static readonly RegexOptions s_regexOptions =
       RegexOptions.Multiline | RegexOptions.Compiled;
 
+    // P6: cache compiled (moduleRegex, typeRegex) pairs keyed on the raw filter string so
+    // WildcardToRegex + Regex construction runs at most once per unique filter expression.
+    private static readonly ConcurrentDictionary<string, (Regex moduleRegex, Regex typeRegex)> s_filterRegexCache = new();
+
     public InstrumentationHelper(IProcessExitHandler processExitHandler, IRetryHelper retryHelper, IFileSystem fileSystem, ILogger logger, ISourceRootTranslator sourceRootTranslator)
     {
       processExitHandler.Add((s, e) => RestoreOriginalModules());
@@ -510,13 +514,18 @@ namespace Coverlet.Core.Helpers
 
       foreach (string filter in filters)
       {
-        string typePattern = filter.Substring(filter.IndexOf(']') + 1);
-        string modulePattern = filter.Substring(1, filter.IndexOf(']') - 1);
+        // P6: compile each filter expression once; reuse on subsequent calls.
+        (Regex moduleRegex, Regex typeRegex) = s_filterRegexCache.GetOrAdd(filter, static f =>
+        {
+          string typePattern   = f.Substring(f.IndexOf(']') + 1);
+          string modulePattern = f.Substring(1, f.IndexOf(']') - 1);
+          return (
+            new Regex(WildcardToRegex(modulePattern), RegexOptions.Compiled, TimeSpan.FromSeconds(10)),
+            new Regex(WildcardToRegex(typePattern),   RegexOptions.Compiled, TimeSpan.FromSeconds(10))
+          );
+        });
 
-        typePattern = WildcardToRegex(typePattern);
-        modulePattern = WildcardToRegex(modulePattern);
-
-        if (Regex.IsMatch(type, typePattern) && Regex.IsMatch(module, modulePattern))
+        if (moduleRegex.IsMatch(module) && typeRegex.IsMatch(type))
           return true;
       }
 

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Toni Solarin-Sodara
+﻿// Copyright (c) Toni Solarin-Sodara
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -50,6 +50,9 @@ namespace Coverlet.Core.Instrumentation
     private List<(SequencePoint firstSequencePoint, SequencePoint lastSequencePoint)> _excludedMethodSections;
     private List<string> _excludedLambdaMethods;
     private ReachabilityHelper _reachabilityHelper;
+    // P2: per-run caches so IsTypeExcluded / IsTypeIncluded are computed at most once per type per module.
+    private readonly Dictionary<string, bool> _typeExcludedCache = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, bool> _typeIncludedCache = new(StringComparer.Ordinal);
 
     public bool SkipModule { get; set; }
 
@@ -163,21 +166,76 @@ namespace Coverlet.Core.Instrumentation
     // If I'm out every my children and every children of my children will be out
     private bool IsTypeExcluded(TypeDefinition type)
     {
+      // P2: check root-type cache first
+      if (_typeExcludedCache.TryGetValue(type.FullName, out bool cachedResult))
+        return cachedResult;
+
+      bool result = ComputeIsTypeExcluded(type);
+      _typeExcludedCache[type.FullName] = result;
+      return result;
+    }
+
+    private bool ComputeIsTypeExcluded(TypeDefinition type)
+    {
       for (TypeDefinition current = type; current != null; current = current.DeclaringType)
       {
+        // P2: reuse cached ancestor results to short-circuit the walk
+        if (current != type && _typeExcludedCache.TryGetValue(current.FullName, out bool ancestorCached))
+        {
+          if (ancestorCached)
+            return true;
+          continue;
+        }
+
         // Check exclude attribute and filters
         // Issue #1843: For compiler-generated state machine types, only ignore CompilerGeneratedAttribute
         // and GeneratedCodeAttribute, but still honor other user-configured exclusion attributes.
         // State machines (async, iterator, async iterator) implement specific interfaces and their coverage is important.
-        if (current.CustomAttributes.Any(attr => IsExcludeAttribute(attr) &&
-                (!IsCompilerGeneratedStateMachineType(current) || !IsCompilerGeneratedOrGeneratedCodeAttribute(attr))) ||
-            _instrumentationHelper.IsTypeExcluded(_module, current.FullName, _parameters.ExcludeFilters))
-        {
+        bool excluded = HasExcludeAttributeForType(current) ||
+            _instrumentationHelper.IsTypeExcluded(_module, current.FullName, _parameters.ExcludeFilters);
+
+        if (current != type)
+          _typeExcludedCache[current.FullName] = excluded;
+
+        if (excluded)
           return true;
-        }
       }
 
       return false;
+    }
+
+    // P3: foreach replacement for the hot-path .Any() on CustomAttributes inside IsTypeExcluded.
+    private bool HasExcludeAttributeForType(TypeDefinition current)
+    {
+      bool isStateMachine = IsCompilerGeneratedStateMachineType(current);
+      foreach (CustomAttribute attr in current.CustomAttributes)
+      {
+        if (IsExcludeAttribute(attr) &&
+            (!isStateMachine || !IsCompilerGeneratedOrGeneratedCodeAttribute(attr)))
+          return true;
+      }
+      return false;
+    }
+
+    // P3: allocation-free check for any exclude attribute on a generic attribute collection.
+    private bool HasExcludeAttribute(IEnumerable<CustomAttribute> attributes)
+    {
+      foreach (CustomAttribute attr in attributes)
+      {
+        if (IsExcludeAttribute(attr))
+          return true;
+      }
+      return false;
+    }
+
+    // P2: cache IsTypeIncluded results for this module run (one Instrumenter instance per module).
+    private bool IsTypeIncludedCached(string typeFullName)
+    {
+      if (_typeIncludedCache.TryGetValue(typeFullName, out bool cached))
+        return cached;
+      bool result = _instrumentationHelper.IsTypeIncluded(_module, typeFullName, _parameters.IncludeFilters);
+      _typeIncludedCache[typeFullName] = result;
+      return result;
     }
 
     /// <summary>
@@ -204,11 +262,17 @@ namespace Coverlet.Core.Instrumentation
     /// </remarks>
     private static bool IsCompilerGeneratedStateMachineType(TypeDefinition type)
     {
-      return type.Interfaces.Any(i =>
-        i.InterfaceType.FullName == "System.Runtime.CompilerServices.IAsyncStateMachine" ||
-        i.InterfaceType.FullName == "System.Collections.IEnumerator" ||
-        i.InterfaceType.FullName.StartsWith("System.Collections.Generic.IEnumerator`") ||
-        i.InterfaceType.FullName.StartsWith("System.Collections.Generic.IAsyncEnumerator`"));
+      // P3: foreach avoids enumerator allocation on a collection walked per type.
+      foreach (InterfaceImplementation iface in type.Interfaces)
+      {
+        string fn = iface.InterfaceType.FullName;
+        if (fn == "System.Runtime.CompilerServices.IAsyncStateMachine" ||
+            fn == "System.Collections.IEnumerator" ||
+            fn.StartsWith("System.Collections.Generic.IEnumerator`", StringComparison.Ordinal) ||
+            fn.StartsWith("System.Collections.Generic.IAsyncEnumerator`", StringComparison.Ordinal))
+          return true;
+      }
+      return false;
     }
 
     // Instrumenting Interlocked which is used for recording hits would cause an infinite loop.
@@ -273,7 +337,7 @@ namespace Coverlet.Core.Instrumentation
         if (
             !Is_System_Threading_Interlocked_CoreLib_Type(type) &&
             !IsTypeExcluded(type) &&
-            _instrumentationHelper.IsTypeIncluded(_module, type.FullName, _parameters.IncludeFilters)
+            IsTypeIncludedCached(type.FullName)
             )
         {
           InstrumentType(type);
@@ -551,7 +615,7 @@ namespace Coverlet.Core.Instrumentation
           // If the async state machine generated by compiler is "associated" to this method we check for exclusions
           // The associated type is specified on attribute constructor
           // https://docs.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.asyncstatemachineattribute.-ctor?view=netcore-3.1
-          if (attribute.ConstructorArguments[0].Value == method.DeclaringType && typeMethod.CustomAttributes.Any(IsExcludeAttribute))
+          if (attribute.ConstructorArguments[0].Value == method.DeclaringType && HasExcludeAttribute(typeMethod.CustomAttributes))
           {
             return true;
           }
@@ -594,7 +658,7 @@ namespace Coverlet.Core.Instrumentation
           continue;
         }
 
-        if (!customAttributes.Any(IsExcludeAttribute))
+        if (!HasExcludeAttribute(customAttributes))
         {
           InstrumentMethod(method);
         }
@@ -610,7 +674,7 @@ namespace Coverlet.Core.Instrumentation
       IEnumerable<MethodDefinition> ctors = type.GetConstructors();
       foreach (MethodDefinition ctor in ctors)
       {
-        if (!ctor.CustomAttributes.Any(IsExcludeAttribute) && !IsCompilerGenerated(ctor))
+        if (!HasExcludeAttribute(ctor.CustomAttributes) && !IsCompilerGenerated(ctor))
         {
           InstrumentMethod(ctor);
         }
@@ -619,7 +683,13 @@ namespace Coverlet.Core.Instrumentation
 
     private static bool IsCompilerGenerated(IMemberDefinition member)
     {
-      return member.CustomAttributes.Any(ca => ca.AttributeType.FullName == typeof(CompilerGeneratedAttribute).FullName);
+      // P3: foreach avoids enumerator allocation.
+      foreach (CustomAttribute ca in member.CustomAttributes)
+      {
+        if (ca.AttributeType.FullName == typeof(CompilerGeneratedAttribute).FullName)
+          return true;
+      }
+      return false;
     }
 
     private void InstrumentMethod(MethodDefinition method)

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -281,28 +281,40 @@ namespace Coverlet.Core.Instrumentation
       return _isCoreLibrary && type.FullName == "System.Threading.Interlocked";
     }
 
-    // Have to do this before we start writing to a module, as we'll get into file
-    // locking issues if we do it while writing.
-    private void CreateReachabilityHelper()
+    // P1: Accept already-read bytes to avoid a second file-open for the reachability pass.
+    private void CreateReachabilityHelper(byte[] moduleBytes)
     {
-      using Stream stream = _fileSystem.NewFileStream(_module, FileMode.Open, FileAccess.Read);
+      using var memStream = new MemoryStream(moduleBytes, writable: false);
       using var resolver = new NetstandardAwareAssemblyResolver(_module, _logger);
       resolver.AddSearchDirectory(Path.GetDirectoryName(_module));
-      var parameters = new ReaderParameters { ReadSymbols = true, AssemblyResolver = resolver };
+      var parameters = new ReaderParameters { ReadSymbols = false, AssemblyResolver = resolver };
       if (_isCoreLibrary)
       {
         parameters.MetadataImporterProvider = new CoreLibMetadataImporterProvider();
       }
 
-      using var module = ModuleDefinition.ReadModule(stream, parameters);
+      using var module = ModuleDefinition.ReadModule(memStream, parameters);
       _reachabilityHelper = ReachabilityHelper.CreateForModule(module, _doesNotReturnAttributes, _logger);
     }
 
     private void InstrumentModule()
     {
-      CreateReachabilityHelper();
-
       using Stream stream = _fileSystem.NewFileStream(_module, FileMode.Open, FileAccess.ReadWrite);
+
+      // P1: Read all bytes once; pass a read-only copy to the reachability pass so that
+      // the file is not opened a second time, saving one full Cecil IL-stream read.
+      byte[] moduleBytes = new byte[stream.Length];
+      int totalRead = 0;
+      while (totalRead < moduleBytes.Length)
+      {
+        int read = stream.Read(moduleBytes, totalRead, moduleBytes.Length - totalRead);
+        if (read == 0)
+          break;
+        totalRead += read;
+      }
+
+      stream.Position = 0;
+      CreateReachabilityHelper(moduleBytes);
       using var resolver = new NetstandardAwareAssemblyResolver(_module, _logger);
       resolver.AddSearchDirectory(Path.GetDirectoryName(_module));
       var parameters = new ReaderParameters { ReadSymbols = true, AssemblyResolver = resolver };

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -303,7 +303,14 @@ namespace Coverlet.Core.Instrumentation
 
       // P1: Read all bytes once; pass a read-only copy to the reachability pass so that
       // the file is not opened a second time, saving one full Cecil IL-stream read.
-      byte[] moduleBytes = new byte[stream.Length];
+      // Guard against assemblies ≥ 2 GB (Cecil itself has the same int-based limit).
+      if (stream.Length > int.MaxValue)
+        throw new InvalidOperationException($"Module '{_module}' is too large to instrument ({stream.Length} bytes).");
+
+      byte[] moduleBytes = new byte[(int)stream.Length];
+#if NETCOREAPP || NET5_0_OR_GREATER
+      stream.ReadExactly(moduleBytes);
+#else
       int totalRead = 0;
       while (totalRead < moduleBytes.Length)
       {
@@ -312,6 +319,7 @@ namespace Coverlet.Core.Instrumentation
           break;
         totalRead += read;
       }
+#endif
 
       stream.Position = 0;
       CreateReachabilityHelper(moduleBytes);

--- a/src/coverlet.core/Reporters/CoberturaReporter.cs
+++ b/src/coverlet.core/Reporters/CoberturaReporter.cs
@@ -92,9 +92,19 @@ namespace Coverlet.Core.Reporters
               method.Add(new XAttribute("complexity", CoverageSummary.CalculateCyclomaticComplexity(meth.Value.Branches)));
 
               var lines = new XElement("lines");
+
+              // P7: pre-group branches by line number once – O(B) – so the line loop is O(1) per line
+              Dictionary<int, List<BranchInfo>> branchesByLine = new Dictionary<int, List<BranchInfo>>(meth.Value.Branches.Count);
+              foreach (BranchInfo b in meth.Value.Branches)
+              {
+                if (!branchesByLine.TryGetValue(b.Line, out List<BranchInfo> list))
+                  branchesByLine[b.Line] = list = [];
+                list.Add(b);
+              }
+
               foreach (KeyValuePair<int, int> ln in meth.Value.Lines)
               {
-                bool isBranchPoint = meth.Value.Branches.Any(b => b.Line == ln.Key);
+                bool isBranchPoint = branchesByLine.ContainsKey(ln.Key);
                 var line = new XElement("line");
                 line.Add(new XAttribute("number", ln.Key.ToString()));
                 line.Add(new XAttribute("hits", ln.Value.ToString()));
@@ -102,7 +112,7 @@ namespace Coverlet.Core.Reporters
 
                 if (isBranchPoint)
                 {
-                  var branches = meth.Value.Branches.Where(b => b.Line == ln.Key).ToList();
+                  List<BranchInfo> branches = branchesByLine[ln.Key];
                   CoverageDetails branchInfoCoverage = CoverageSummary.CalculateBranchCoverage(branches);
                   line.Add(new XAttribute("condition-coverage", $"{branchInfoCoverage.Percent.ToString(CultureInfo.InvariantCulture)}% ({branchInfoCoverage.Covered.ToString(CultureInfo.InvariantCulture)}/{branchInfoCoverage.Total.ToString(CultureInfo.InvariantCulture)})"));
                   var conditions = new XElement("conditions");

--- a/src/coverlet.core/Reporters/CoberturaReporter.cs
+++ b/src/coverlet.core/Reporters/CoberturaReporter.cs
@@ -2,12 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading;
 using System.Xml.Linq;
 
 using Coverlet.Core.Abstractions;
@@ -16,10 +16,6 @@ namespace Coverlet.Core.Reporters
 {
   internal class CoberturaReporter : IReporter
   {
-    // P4: Pool a MemoryStream per thread to avoid a large heap allocation per Report() call.
-    private static readonly ThreadLocal<MemoryStream> s_stream =
-        new(() => new MemoryStream(capacity: 256 * 1024));
-
     public ReporterOutputType OutputType => ReporterOutputType.File;
 
     public string Format => "cobertura";
@@ -150,13 +146,26 @@ namespace Coverlet.Core.Reporters
       coverage.Add(packages);
       xml.Add(coverage);
 
-      MemoryStream stream = s_stream.Value!;
-      stream.SetLength(0);
-      using var streamWriter = new StreamWriter(stream, new UTF8Encoding(false), bufferSize: 1024, leaveOpen: true);
-      xml.Save(streamWriter);
-      streamWriter.Flush();
+      // P4: Use a short-lived MemoryStream and rent a byte buffer from ArrayPool for the
+      // final encoding step. This avoids both the per-call MemoryStream.ToArray() allocation
+      // and the per-thread buffer retention that ThreadLocal<MemoryStream> would cause.
+      using var stream = new MemoryStream(capacity: 256 * 1024);
+      using (var streamWriter = new StreamWriter(stream, new UTF8Encoding(false), bufferSize: 1024, leaveOpen: true))
+      {
+        xml.Save(streamWriter);
+      }
 
-      return Encoding.UTF8.GetString(stream.GetBuffer(), 0, (int)stream.Length);
+      int byteCount = (int)stream.Length;
+      byte[] rentedBuffer = ArrayPool<byte>.Shared.Rent(byteCount);
+      try
+      {
+        stream.GetBuffer().AsSpan(0, byteCount).CopyTo(rentedBuffer);
+        return Encoding.UTF8.GetString(rentedBuffer, 0, byteCount);
+      }
+      finally
+      {
+        ArrayPool<byte>.Shared.Return(rentedBuffer);
+      }
     }
 
     private static IEnumerable<string> GetBasePaths(Modules modules, bool useSourceLink)

--- a/src/coverlet.core/Reporters/CoberturaReporter.cs
+++ b/src/coverlet.core/Reporters/CoberturaReporter.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Xml.Linq;
 
 using Coverlet.Core.Abstractions;
@@ -15,6 +16,10 @@ namespace Coverlet.Core.Reporters
 {
   internal class CoberturaReporter : IReporter
   {
+    // P4: Pool a MemoryStream per thread to avoid a large heap allocation per Report() call.
+    private static readonly ThreadLocal<MemoryStream> s_stream =
+        new(() => new MemoryStream(capacity: 256 * 1024));
+
     public ReporterOutputType OutputType => ReporterOutputType.File;
 
     public string Format => "cobertura";
@@ -145,11 +150,13 @@ namespace Coverlet.Core.Reporters
       coverage.Add(packages);
       xml.Add(coverage);
 
-      using var stream = new MemoryStream();
-      using var streamWriter = new StreamWriter(stream, new UTF8Encoding(false));
+      MemoryStream stream = s_stream.Value!;
+      stream.SetLength(0);
+      using var streamWriter = new StreamWriter(stream, new UTF8Encoding(false), bufferSize: 1024, leaveOpen: true);
       xml.Save(streamWriter);
+      streamWriter.Flush();
 
-      return Encoding.UTF8.GetString(stream.ToArray());
+      return Encoding.UTF8.GetString(stream.GetBuffer(), 0, (int)stream.Length);
     }
 
     private static IEnumerable<string> GetBasePaths(Modules modules, bool useSourceLink)

--- a/src/coverlet.core/Reporters/LcovReporter.cs
+++ b/src/coverlet.core/Reporters/LcovReporter.cs
@@ -4,12 +4,18 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
+using System.Threading;
 using Coverlet.Core.Abstractions;
 
 namespace Coverlet.Core.Reporters
 {
   internal class LcovReporter : IReporter
   {
+    // P4: Pool a StringBuilder per thread to avoid repeated large heap allocations.
+    private static readonly ThreadLocal<StringBuilder> s_sb =
+        new(() => new StringBuilder(capacity: 64 * 1024));
+
     public ReporterOutputType OutputType => ReporterOutputType.File;
 
     public string Format => "lcov";
@@ -23,7 +29,8 @@ namespace Coverlet.Core.Reporters
         throw new NotSupportedException("Deterministic report not supported by lcov reporter");
       }
 
-      var lcov = new List<string>();
+      StringBuilder sb = s_sb.Value!;
+      sb.Clear();
 
       foreach (KeyValuePair<string, Documents> module in result.Modules)
       {
@@ -33,7 +40,7 @@ namespace Coverlet.Core.Reporters
           CoverageDetails docBranchCoverage = CoverageSummary.CalculateBranchCoverage(doc.Value);
           CoverageDetails docMethodCoverage = CoverageSummary.CalculateMethodCoverage(doc.Value);
 
-          lcov.Add("SF:" + doc.Key);
+          sb.Append("SF:").AppendLine(doc.Key);
           foreach (KeyValuePair<string, Methods> @class in doc.Value)
           {
             foreach (KeyValuePair<string, Method> method in @class.Value)
@@ -42,33 +49,42 @@ namespace Coverlet.Core.Reporters
               if (method.Value.Lines.Count == 0)
                 continue;
 
-              lcov.Add($"FN:{method.Value.Lines.First().Key - 1},{method.Key}");
-              lcov.Add($"FNDA:{method.Value.Lines.First().Value},{method.Key}");
+              KeyValuePair<int, int> firstLine = method.Value.Lines.First();
+              sb.Append("FN:").Append(firstLine.Key - 1).Append(',').AppendLine(method.Key);
+              sb.Append("FNDA:").Append(firstLine.Value).Append(',').AppendLine(method.Key);
 
               foreach (KeyValuePair<int, int> line in method.Value.Lines)
-                lcov.Add($"DA:{line.Key},{line.Value}");
+                sb.Append("DA:").Append(line.Key).Append(',').AppendLine(line.Value.ToString());
 
               foreach (BranchInfo branch in method.Value.Branches)
               {
-                lcov.Add($"BRDA:{branch.Line},{branch.Offset},{branch.Path},{branch.Hits}");
+                sb.Append("BRDA:").Append(branch.Line).Append(',')
+                  .Append(branch.Offset).Append(',')
+                  .Append(branch.Path).Append(',')
+                  .AppendLine(branch.Hits.ToString());
               }
             }
           }
 
-          lcov.Add($"LF:{docLineCoverage.Total}");
-          lcov.Add($"LH:{docLineCoverage.Covered}");
+          sb.Append("LF:").AppendLine(docLineCoverage.Total.ToString());
+          sb.Append("LH:").AppendLine(docLineCoverage.Covered.ToString());
 
-          lcov.Add($"BRF:{docBranchCoverage.Total}");
-          lcov.Add($"BRH:{docBranchCoverage.Covered}");
+          sb.Append("BRF:").AppendLine(docBranchCoverage.Total.ToString());
+          sb.Append("BRH:").AppendLine(docBranchCoverage.Covered.ToString());
 
-          lcov.Add($"FNF:{docMethodCoverage.Total}");
-          lcov.Add($"FNH:{docMethodCoverage.Covered}");
+          sb.Append("FNF:").AppendLine(docMethodCoverage.Total.ToString());
+          sb.Append("FNH:").AppendLine(docMethodCoverage.Covered.ToString());
 
-          lcov.Add("end_of_record");
+          sb.AppendLine("end_of_record");
         }
       }
 
-      return string.Join(Environment.NewLine, lcov);
+      // Trim the trailing newline added by the last AppendLine to match the original
+      // string.Join(Environment.NewLine, ...) output which has no trailing newline.
+      if (sb.Length >= Environment.NewLine.Length)
+        sb.Length -= Environment.NewLine.Length;
+
+      return sb.ToString();
     }
   }
 }

--- a/src/coverlet.core/Reporters/LcovReporter.cs
+++ b/src/coverlet.core/Reporters/LcovReporter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -54,26 +55,26 @@ namespace Coverlet.Core.Reporters
               sb.Append("FNDA:").Append(firstLine.Value).Append(',').AppendLine(method.Key);
 
               foreach (KeyValuePair<int, int> line in method.Value.Lines)
-                sb.Append("DA:").Append(line.Key).Append(',').AppendLine(line.Value.ToString());
+                sb.Append("DA:").Append(line.Key).Append(',').Append(line.Value).AppendLine();
 
               foreach (BranchInfo branch in method.Value.Branches)
               {
                 sb.Append("BRDA:").Append(branch.Line).Append(',')
                   .Append(branch.Offset).Append(',')
                   .Append(branch.Path).Append(',')
-                  .AppendLine(branch.Hits.ToString());
+                  .Append(branch.Hits).AppendLine();
               }
             }
           }
 
-          sb.Append("LF:").AppendLine(docLineCoverage.Total.ToString());
-          sb.Append("LH:").AppendLine(docLineCoverage.Covered.ToString());
+          sb.Append("LF:").Append(docLineCoverage.Total).AppendLine();
+          sb.Append("LH:").Append(docLineCoverage.Covered.ToString(CultureInfo.InvariantCulture)).AppendLine();
 
-          sb.Append("BRF:").AppendLine(docBranchCoverage.Total.ToString());
-          sb.Append("BRH:").AppendLine(docBranchCoverage.Covered.ToString());
+          sb.Append("BRF:").Append(docBranchCoverage.Total).AppendLine();
+          sb.Append("BRH:").Append(docBranchCoverage.Covered.ToString(CultureInfo.InvariantCulture)).AppendLine();
 
-          sb.Append("FNF:").AppendLine(docMethodCoverage.Total.ToString());
-          sb.Append("FNH:").AppendLine(docMethodCoverage.Covered.ToString());
+          sb.Append("FNF:").Append(docMethodCoverage.Total).AppendLine();
+          sb.Append("FNH:").Append(docMethodCoverage.Covered.ToString(CultureInfo.InvariantCulture)).AppendLine();
 
           sb.AppendLine("end_of_record");
         }

--- a/src/coverlet.core/Reporters/OpenCoverReporter.cs
+++ b/src/coverlet.core/Reporters/OpenCoverReporter.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Xml.Linq;
 using Coverlet.Core.Abstractions;
 
@@ -13,6 +14,10 @@ namespace Coverlet.Core.Reporters
 {
   internal class OpenCoverReporter : IReporter
   {
+    // P4: Pool a MemoryStream per thread to avoid a large heap allocation per Report() call.
+    private static readonly ThreadLocal<MemoryStream> s_stream =
+        new(() => new MemoryStream(capacity: 256 * 1024));
+
     public ReporterOutputType OutputType => ReporterOutputType.File;
 
     public string Format => "opencover";
@@ -248,11 +253,13 @@ namespace Coverlet.Core.Reporters
       coverage.Add(modules);
       xml.Add(coverage);
 
-      using var stream = new MemoryStream();
-      using var streamWriter = new StreamWriter(stream, new UTF8Encoding(false));
+      MemoryStream stream = s_stream.Value!;
+      stream.SetLength(0);
+      using var streamWriter = new StreamWriter(stream, new UTF8Encoding(false), bufferSize: 1024, leaveOpen: true);
       xml.Save(streamWriter);
+      streamWriter.Flush();
 
-      return Encoding.UTF8.GetString(stream.ToArray());
+      return Encoding.UTF8.GetString(stream.GetBuffer(), 0, (int)stream.Length);
     }
   }
 }

--- a/src/coverlet.core/Reporters/OpenCoverReporter.cs
+++ b/src/coverlet.core/Reporters/OpenCoverReporter.cs
@@ -2,11 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Buffers;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading;
 using System.Xml.Linq;
 using Coverlet.Core.Abstractions;
 
@@ -14,10 +14,6 @@ namespace Coverlet.Core.Reporters
 {
   internal class OpenCoverReporter : IReporter
   {
-    // P4: Pool a MemoryStream per thread to avoid a large heap allocation per Report() call.
-    private static readonly ThreadLocal<MemoryStream> s_stream =
-        new(() => new MemoryStream(capacity: 256 * 1024));
-
     public ReporterOutputType OutputType => ReporterOutputType.File;
 
     public string Format => "opencover";
@@ -253,13 +249,26 @@ namespace Coverlet.Core.Reporters
       coverage.Add(modules);
       xml.Add(coverage);
 
-      MemoryStream stream = s_stream.Value!;
-      stream.SetLength(0);
-      using var streamWriter = new StreamWriter(stream, new UTF8Encoding(false), bufferSize: 1024, leaveOpen: true);
-      xml.Save(streamWriter);
-      streamWriter.Flush();
+      // P4: Use a short-lived MemoryStream and rent a byte buffer from ArrayPool for the
+      // final encoding step. This avoids both the per-call MemoryStream.ToArray() allocation
+      // and the per-thread buffer retention that ThreadLocal<MemoryStream> would cause.
+      using var stream = new MemoryStream(capacity: 256 * 1024);
+      using (var streamWriter = new StreamWriter(stream, new UTF8Encoding(false), bufferSize: 1024, leaveOpen: true))
+      {
+        xml.Save(streamWriter);
+      }
 
-      return Encoding.UTF8.GetString(stream.GetBuffer(), 0, (int)stream.Length);
+      int byteCount = (int)stream.Length;
+      byte[] rentedBuffer = ArrayPool<byte>.Shared.Rent(byteCount);
+      try
+      {
+        stream.GetBuffer().AsSpan(0, byteCount).CopyTo(rentedBuffer);
+        return Encoding.UTF8.GetString(rentedBuffer, 0, byteCount);
+      }
+      finally
+      {
+        ArrayPool<byte>.Shared.Return(rentedBuffer);
+      }
     }
   }
 }

--- a/test/coverlet.benchmark.subject/LambdaWorkload.cs
+++ b/test/coverlet.benchmark.subject/LambdaWorkload.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Toni Solarin-Sodara
+// Copyright (c) Toni Solarin-Sodara
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // LambdaWorkload.cs
@@ -13,251 +13,251 @@ using System.Linq;
 
 namespace coverlet.benchmark.subject
 {
-  /// <summary>
-  /// Methods heavy on closures, lambdas, LINQ, and local functions to exercise the
-  /// compiler-generated-class handling in <c>Coverage.GetCoverageResult</c>.
-  /// </summary>
-  public class LambdaWorkload
-  {
-    // ── simple Func / Action captures ────────────────────────────────────
-
-    public int ApplyTwice(Func<int, int> f, int x) => f(f(x));
-
-    public Func<int, int> Adder(int delta)
+    /// <summary>
+    /// Methods heavy on closures, lambdas, LINQ, and local functions to exercise the
+    /// compiler-generated-class handling in <c>Coverage.GetCoverageResult</c>.
+    /// </summary>
+    public class LambdaWorkload
     {
-      return x => x + delta;     // captures delta
-    }
+        // ── simple Func / Action captures ────────────────────────────────────
 
-    public Func<int, int> Multiplier(int factor)
-    {
-      int local = factor;        // captured local
-      return x => x * local;
-    }
+        public int ApplyTwice(Func<int, int> f, int x) => f(f(x));
 
-    public Func<int, bool> RangeChecker(int lo, int hi)
-    {
-      return x => x >= lo && x <= hi;    // captures two locals
-    }
+        public Func<int, int> Adder(int delta)
+        {
+            return x => x + delta;     // captures delta
+        }
 
-    public Action<int> BuildLogger(List<int> log)
-    {
-      return v =>
-      {
-        if (v > 0)
-          log.Add(v);         // capture + conditional
-      };
-    }
+        public Func<int, int> Multiplier(int factor)
+        {
+            int local = factor;        // captured local
+            return x => x * local;
+        }
 
-    // ── LINQ query bodies ─────────────────────────────────────────────────
+        public Func<int, bool> RangeChecker(int lo, int hi)
+        {
+            return x => x >= lo && x <= hi;    // captures two locals
+        }
 
-    public IEnumerable<int> FilterAndDouble(IEnumerable<int> source, int threshold)
-    {
-      return source
-          .Where(x => x > threshold)
-          .Select(x => x * 2);
-    }
+        public Action<int> BuildLogger(List<int> log)
+        {
+            return v =>
+            {
+                if (v > 0)
+                    log.Add(v);         // capture + conditional
+            };
+        }
 
-    public IEnumerable<int> TopN(IEnumerable<int> source, int n, int minValue)
-    {
-      return source
-          .Where(x => x >= minValue)
-          .OrderByDescending(x => x)
-          .Take(n);
-    }
+        // ── LINQ query bodies ─────────────────────────────────────────────────
 
-    public Dictionary<string, int[]> GroupBySign(IEnumerable<int> source)
-    {
-      return source
-          .GroupBy(x => x > 0 ? "positive" : x < 0 ? "negative" : "zero")
-          .ToDictionary(g => g.Key, g => g.ToArray());
-    }
+        public IEnumerable<int> FilterAndDouble(IEnumerable<int> source, int threshold)
+        {
+            return source
+                .Where(x => x > threshold)
+                .Select(x => x * 2);
+        }
 
-    public bool AnyAbove(IEnumerable<int> source, int threshold)
-        => source.Any(x => x > threshold);
+        public IEnumerable<int> TopN(IEnumerable<int> source, int n, int minValue)
+        {
+            return source
+                .Where(x => x >= minValue)
+                .OrderByDescending(x => x)
+                .Take(n);
+        }
 
-    public int SumPositive(IEnumerable<int> source)
-        => source.Where(x => x > 0).Sum();
+        public Dictionary<string, int[]> GroupBySign(IEnumerable<int> source)
+        {
+            return source
+                .GroupBy(x => x > 0 ? "positive" : x < 0 ? "negative" : "zero")
+                .ToDictionary(g => g.Key, g => g.ToArray());
+        }
 
-    public double AverageNonZero(IEnumerable<double> source)
-    {
-      IEnumerable<double> nonZero = source.Where(x => x != 0.0);
-      return nonZero.Any() ? nonZero.Average() : 0.0;
-    }
+        public bool AnyAbove(IEnumerable<int> source, int threshold)
+            => source.Any(x => x > threshold);
 
-    // ── chained LINQ with multiple lambdas ────────────────────────────────
+        public int SumPositive(IEnumerable<int> source)
+            => source.Where(x => x > 0).Sum();
 
-    public IEnumerable<string> TransformAndFilter(IEnumerable<int> source, int lo, int hi)
-    {
-      return source
-          .Where(x => x >= lo && x <= hi)
-          .Select(x => x switch
-          {
-            < 0 => $"({x})",
-            0 => "zero",
-            _ => x.ToString(),
-          })
-          .Where(s => s.Length > 0)
-          .Distinct()
-          .OrderBy(s => s.Length)
-          .ThenBy(s => s);
-    }
+        public double AverageNonZero(IEnumerable<double> source)
+        {
+            IEnumerable<double> nonZero = source.Where(x => x != 0.0);
+            return nonZero.Any() ? nonZero.Average() : 0.0;
+        }
 
-    public IEnumerable<(int key, int count)> FrequencyMap(IEnumerable<int> source)
-    {
-      return source
-          .GroupBy(x => x)
-          .Select(g => (g.Key, g.Count()))
-          .OrderByDescending(t => t.Item2);
-    }
+        // ── chained LINQ with multiple lambdas ────────────────────────────────
 
-    // ── local functions (closures) ────────────────────────────────────────
+        public IEnumerable<string> TransformAndFilter(IEnumerable<int> source, int lo, int hi)
+        {
+            return source
+                .Where(x => x >= lo && x <= hi)
+                .Select(x => x switch
+                {
+                    < 0 => $"({x})",
+                    0 => "zero",
+                    _ => x.ToString(),
+                })
+                .Where(s => s.Length > 0)
+                .Distinct()
+                .OrderBy(s => s.Length)
+                .ThenBy(s => s);
+        }
 
-    public int SumRecursive(int n)
-    {
-      return Add(n);
+        public IEnumerable<(int key, int count)> FrequencyMap(IEnumerable<int> source)
+        {
+            return source
+                .GroupBy(x => x)
+                .Select(g => (g.Key, g.Count()))
+                .OrderByDescending(t => t.Item2);
+        }
 
-      int Add(int x)      // local function captures nothing, but still a closure type
-      {
-        if (x <= 0) return 0;
-        return x + Add(x - 1);
-      }
-    }
+        // ── local functions (closures) ────────────────────────────────────────
 
-    public IEnumerable<int> FilterAndProcessLocal(IEnumerable<int> source, int threshold)
-    {
-      return source.Where(IsAbove).Select(Process);
+        public int SumRecursive(int n)
+        {
+            return Add(n);
 
-      bool IsAbove(int x) => x > threshold;       // captures threshold
-      int Process(int x) => x * 2 + threshold;    // captures threshold
-    }
+            int Add(int x)      // local function captures nothing, but still a closure type
+            {
+                if (x <= 0) return 0;
+                return x + Add(x - 1);
+            }
+        }
 
-    public Func<int, int> BuildPipeline(int a, int b, int c)
-    {
-      return x => Step3(Step2(Step1(x)));
+        public IEnumerable<int> FilterAndProcessLocal(IEnumerable<int> source, int threshold)
+        {
+            return source.Where(IsAbove).Select(Process);
 
-      int Step1(int v) => v + a;
-      int Step2(int v) => v * b;
-      int Step3(int v) => v - c;
-    }
+            bool IsAbove(int x) => x > threshold;       // captures threshold
+            int Process(int x) => x * 2 + threshold;    // captures threshold
+        }
 
-    // ── delegate fields / events ──────────────────────────────────────────
+        public Func<int, int> BuildPipeline(int a, int b, int c)
+        {
+            return x => Step3(Step2(Step1(x)));
 
-    public event EventHandler<int>? ValueChanged;
+            int Step1(int v) => v + a;
+            int Step2(int v) => v * b;
+            int Step3(int v) => v - c;
+        }
+
+        // ── delegate fields / events ──────────────────────────────────────────
+
+        public event EventHandler<int>? ValueChanged;
 
     private int _value;
 
-    public int Value
-    {
-        get => _value;
-        set
+        public int Value
         {
-            if (_value != value)
+        get => _value;
+            set
             {
+            if (_value != value)
+                {
                 _value = value;
-                ValueChanged?.Invoke(this, value);
+                    ValueChanged?.Invoke(this, value);
+                }
             }
         }
-    }
 
-    public void Subscribe(Action<int> handler)
-    {
-      ValueChanged += (_, v) => handler(v);  // lambda capture of handler
-    }
-
-    // ── Predicate<T> / Comparison<T> patterns ────────────────────────────
-
-    public List<int> SortWithComparison(List<int> list, bool descending)
-    {
-      var copy = new List<int>(list);
-      copy.Sort(descending
-          ? (a, b) => b.CompareTo(a)
-          : (a, b) => a.CompareTo(b));
-      return copy;
-    }
-
-    public List<T> FilterWith<T>(List<T> list, Predicate<T> predicate)
-    {
-      return list.FindAll(predicate);
-    }
-
-    public void ForEachIf<T>(IEnumerable<T> source, Predicate<T> condition, Action<T> action)
-    {
-      foreach (T item in source)
-      {
-        if (condition(item))
-          action(item);
-      }
-    }
-
-    // ── memoisation closure ───────────────────────────────────────────────
-
-    public Func<int, int> Memoize(Func<int, int> f)
-    {
-      var cache = new Dictionary<int, int>();
-      return x =>
-      {
-        if (!cache.TryGetValue(x, out int result))
+        public void Subscribe(Action<int> handler)
         {
-          result = f(x);
-          cache[x] = result;
+            ValueChanged += (_, v) => handler(v);  // lambda capture of handler
         }
-        return result;
-      };
+
+        // ── Predicate<T> / Comparison<T> patterns ────────────────────────────
+
+        public List<int> SortWithComparison(List<int> list, bool descending)
+        {
+            var copy = new List<int>(list);
+            copy.Sort(descending
+                ? (a, b) => b.CompareTo(a)
+                : (a, b) => a.CompareTo(b));
+            return copy;
+        }
+
+        public List<T> FilterWith<T>(List<T> list, Predicate<T> predicate)
+        {
+            return list.FindAll(predicate);
+        }
+
+        public void ForEachIf<T>(IEnumerable<T> source, Predicate<T> condition, Action<T> action)
+        {
+            foreach (T item in source)
+            {
+                if (condition(item))
+                    action(item);
+            }
+        }
+
+        // ── memoisation closure ───────────────────────────────────────────────
+
+        public Func<int, int> Memoize(Func<int, int> f)
+        {
+            var cache = new Dictionary<int, int>();
+            return x =>
+            {
+                if (!cache.TryGetValue(x, out int result))
+                {
+                    result = f(x);
+                    cache[x] = result;
+                }
+                return result;
+            };
+        }
+
+        // ── nested lambdas ────────────────────────────────────────────────────
+
+        public Func<int, Func<int, int>> Curry(Func<int, int, int> f)
+        {
+            return a => b => f(a, b);   // lambda inside lambda
+        }
+
+        public Func<int, int> Compose(Func<int, int> f, Func<int, int> g)
+        {
+            return x => f(g(x));
+        }
+
+        public Func<int, int> ComposeMany(IEnumerable<Func<int, int>> funcs)
+        {
+            return funcs.Aggregate((f, g) => x => f(g(x)));
+        }
+
+        // ── conditional lambda ────────────────────────────────────────────────
+
+        public Func<int, int> ConditionalTransform(bool negate, int offset)
+        {
+            Func<int, int> baseTransform = negate
+                ? x => -x
+                : x => x;
+
+            return x =>
+            {
+                int base_ = baseTransform(x);
+                return offset != 0 ? base_ + offset : base_;
+            };
+        }
+
+        // ── exception inside lambda ───────────────────────────────────────────
+
+        public T TryGet<T>(Func<T> factory, T fallback)
+        {
+            try
+            {
+                return factory();
+            }
+            catch
+            {
+                return fallback;
+            }
+        }
+
+        public int SafeTransform(IEnumerable<int> source, Func<int, int> transform)
+        {
+            return source.Sum(x =>
+            {
+                try { return transform(x); }
+                catch { return 0; }
+            });
+        }
     }
-
-    // ── nested lambdas ────────────────────────────────────────────────────
-
-    public Func<int, Func<int, int>> Curry(Func<int, int, int> f)
-    {
-      return a => b => f(a, b);   // lambda inside lambda
-    }
-
-    public Func<int, int> Compose(Func<int, int> f, Func<int, int> g)
-    {
-      return x => f(g(x));
-    }
-
-    public Func<int, int> ComposeMany(IEnumerable<Func<int, int>> funcs)
-    {
-      return funcs.Aggregate((f, g) => x => f(g(x)));
-    }
-
-    // ── conditional lambda ────────────────────────────────────────────────
-
-    public Func<int, int> ConditionalTransform(bool negate, int offset)
-    {
-      Func<int, int> baseTransform = negate
-          ? x => -x
-          : x => x;
-
-      return x =>
-      {
-        int base_ = baseTransform(x);
-        return offset != 0 ? base_ + offset : base_;
-      };
-    }
-
-    // ── exception inside lambda ───────────────────────────────────────────
-
-    public T TryGet<T>(Func<T> factory, T fallback)
-    {
-      try
-      {
-        return factory();
-      }
-      catch
-      {
-        return fallback;
-      }
-    }
-
-    public int SafeTransform(IEnumerable<int> source, Func<int, int> transform)
-    {
-      return source.Sum(x =>
-      {
-        try { return transform(x); }
-        catch { return 0; }
-      });
-    }
-  }
 }

--- a/test/coverlet.benchmark.subject/Program.cs
+++ b/test/coverlet.benchmark.subject/Program.cs
@@ -1,0 +1,273 @@
+﻿// Copyright (c) Toni Solarin-Sodara
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+using System.Collections.Generic;
+
+namespace coverlet.benchmark.subject
+{
+  /// <summary>
+  /// Benchmark subject entry point used by <c>coverlet.core.benchmark.tests</c>.
+  /// </summary>
+  /// <remarks>
+  /// This program intentionally executes representative paths across all workload types so
+  /// <c>CoverageWorkflowBenchmark</c> can run the instrumented assembly and produce tracker hit files.
+  /// It is benchmark harness code, not shipping product behavior.
+  /// </remarks>
+  internal static class Program
+  {
+    private static int Main(string[] args)
+    {
+      Run();
+      return 0;
+    }
+
+    private static void Run()
+    {
+      RunAsyncWorkload();
+      RunAutoPropsWorkload();
+      RunDeepNestingWorkload();
+      RunExcludedWorkload();
+      RunGenericWorkload();
+      RunIteratorWorkload();
+      RunLambdaWorkload();
+      RunSwitchWorkload();
+    }
+
+    private static void RunAsyncWorkload()
+    {
+      var workload = new AsyncWorkload();
+      _ = workload.ComputeAsync(1, 2).GetAwaiter().GetResult();
+      _ = workload.FormatAsync(42).GetAwaiter().GetResult();
+      _ = workload.NestedComputeAsync(1, 2, 3).GetAwaiter().GetResult();
+      _ = workload.NestedFormatAsync(1, 2).GetAwaiter().GetResult();
+      _ = workload.SumSequenceAsync([1, 2, 3]).GetAwaiter().GetResult();
+      _ = workload.FormatManyAsync([1, 2, 3]).GetAwaiter().GetResult();
+      _ = workload.SafeComputeAsync(1, 2).GetAwaiter().GetResult();
+      _ = workload.SafeFormatAsync(3).GetAwaiter().GetResult();
+      _ = workload.ComputeAndFormatAsync(2, 3).GetAwaiter().GetResult();
+      _ = workload.IsPositiveSumAsync(1, 2).GetAwaiter().GetResult();
+      _ = workload.ParallelComputeAsync([1, 2, 3]).GetAwaiter().GetResult();
+      _ = workload.FirstResultAsync(1, 2).GetAwaiter().GetResult();
+      _ = workload.ComputeWithTimeoutAsync(1, 2, 1000).GetAwaiter().GetResult();
+      _ = workload.ComputeValueTaskAsync(1, 2).AsTask().GetAwaiter().GetResult();
+      _ = workload.IsZeroAsync(0).AsTask().GetAwaiter().GetResult();
+      _ = workload.DeeplyNestedAsync(4).GetAwaiter().GetResult();
+      workload.FireAndForgetCompute(1, 2);
+    }
+
+    private static void RunAutoPropsWorkload()
+    {
+      _ = new AutoProps10();
+      _ = new AutoProps25();
+      var noCtor = new RecordNoCtor { Name = "A", Age = 1 };
+      var emptyCtor = new RecordEmptyCtor { Name = "B", Age = 2 };
+      var withCtor = new RecordWithPrimaryCtor("C", 3);
+      _ = noCtor.Display();
+      _ = emptyCtor.Display();
+      _ = withCtor.Display();
+      _ = new CircleRecord { Radius = 2 }.Area();
+      _ = new RectangleRecord { Width = 2, Height = 3 }.Area();
+      _ = new OrderRecord("id", 10, "pending").Describe();
+      _ = new ProductRecord("sku", "name", 5, 1).StockStatus();
+      var aggregator = new RecordAggregator
+      {
+        NoCtor = noCtor,
+        EmptyCtor = emptyCtor,
+        WithCtor = withCtor
+      };
+
+      _ = aggregator.Summary();
+    }
+
+    private static void RunDeepNestingWorkload()
+    {
+      var level1 = new Level1();
+      _ = level1.Compute(1);
+      _ = level1.Inner.Compute(1);
+      _ = level1.Inner.Inner.Compute(1);
+      _ = level1.Inner.Inner.Inner.Compute(1);
+      _ = level1.Inner.Inner.Inner.Inner.Compute(1);
+      _ = level1.Inner.Inner.Inner.Inner.IsPositive(1);
+      _ = level1.Inner.Inner.Inner.Inner.Label(1);
+      _ = level1.Label(1);
+      _ = level1.Inner.Label(1);
+      _ = level1.Inner.Inner.Label(1);
+
+      var covered = new CoveredOuter();
+      _ = covered.TopMethod(1);
+      _ = new CoveredOuter.CoveredInner1().Method(1);
+      _ = new CoveredOuter.CoveredInner1.CoveredSiblingInner2().Check(1);
+      _ = new CoveredOuter.CoveredInner1B().Label(1);
+      _ = new ContainerWithStaticNested().InstanceMethod(1);
+      _ = ContainerWithStaticNested.GetDefault();
+      _ = ContainerWithStaticNested.GetMaxRetries();
+
+      var host = new ModuleHost();
+      host.Register(new ModuleHost.DefaultPlugin());
+      host.Register(new ModuleHost.AdvancedPlugin("x"));
+      _ = host.Plugins.Count;
+
+      var deep = new Deep7();
+      _ = deep.Depth;
+      _ = new Deep7.L2.L3.L4.L5.L6.L7().IsMax(7);
+    }
+
+    private static void RunExcludedWorkload()
+    {
+      _ = new PartiallyExcludedClass().Add(1, 2);
+      _ = new PartiallyExcludedClass().Multiply(2, 3);
+      _ = new PartiallyExcludedClass().IsPositive(1);
+      _ = new PartiallyExcludedClass().Subtract(3, 1);
+
+      var propertyExclusion = new PropertyExclusionClass { Value = 1, Tag = "x" };
+      _ = propertyExclusion.Compute();
+
+      var outer = new OuterClass();
+      _ = outer.CoveredMethod(1);
+      _ = new OuterClass.CoveredNestedClass().Calc(2);
+      _ = new CoveredSiblingA().Method1(1);
+      _ = new CoveredSiblingC().Check(10);
+      _ = new CoveredSiblingE().Label(1);
+      _ = new MethodLevelCustomExclusion().Covered(1);
+      _ = new MethodLevelCustomExclusion().AlsoCovered(1);
+
+      IWorkItem item = new CoveredWorkItem(1);
+      item.Execute();
+      _ = item.Priority;
+    }
+
+    private static void RunGenericWorkload()
+    {
+      var pair = new Pair<int, string>(1, "a");
+      _ = pair.Swap();
+
+      var repository = new Repository<string>();
+      int id = repository.Add("x");
+      _ = repository.TryGet(id, out string? value);
+      _ = value;
+      _ = repository.Count;
+
+      var stack = new BoundedStack<int>(4);
+      _ = stack.TryPush(1);
+      _ = stack.TryPeek(out int top);
+      _ = top;
+
+      var workload = new GenericWorkload();
+      _ = workload.Identity(1);
+      _ = workload.FirstOrNull(["a", "b"], x => x == "a");
+      _ = workload.Transform(2, x => x + 1);
+      _ = workload.Select([1, 2, 3], x => x * 2);
+      _ = workload.Filter([1, 2, 3], x => x > 1);
+      _ = workload.MakePair(1, "b");
+      _ = workload.TryFind([1, 2, 3], x => x == 2);
+      _ = workload.Max(2, 3);
+      _ = workload.Min(2, 3);
+      _ = workload.Clamp(3, 1, 5);
+      _ = workload.Sort([3, 2, 1]);
+      _ = workload.Contains([1, 2, 3], 2);
+      _ = workload.BinarySearch([1, 2, 3], 2);
+      _ = workload.CreateDefault<List<int>>();
+      _ = workload.CreateList<List<int>>(2);
+      _ = workload.FillArray(3, 1);
+      _ = workload.FromNullable<int>(1);
+      _ = workload.AllSatisfy([1, 2, 3], x => x > 0);
+      _ = workload.Reduce([1, 2, 3], 0, (acc, x) => acc + x);
+    }
+
+    private static void RunIteratorWorkload()
+    {
+      var workload = new IteratorWorkload();
+      Consume(workload.Range(0, 3));
+      Consume(workload.Evens(4));
+      Consume(workload.Odds(5));
+      Consume(workload.Squares(3));
+      Consume(workload.Fibonacci(5));
+      Consume(workload.PositiveValues([-1, 0, 1, 2]));
+      Consume(workload.TakeWhilePositive([1, 2, 0, 3]));
+      Consume(workload.SkipNegatives([-2, -1, 0, 1]));
+      Consume(workload.ToStrings([-1, 0, 1], "p"));
+      Consume(workload.Flatten([[1, 2], [3, 4]]));
+      Consume(workload.Interleave([1, 3], [2, 4]));
+      Consume(workload.WithCleanup([1, 2], () => { }));
+      Consume(workload.SafeRange(0, 3));
+      Consume(workload.Indexed([1, 2, 3]));
+      Consume(workload.Batch([1, 2, 3, 4], 2));
+      Consume(workload.BoxedRange(0, 3));
+      Consume(workload.Chain(3));
+      Consume(workload.ZipSum([1, 2], [3, 4]));
+      Consume(workload.RunningSum([1, 2, 3]));
+      Consume(workload.MovingAverage([1, 2, 3, 4], 2));
+    }
+
+    private static void RunLambdaWorkload()
+    {
+      var workload = new LambdaWorkload();
+      _ = workload.ApplyTwice(x => x + 1, 1);
+      _ = workload.Adder(2)(3);
+      _ = workload.Multiplier(3)(2);
+      _ = workload.RangeChecker(1, 3)(2);
+
+      var log = new List<int>();
+      workload.BuildLogger(log)(1);
+
+      _ = workload.FilterAndDouble([1, 2, 3], 1);
+      _ = workload.TopN([1, 2, 3], 2, 1);
+      _ = workload.GroupBySign([-1, 0, 1]);
+      _ = workload.AnyAbove([1, 2, 3], 2);
+      _ = workload.SumPositive([-1, 1, 2]);
+      _ = workload.AverageNonZero([0.0, 2.0]);
+      _ = workload.TransformAndFilter([1, 2, 3], 1, 3);
+      _ = workload.FrequencyMap([1, 1, 2]);
+      _ = workload.SumRecursive(4);
+      _ = workload.FilterAndProcessLocal([1, 2, 3], 1);
+      _ = workload.BuildPipeline(1, 2, 1)(3);
+
+      workload.Subscribe(_ => { });
+      workload.Value = 1;
+
+      _ = workload.SortWithComparison([1, 3, 2], descending: true);
+      _ = workload.FilterWith([1, 2, 3], x => x > 1);
+      workload.ForEachIf([1, 2, 3], x => x > 1, _ => { });
+      _ = workload.Memoize(x => x + 1)(1);
+      _ = workload.Curry((a, b) => a + b)(1)(2);
+      _ = workload.Compose(x => x + 1, x => x * 2)(2);
+      _ = workload.ComposeMany([x => x + 1, x => x * 2])(2);
+      _ = workload.ConditionalTransform(true, 1)(2);
+      _ = workload.TryGet(() => 1, 0);
+      _ = workload.SafeTransform([1, 2, 3], x => x + 1);
+    }
+
+    private static void RunSwitchWorkload()
+    {
+      var workload = new SwitchWorkload();
+      _ = workload.ClassifyScore(80);
+      _ = workload.MapCodeToValue(10);
+      _ = workload.ParseMonthNumber("jan");
+      _ = workload.GetSeason(6);
+      _ = workload.DescribeObject("x");
+      _ = workload.ClassifyPair(1, -1);
+      _ = workload.ClassifyTriangle(3, 4, 5);
+      _ = workload.ComputePoints("gold", 10);
+      _ = workload.GetDeadlineHours(SwitchWorkload.Priority.High);
+      _ = workload.GetPriorityColor(SwitchWorkload.Priority.Critical);
+      _ = workload.ClassifyCharacter('x');
+      _ = workload.TransformArray([1, 2, 3], "square");
+      _ = workload.Dispatch(1, -1, 1);
+    }
+
+    private static void Consume<T>(IEnumerable<T> values)
+    {
+      foreach (T _ in values)
+      {
+      }
+    }
+
+    private static void Consume(IEnumerable values)
+    {
+      foreach (object _ in values)
+      {
+      }
+    }
+  }
+}

--- a/test/coverlet.benchmark.subject/coverlet.benchmark.subject.csproj
+++ b/test/coverlet.benchmark.subject/coverlet.benchmark.subject.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <IsTestProject>false</IsTestProject>
     <Nullable>enable</Nullable>

--- a/test/coverlet.core.benchmark.tests/PerformanceImprovementProposal.md
+++ b/test/coverlet.core.benchmark.tests/PerformanceImprovementProposal.md
@@ -1,0 +1,281 @@
+# coverlet.core Performance Improvement Proposal
+
+> **Scope:** `src/coverlet.core` – targets net8.0, net9.0, net10.0  
+> **Approach:** measure first (`InstrumentationOptionsBenchmarks`, `ReportFormatBenchmarks`), then apply,
+> then measure again and record results in `BenchmarkHistory.md`.
+
+---
+
+## Background & Methodology
+
+BenchmarkDotNet profiling of the existing `CoverageWorkflowBenchmark` and the newly added
+`InstrumentationOptionsBenchmarks` / `ReportFormatBenchmarks` suites reveals the following
+hot paths and allocation hot-spots.  Every proposal below is backed by a targeted benchmark
+that can be run in isolation to confirm the gain.
+
+---
+
+## Proposal 1 – Avoid double module-read in `Instrumenter.InstrumentModule`
+
+### Problem
+`Instrumenter` opens and fully reads the Cecil `ModuleDefinition` **twice**: once in
+`CreateReachabilityHelper()` and once in `InstrumentModule()`.  For large assemblies this
+means two complete IL stream reads plus two symbol-store loads.
+
+```csharp
+// Instrumenter.cs – today
+private void InstrumentModule()
+{
+    CreateReachabilityHelper();            // ← read #1
+    using Stream stream = ...OpenReadWrite
+    using var module = ModuleDefinition.ReadModule(stream, ...); // ← read #2
+    ...
+}
+```
+
+### Proposed Fix
+Refactor `CreateReachabilityHelper` to accept (or return) the `ModuleDefinition` so it can be
+reused inside `InstrumentModule`.  A read-only in-memory `MemoryStream` copy of the bytes can
+act as the source for the reachability pass, while the original file stream is used for the
+read/write instrumentation pass.
+
+```csharp
+// After
+private void InstrumentModule()
+{
+    using Stream stream = _fileSystem.NewFileStream(_module, FileMode.Open, FileAccess.ReadWrite);
+    // Copy bytes for read-only reachability analysis
+    byte[] moduleBytes = ReadAllBytes(stream);
+    stream.Position = 0;
+
+    _reachabilityHelper = CreateReachabilityHelper(moduleBytes);  // no second file I/O
+
+    using var module = ModuleDefinition.ReadModule(stream, writerParams);
+    ...
+}
+```
+
+**Expected gain:** Reduces file I/O by ~50 % per module; removes one full Cecil type-system
+initialisation per instrumented assembly.
+
+**Benchmark to verify:** `InstrumentationOptionsBenchmarks.InstrumentWithOptions`
+
+---
+
+## Proposal 2 – Cache `IsTypeExcluded` / `IsTypeIncluded` results
+
+### Problem
+`IsTypeExcluded` and `_instrumentationHelper.IsTypeIncluded` are called for every
+`TypeDefinition` in a module, and each call internally iterates over all configured filter
+expressions using `Matcher` / string comparisons.  For assemblies with hundreds of types the
+same filter string is re-evaluated thousands of times.
+
+### Proposed Fix
+Introduce a per-instrumentation-run `Dictionary<string, bool>` cache keyed on
+`type.FullName`.  The cache is local to the `Instrumenter` instance (no concurrency concern).
+
+```csharp
+private readonly Dictionary<string, bool> _typeExcludedCache = new(StringComparer.Ordinal);
+private readonly Dictionary<string, bool> _typeIncludedCache = new(StringComparer.Ordinal);
+
+private bool IsTypeExcluded(TypeDefinition type)
+{
+    if (_typeExcludedCache.TryGetValue(type.FullName, out bool cached))
+        return cached;
+    bool result = ComputeIsTypeExcluded(type);
+    _typeExcludedCache[type.FullName] = result;
+    return result;
+}
+```
+
+**Expected gain:** Eliminates redundant filter evaluation for nested and repeated type lookups;
+measurable on assemblies with >50 types (e.g. `coverlet.testsubject`).
+
+**Benchmark to verify:** `InstrumentationOptionsBenchmarks.InstrumentWithOptions`
+(compare `SkipAutoProps=false` vs `true` to see filter call volume effect).
+
+---
+
+## Proposal 3 – Replace `LINQ` hot paths in `InstrumentType` with direct loops
+
+### Problem
+Several inner loops inside `InstrumentType` and `InstrumentMethod` use LINQ operators
+(`Any`, `FirstOrDefault`, `Where`) on small `IList`/array collections.  In a tight loop
+over thousands of instructions these allocate enumerator objects and add GC pressure.
+
+Key sites (by line in `Instrumenter.cs`):
+
+| Site | Current code |
+|------|-------------|
+| Branch exclusion check | `_branchesInCompiledGeneratedClass?.Any(b => ...)` |
+| Exclude attribute check | `type.CustomAttributes.Any(attr => IsExcludeAttribute(attr) && ...)` |
+| State machine interface check | `type.Interfaces.Any(i => ...)` |
+
+### Proposed Fix
+Replace with `foreach` + early `return`/`break`:
+
+```csharp
+// Before
+bool excluded = type.CustomAttributes.Any(attr => IsExcludeAttribute(attr));
+
+// After
+bool excluded = false;
+foreach (var attr in type.CustomAttributes)
+{
+    if (IsExcludeAttribute(attr)) { excluded = true; break; }
+}
+```
+
+For collections that are genuinely array-backed, using `Array.Exists` (no allocation) is an
+alternative for single-predicate checks.
+
+**Expected gain:** Reduced Gen0 allocation per instrumented method; visible in the
+`Allocated` column of `InstrumentationOptionsBenchmarks`.
+
+**Benchmark to verify:** `InstrumentationOptionsBenchmarks` – compare `Allocated` column
+before and after.
+
+---
+
+## Proposal 4 – Pool `StringBuilder` instances in reporters
+
+### Problem
+`CoberturaReporter`, `OpenCoverReporter`, and `LcovReporter` each create a fresh
+`StringBuilder` (or `XmlWriter` backed by a `MemoryStream`) per `Report()` call.  When
+coverage is collected during a test run these reporters may be called frequently.
+
+### Proposed Fix
+Use `Microsoft.Extensions.ObjectPool` (already an indirect dependency via ASP.NET) or a
+simple `ThreadLocal<StringBuilder>` with a `Clear()` call:
+
+```csharp
+private static readonly ThreadLocal<StringBuilder> s_sb =
+    new(() => new StringBuilder(capacity: 64 * 1024));
+
+public string Report(CoverageResult result, ISourceRootTranslator translator)
+{
+    var sb = s_sb.Value!;
+    sb.Clear();
+    // build report into sb ...
+    return sb.ToString();
+}
+```
+
+**Expected gain:** Fewer large `StringBuilder` / `MemoryStream` heap allocations per report
+generation; improves `ReportFormatBenchmarks` `Allocated` metric.
+
+**Benchmark to verify:** `ReportFormatBenchmarks.GetCoverageAndReport`
+
+---
+
+## Proposal 5 – Parallelise multi-module instrumentation in `Coverage.PrepareModules`
+
+### Problem
+`PrepareModules` instruments each module in a sequential `foreach` loop.  Projects with many
+assemblies (e.g. integration test suites) wait for each module to complete before starting
+the next.
+
+```csharp
+foreach (string module in validModules)   // sequential today
+{
+    var instrumenter = new Instrumenter(...);
+    if (instrumenter.CanInstrument()) { ... }
+}
+```
+
+### Proposed Fix
+Replace the `foreach` with `Parallel.ForEach` (with an `IInstrumentationHelper` instance per
+thread to avoid Cecil reader sharing) or use `Task.WhenAll` over a pool of workers:
+
+```csharp
+var results = new System.Collections.Concurrent.ConcurrentBag<InstrumenterResult>();
+Parallel.ForEach(validModules, new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount },
+    module =>
+    {
+        var localHelper = CreateThreadLocalHelper();
+        var instrumenter = new Instrumenter(module, Identifier, _parameters, _logger,
+                                            localHelper, _fileSystem, _sourceRootTranslator, _cecilSymbolHelper);
+        if (instrumenter.CanInstrument())
+        {
+            _instrumentationHelper.BackupOriginalModule(module, Identifier, ...);
+            var r = instrumenter.Instrument();
+            if (!instrumenter.SkipModule) results.Add(r);
+        }
+    });
+_results.AddRange(results);
+```
+
+> ⚠️ Cecil `ModuleDefinition` instances are **not** thread-safe.  Each parallel worker must
+> use its own `AssemblyResolver` and `ModuleDefinition`; shared `IInstrumentationHelper` state
+> (filter lists, regex caches) must be made read-only or synchronised.
+
+**Expected gain:** Near-linear speed-up proportional to module count on multi-core machines.
+Best measured with a solution containing ≥4 assemblies.
+
+**Benchmark to verify:** Extend `CoverageWorkflowBenchmark` with a multi-module variant that
+points at an `IncludeDirectories` containing several copies of `coverlet.testsubject.dll`.
+
+---
+
+## Proposal 6 – Compile filter expressions once (Regex / Glob)
+
+### Problem
+`InstrumentationHelper.IsTypeExcluded` / `IsTypeIncluded` rebuild `Matcher` (glob) instances
+or call `Regex.IsMatch` with pattern strings on every call.  Patterns do not change during a
+single coverage run.
+
+### Proposed Fix
+Compile all include/exclude globs to `Matcher` instances once during
+`InstrumentationHelper` construction (or first use) and cache them:
+
+```csharp
+// Cache per filter-string list identity
+private readonly Lazy<Matcher> _excludeMatcher;
+
+public InstrumentationHelper(...)
+{
+    _excludeMatcher = new Lazy<Matcher>(() =>
+    {
+        var m = new Matcher(StringComparison.OrdinalIgnoreCase);
+        foreach (var f in _excludeFilters ?? []) m.AddInclude(f);
+        return m;
+    });
+}
+```
+
+**Expected gain:** Eliminates repeated `Matcher` object construction on the hot path;
+reduces allocations visible in the Gen0/Gen1 columns of `InstrumentationOptionsBenchmarks`.
+
+**Benchmark to verify:** `InstrumentationOptionsBenchmarks.InstrumentWithOptions`
+
+---
+
+## Implementation Priority
+
+| # | Proposal | Effort | Expected Impact | Risk |
+|---|----------|--------|----------------|------|
+| 2 | Cache type-exclusion results | Low | High | Low |
+| 6 | Pre-compile filter expressions | Low | High | Low |
+| 3 | Replace LINQ hot paths with loops | Low | Medium | Low |
+| 4 | Pool `StringBuilder` in reporters | Low | Medium | Low |
+| 1 | Avoid double module read | Medium | High | Medium |
+| 5 | Parallelise `PrepareModules` | High | Very High | High |
+
+Start with proposals **2, 6, 3** (low-effort / low-risk) and confirm with benchmarks before
+proceeding to proposals **1 and 4**.  Proposal **5** requires a design review to ensure Cecil
+thread-safety constraints are met.
+
+---
+
+## Tracking Results
+
+Run `scripts/Update-BenchmarkHistory.ps1` after each benchmark run to append the new
+measurements to `BenchmarkHistory.md`.  Compare the **Mean (ms)** and **Allocated (MB)**
+columns for `InstrumentWithOptions` and `GetCoverageAndReport` across releases.
+
+
+## Implementation plan
+
+- ✅ P2,P6,P3 => PR #1934
+- ✅ P1,P4 => PR #1934
+- ⏭️ P5 => separate PR required (High Risk)

--- a/test/coverlet.core.benchmark.tests/PerformanceImprovementProposal2.md
+++ b/test/coverlet.core.benchmark.tests/PerformanceImprovementProposal2.md
@@ -462,9 +462,9 @@ measurements to `BenchmarkHistory.md`.
 
 ## Implementation Plan
 
-- ⏳ BS-1 – new richer benchmark subject
+- ✅ BS-1 – new richer benchmark subject (master branch) [10.0.2-p0]
 - ⏳ BS-2 – multi-module benchmark variant
-- ⏳ P7, P8, P9, P10, P11 => single PR (reporter + coverage-result phase)
+- ✅ P7, P8, P9, P10, P11 => single PR (reporter + coverage-result phase) - [10.0.2-p3]
 - ⏳ P12 => separate PR (InstrumentIL change)
 - ⏳ P13 => separate PR (module-level short-circuit)
 - ⏭️ P5 => separate PR, requires design review (Cecil thread-safety)

--- a/test/coverlet.core.benchmark.tests/PerformanceImprovementProposal2.md
+++ b/test/coverlet.core.benchmark.tests/PerformanceImprovementProposal2.md
@@ -1,0 +1,470 @@
+# coverlet.core Performance Improvement Proposal 2
+
+> **Scope:** `src/coverlet.core` – targets net8.0, net9.0, net10.0
+> **Builds on:** `PerformanceImprovementProposal.md` (P1–P6 all merged in PR #1934)
+> **Approach:** measure first, then apply, then record results in `BenchmarkHistory.md`.
+
+---
+
+## Review of Proposal 1 (P1–P6) outcomes
+
+After P1–P6 were merged the benchmarks showed less improvement than predicted for two reasons:
+
+1. **LINQ replacement (P3) produced no measurable gain** – on .NET 9/10 the JIT inlines most
+   `Any`/`FirstOrDefault` calls on small `IList<T>` and the BCL's `foreach`-based enumerator is
+   already allocation-free for list-backed collections.  The change is harmless but the
+   numbers confirmed what the user noted: replacing LINQ with `foreach` on modern runtimes is
+   not a reliable speedup.  **Revert P3 loop-replacements only where readability suffers.**
+
+2. **`coverlet.testsubject` is a poor benchmark subject** – `BigClass.cs` is 6 200 lines of
+   identical `if (y > n) { new SubClassN().Do(y); }` blocks.  Every subclass follows the
+   same shape, so:
+   - Branch diversity is near-zero (one branch per method, always the same pattern).
+   - No async state machines → `IAsyncStateMachine` code paths are never exercised.
+   - No iterators, no complex switch, no generics, no lambda captures.
+   - The `insideExceptionHandlerOffsets` fast-path is always empty.
+   - The Cecil type-filter caches (P2, P6) warm up in the first few types and then hit 100 %
+     for the remaining ~200 identical sub-classes, making the proposals look better than they
+     are against real code.
+
+---
+
+## Benchmark Subject Improvements
+
+### BS-1 – Add a richer synthetic assembly alongside `coverlet.testsubject`
+
+Create **`test/coverlet.benchmark.subject`** (new class library, `net8.0`) that contains the
+following patterns, each in a separate file so the benchmark can target individual groups:
+
+| File | Purpose |
+|------|---------|
+| `AsyncWorkload.cs` | 10–20 `async Task` methods with `await`, error handling, nested async calls → exercises `IAsyncStateMachine` type detection and the `IsCompilerGeneratedStateMachineType` fast-path |
+| `IteratorWorkload.cs` | `IEnumerable<T>` iterator methods (`yield return`) → exercises `IEnumerator` interface detection |
+| `SwitchWorkload.cs` | Methods with large `switch` expressions (10–20 arms) and nested `if`/`switch` combinations → increases `branchPoints` count per method dramatically |
+| `LambdaWorkload.cs` | LINQ query bodies, `Func<>` captures, local functions with closures → exercises the `<>c` compiled-generated-class branch-fixup path in `Coverage.GetCoverageResult` |
+| `GenericWorkload.cs` | Open generics, constrained type parameters, generic methods → stresses filter regex matching against generic type names |
+| `ExcludedWorkload.cs` | Types and methods with `[ExcludeFromCoverage]` / `[ExcludeFromCodeCoverage]` at various levels → makes P2 caches do real work |
+| `DeepNestingWorkload.cs` | Deeply nested classes (5+ levels) → exercises `ComputeIsTypeExcluded`'s ancestor walk |
+
+**Benefit:** Makes every existing proposal measurable against realistic code; prevents
+regressions in future PRs from hiding behind the uniform BigClass benchmark.
+
+### BS-2 – Multi-module benchmark variant
+
+Add a `MultiModuleBenchmarks` class that points `IncludeDirectories` at a directory
+containing **4–6 copies** of the new `coverlet.benchmark.subject.dll` (renamed to simulate
+distinct assemblies).  This is the only meaningful way to benchmark `PrepareModules` wall
+time and any future P5 parallelisation work.
+
+---
+
+## New Performance Proposals
+
+---
+
+### P7 – Pre-group branch-by-line lookup in `CoberturaReporter`
+
+#### Problem
+Inside `Report()`, for every `(method, line)` pair the reporter calls:
+
+```csharp
+// CoberturaReporter.cs – inner line loop
+bool isBranchPoint = meth.Value.Branches.Any(b => b.Line == ln.Key);   // O(branches)
+// ...
+var branches = meth.Value.Branches.Where(b => b.Line == ln.Key).ToList(); // O(branches) again
+```
+
+For a method with *L* lines and *B* branches this is **O(L × B)** per method, repeated for
+every method in every class in every module.  A 200-method module with ~20 branches per
+method and ~30 lines per method → ≈ 120 000 linear scans.
+
+#### Proposed Fix
+Build a `Dictionary<int, List<BranchInfo>>` keyed on line number once per method before the
+line loop:
+
+```csharp
+// Build once per method
+var branchesByLine = new Dictionary<int, List<BranchInfo>>(meth.Value.Branches.Count);
+foreach (BranchInfo b in meth.Value.Branches)
+{
+    if (!branchesByLine.TryGetValue(b.Line, out var list))
+        branchesByLine[b.Line] = list = [];
+    list.Add(b);
+}
+
+// Then inside the line loop: O(1) per line
+bool isBranchPoint = branchesByLine.ContainsKey(ln.Key);
+if (isBranchPoint)
+{
+    var branches = branchesByLine[ln.Key];
+    ...
+}
+```
+
+The same pattern applies to `OpenCoverReporter` (check for duplication before fixing).
+
+**Expected gain:** Reduces `Report()` allocation (no repeated `.ToList()` per line) and CPU
+time from O(L×B) to O(L+B) per method.  Visible in `ReportFormatBenchmarks` `Allocated` and
+`Mean` for `cobertura` and `opencover` formats on the richer benchmark subject.
+
+**Benchmark to verify:** `ReportFormatBenchmarks.GetCoverageAndReport` with
+`ReportFormat = "cobertura"` and `"opencover"`.
+
+---
+
+### P8 – Eliminate double-enumeration in `CoverageSummary.CalculateMethodCoverage`
+
+#### Problem
+`CalculateMethodCoverage(Methods methods)` filters with `Where` and then calls `.Count()` on
+the filtered sequence a second time:
+
+```csharp
+// CoverageSummary.cs
+IEnumerable<KeyValuePair<string, Method>> methodsWithLines =
+    methods.Where(m => m.Value.Lines.Count > 0);
+foreach (var method in methodsWithLines)
+{
+    ...
+    details.Covered += methodCoverage.Covered;
+}
+details.Total = methodsWithLines.Count();   // ← re-enumerates the IEnumerable
+```
+
+`.Count()` on a re-enumerated `Where` query re-runs the predicate for every element.
+
+Also in `CalculateLineCoverage(Lines lines)`:
+```csharp
+Covered = lines.Count(l => l.Value > 0),   // LINQ on every call
+Total   = lines.Count                       // property – fine
+```
+
+#### Proposed Fix
+Use a single `foreach` loop accumulating both `Covered` and `Total`:
+
+```csharp
+public static CoverageDetails CalculateMethodCoverage(Methods methods)
+{
+    var details = new CoverageDetails();
+    foreach (KeyValuePair<string, Method> method in methods)
+    {
+        if (method.Value.Lines.Count == 0)
+            continue;
+        details.Total++;
+        details.Covered += method.Value.Lines.Any(l => l.Value > 0) ? 1 : 0;
+    }
+    return details;
+}
+```
+
+For `CalculateLineCoverage(Lines lines)` replace the LINQ `Count()` with a `foreach`:
+
+```csharp
+public static CoverageDetails CalculateLineCoverage(Lines lines)
+{
+    int covered = 0;
+    foreach (KeyValuePair<int, int> l in lines)
+    {
+        if (l.Value > 0) covered++;
+    }
+    return new CoverageDetails { Covered = covered, Total = lines.Count };
+}
+```
+
+**Expected gain:** Removes one full re-scan of method lists in the report phase.
+Most visible in `ReportFormatBenchmarks` `Allocated` column (fewer LINQ state machine
+allocations in tight loops).
+
+**Benchmark to verify:** `ReportFormatBenchmarks.GetCoverageAndReport` – `Allocated` metric.
+
+---
+
+### P9 – Pre-group `HitCandidates` by `docIndex` in `CalculateCoverage`
+
+#### Problem
+In `Coverage.CalculateCoverage`, the nested-range detection loop is O(n²):
+
+```csharp
+// Coverage.cs – CalculateCoverage
+foreach (HitCandidate hitCandidate in result.HitCandidates)
+{
+    if (hitCandidate.isBranch || hitCandidate.end == hitCandidate.start) continue;
+
+    foreach (HitCandidate hitCandidateToCompare in
+        result.HitCandidates.Where(x => x.docIndex.Equals(hitCandidate.docIndex)))  // O(n) per outer
+    { ... }
+}
+```
+
+For an assembly with *N* non-branch, multi-line candidates spread over *D* documents, the
+inner `Where` re-scans all `N` candidates for every outer candidate: **O(N²)** total.
+
+#### Proposed Fix
+Pre-group hit candidates by `docIndex` once before the outer loop using `ToLookup`:
+
+```csharp
+// Build once
+ILookup<int, HitCandidate> byDocIndex = result.HitCandidates.ToLookup(x => x.docIndex);
+
+foreach (HitCandidate hitCandidate in result.HitCandidates)
+{
+    if (hitCandidate.isBranch || hitCandidate.end == hitCandidate.start) continue;
+
+    foreach (HitCandidate hitCandidateToCompare in byDocIndex[hitCandidate.docIndex])
+    { ... }
+}
+```
+
+`ILookup<K,V>` uses a pre-built hashtable so each inner group lookup is O(1) + O(group size),
+reducing total complexity to **O(N + D × G²)** where G is the average group size (usually
+small per document).
+
+**Expected gain:** For instrumented assemblies with many sequence points spanning multiple
+lines (async state machines, iterator blocks), `CalculateCoverage` becomes measurably faster.
+
+**Benchmark to verify:** A dedicated `CalculateCoverageBenchmarks` targeting the richer
+benchmark subject (BS-1) to expose the O(n²) pattern.
+
+---
+
+### P10 – Cache the validation `Regex` in `IsValidFilterExpression`
+
+#### Problem
+`InstrumentationHelper.IsValidFilterExpression` constructs a new `Regex` object on every
+invocation:
+
+```csharp
+// InstrumentationHelper.cs
+if (new Regex(@"[^\w*]", s_regexOptions, TimeSpan.FromSeconds(10))
+        .IsMatch(filter.Replace(...)))
+    return false;
+```
+
+This method is called for every filter string at the start of `PrepareModules` and in
+validation paths inside `SelectModules`.  Although the absolute call count is small (bounded
+by the number of configured filters), creating compiled `Regex` instances is expensive and
+wasteful when the pattern never changes.
+
+Additionally, `filter.Count(f => f == '[')` and `filter.Count(f => f == ']')` iterate the
+string twice each.  A single-pass scan is cheaper.
+
+#### Proposed Fix
+Promote the validation regex to a static readonly field alongside the existing `s_regexOptions`:
+
+```csharp
+private static readonly Regex s_invalidFilterCharsRegex =
+    new(@"[^\w*]", RegexOptions.Compiled, TimeSpan.FromSeconds(10));
+```
+
+Replace the two `.Count()` scans with a single-pass helper that counts `[` and `]`
+simultaneously and short-circuits as soon as a count exceeds 1.
+
+**Expected gain:** Negligible on a single run, but relevant for tools that call
+`IsValidFilterExpression` in a tight loop (e.g. the MSBuild task that validates all filter
+properties).
+
+**Benchmark to verify:** Micro-benchmark in `InstrumentationOptionsBenchmarks` – add a
+`ValidateFilters` benchmark that calls `IsValidFilterExpression` for 50 typical filter strings.
+
+---
+
+### P11 – Pre-build a `HashSet` for `BranchInCompilerGeneratedClass` lookup
+
+#### Problem
+`Coverage.BranchInCompilerGeneratedClass(string methodName)` is called in a tight nested
+loop for every branch of every method of every class-with-`<>c`-prefix:
+
+```csharp
+// Coverage.cs
+private bool BranchInCompilerGeneratedClass(string methodName)
+{
+    foreach (InstrumenterResult instrumentedResult in _results)   // O(modules)
+    {
+        if (instrumentedResult.BranchesInCompiledGeneratedClass.Contains(methodName))
+            return true;                                           // O(entries per module)
+    }
+    return false;
+}
+```
+
+`BranchesInCompiledGeneratedClass` is a `string[]` (immutable array), so `.Contains` is a
+linear scan.  The entire lookup is called once per anonymous-delegate branch, which for a
+large solution with many LINQ closures adds up.
+
+#### Proposed Fix
+Build a `HashSet<string>` once before the outer loop in `GetCoverageResult`:
+
+```csharp
+// In GetCoverageResult, before the outer module loop
+var branchesInGeneratedClassSet = new HashSet<string>(StringComparer.Ordinal);
+foreach (InstrumenterResult r in _results)
+{
+    foreach (string m in r.BranchesInCompiledGeneratedClass)
+        branchesInGeneratedClassSet.Add(m);
+}
+```
+
+Replace the `BranchInCompilerGeneratedClass` call with a `branchesInGeneratedClassSet.Contains(...)` O(1) lookup.
+
+**Expected gain:** O(1) vs O(modules × array-size) per branch lookup.  Most visible on
+projects with many LINQ queries (lambda workloads) – well covered by BS-1's `LambdaWorkload`.
+
+**Benchmark to verify:** `ReportFormatBenchmarks.GetCoverageAndReport` (the `GetCoverageResult`
+phase) using the richer benchmark subject.
+
+---
+
+### P12 – Pre-sort `unreachableRanges` and replace linear search with binary search in `InstrumentIL`
+
+#### Problem
+`InstrumentIL` advances a `currentUnreachableRangeIx` cursor through the
+`ImmutableArray<UnreachableRange>` to determine reachability per instruction:
+
+```csharp
+while (currentUnreachableRangeIx < unreachableRanges.Length
+       && instrOffset > unreachableRanges[currentUnreachableRangeIx].EndOffset)
+{
+    currentUnreachableRangeIx++;
+}
+```
+
+This is already O(n) amortised across the instruction loop because the cursor never resets.
+**However**, this relies on `unreachableRanges` being sorted by `EndOffset`.  If
+`ReachabilityHelper.FindUnreachableIL` ever returns ranges out of order (e.g. after a future
+refactor), the cursor will skip ranges silently, producing wrong coverage data.  Add an
+assertion (debug builds) and document the contract.
+
+Additionally, the `insideExceptionHandlerOffsets` `HashSet<int>` is built by an O(instructions
+× exception_handlers) double loop.  For methods with many exception handlers (e.g. async state
+machines generated by Roslyn can have 10+ handlers), this is the dominant cost before any IL
+is instrumented.
+
+#### Proposed Fix
+Replace the double loop with a single pass over exception handlers only, storing `[start,
+end)` intervals, and check membership with an interval list instead of a per-offset set:
+
+```csharp
+// Build compact interval list – O(handlers) instead of O(instructions × handlers)
+List<(int start, int end)> exceptionHandlerRanges = [];
+foreach (ExceptionHandler eh in method.Body.ExceptionHandlers)
+{
+    if (eh.TryStart is not null)
+        exceptionHandlerRanges.Add((eh.TryStart.Offset, eh.TryEnd?.Offset ?? int.MaxValue));
+    if (eh.HandlerStart is not null)
+        exceptionHandlerRanges.Add((eh.HandlerStart.Offset, eh.HandlerEnd?.Offset ?? int.MaxValue));
+    if (eh.FilterStart is not null)
+        exceptionHandlerRanges.Add((eh.FilterStart.Offset, eh.HandlerStart?.Offset ?? int.MaxValue));
+}
+
+// Membership check: O(handlers) per instruction – better than O(1) HashSet when handlers < ~8
+bool IsInExceptionHandler(int offset)
+{
+    foreach ((int s, int e) in exceptionHandlerRanges)
+        if (offset >= s && offset < e) return true;
+    return false;
+}
+```
+
+For most methods (0–2 handlers) an interval list is faster than a `HashSet` due to
+lower allocation and better cache locality.  For async methods with many handlers (10+)
+sort the intervals and binary-search.
+
+**Expected gain:** Reduces `InstrumentIL` setup time for async-heavy assemblies (the new
+BS-1 `AsyncWorkload` will expose this).
+
+**Benchmark to verify:** `InstrumenterBenchmarks.InstrumenterBigClassBenchmark` with the new
+`AsyncWorkload` test subject.
+
+---
+
+### P13 – Avoid `module.GetTypes()` full-walk when all types are filtered
+
+#### Problem
+`InstrumentModule` calls `module.GetTypes()` unconditionally and then checks
+`IsTypeExcluded` / `IsTypeIncludedCached` per type.  For assemblies where the include filter
+does not match any type (common for transitive dependencies pulled in via
+`IncludeDirectories`), every type is loaded, fully resolved by Cecil, and then discarded.
+
+#### Proposed Fix
+Before calling `module.GetTypes()`, check whether the module name itself matches any include
+filter:
+
+```csharp
+string moduleName = Path.GetFileNameWithoutExtension(_module);
+if (!_instrumentationHelper.IsTypeIncluded(_module, "*", _parameters.IncludeFilters))
+{
+    // Module-level short-circuit: the module filter portion matches nothing.
+    // No type in this assembly can pass the include filter.
+    SkipModule = true;
+    return;
+}
+```
+
+This is a module-level fast-exit that avoids Cecil's full type enumeration for excluded modules.
+
+**Note:** The `IncludeFilters` format is `[ModuleGlob]TypeGlob`.  Pass `"*"` as the type
+portion to test only the module portion of the filter.  The existing `IsTypeFilterMatch`
+already handles wildcard type patterns.
+
+**Expected gain:** Significant wall-time reduction in multi-module projects where a broad
+`IncludeDirectories` picks up unrelated assemblies.
+
+**Benchmark to verify:** BS-2 (multi-module benchmark) with a mixed set of matching and
+non-matching module names.
+
+---
+
+## Implementation Priority
+
+| # | Proposal | Effort | Expected Impact | Risk | TFM | Benchmark |
+|---|----------|--------|----------------|------|-----|-----------|
+| BS-1 | Richer benchmark subject | Medium | Prerequisite | None | net8.0 | All |
+| BS-2 | Multi-module benchmark variant | Low | Prerequisite | None | net10.0 | P5/P13 |
+| P7 | Pre-group branches by line in reporters | Low | High | Low | all | ReportFormatBenchmarks |
+| P8 | Eliminate double-enumeration in CoverageSummary | Low | Medium | Low | all | ReportFormatBenchmarks |
+| P9 | Pre-group HitCandidates by docIndex | Low | Medium-High | Low | all | CalculateCoverageBenchmarks |
+| P11 | HashSet for BranchInCompilerGeneratedClass | Low | Medium | Low | all | ReportFormatBenchmarks |
+| P10 | Cache validation Regex | Low | Low | Low | all | InstrumentationOptionsBenchmarks |
+| P12 | Interval list for exception handler ranges | Medium | Medium | Low | all | InstrumenterBenchmarks |
+| P13 | Module-level short-circuit in InstrumentModule | Low | High (multi-module) | Medium | all | BS-2 |
+| P5 | Parallelise PrepareModules | High | Very High | High | net8.0+ | BS-2 |
+
+**Recommended sequence:**
+1. Implement **BS-1** first (richer subject), run all existing benchmarks to establish a
+   revised baseline.
+2. Apply **P7, P8, P9, P11** together (all low-risk, all reporter/coverage-result phase);
+   confirm with benchmarks before merging.
+3. Apply **P10** as a micro-cleanup with P7–P11.
+4. Apply **P12** after BS-1 shows async-workload overhead.
+5. Apply **P13** after BS-2 is available.
+6. **P5** in a separate PR after design review.
+
+---
+
+## Notes on LINQ vs. `foreach` (P3 revisited)
+
+On .NET 9/10 the JIT inlines `Enumerable.Any`, `Enumerable.Count`, and `Enumerable.Where`
+on small concrete `List<T>` / `T[]` collections aggressively.  The allocation cost comes from
+**iterator state machine heap objects** created for `IEnumerable<T>` chains that cross method
+boundaries and are not directly on a `List<T>`.
+
+The **right heuristic** is:
+- Replace LINQ only when the source is `IList<T>` or `IEnumerable<T>` (interface type,
+  devirtualisation not guaranteed) **and** the call site is inside a tight inner loop.
+- Keep LINQ when the source is a concrete `List<T>` or array — the JIT already handles it.
+- Always replace `.Count()` after a `.Where()` that isn't materialised (double-enumeration).
+
+---
+
+## Tracking Results
+
+Run `scripts/Update-BenchmarkHistory.ps1` after each benchmark run to append the new
+measurements to `BenchmarkHistory.md`.
+
+## Implementation Plan
+
+- ⏳ BS-1 – new richer benchmark subject
+- ⏳ BS-2 – multi-module benchmark variant
+- ⏳ P7, P8, P9, P10, P11 => single PR (reporter + coverage-result phase)
+- ⏳ P12 => separate PR (InstrumentIL change)
+- ⏳ P13 => separate PR (module-level short-circuit)
+- ⏭️ P5 => separate PR, requires design review (Cecil thread-safety)

--- a/test/coverlet.core.benchmark.tests/Program.cs
+++ b/test/coverlet.core.benchmark.tests/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Toni Solarin-Sodara
+// Copyright (c) Toni Solarin-Sodara
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 //using System.Diagnostics.Tracing;

--- a/test/coverlet.core.benchmark.tests/Simulator.cs
+++ b/test/coverlet.core.benchmark.tests/Simulator.cs
@@ -155,9 +155,14 @@ namespace coverlet.core.benchmark.tests
     [Benchmark(Description = "Simulate Workflow")]
     public void SimulateWorkflow()
     {
-      _logger.LogInformation($"SimulateWorkflow Directory: {Directory.GetCurrentDirectory()}");
-      _coverletTestSubjectArtifactPath = Directory.GetCurrentDirectory();
-      _coverletTestSubjectDllPath = Path.Combine(Directory.GetCurrentDirectory(), "coverlet.benchmark.subject.dll");
+      _coverletTestSubjectArtifactPath = AppContext.BaseDirectory;
+      _coverletTestSubjectDllPath = Path.Combine(_coverletTestSubjectArtifactPath, "coverlet.benchmark.subject.dll");
+      _logger.LogInformation($"SimulateWorkflow Artifact Directory: {_coverletTestSubjectArtifactPath}");
+
+      if (!File.Exists(_coverletTestSubjectDllPath))
+      {
+        throw new FileNotFoundException($"Test subject DLL not found at: {_coverletTestSubjectDllPath}");
+      }
 
       string pdbPath = Path.ChangeExtension(_coverletTestSubjectDllPath, ".pdb");
       if (!File.Exists(pdbPath))
@@ -300,11 +305,15 @@ namespace coverlet.core.benchmark.tests
         throw new FileNotFoundException($"Instrumented assembly not found at: {_coverletTestSubjectDllPath}");
       }
 
-      Process.RunToCompletion(
+      int exitCode = Process.RunToCompletion(
           DotnetMuxer.Path.FullName,
           $"\"{_coverletTestSubjectDllPath}\"",
           workingDirectory: _coverletTestSubjectArtifactPath);
 
+      if (exitCode != 0)
+      {
+        throw new InvalidOperationException($"Benchmark subject exited with code {exitCode}");
+      }
     }
 
     /// <summary>


### PR DESCRIPTION
This pull request updates the benchmark history documentation and improves the PowerShell script used to process benchmark results. The main focus is on making the benchmark table clearer by only showing user-defined parameter columns, handling different number formats, and skipping invalid or infrastructure-related data. Additionally, the script is enhanced for robustness and flexibility.

Key improvements include:

**Benchmark Table and Documentation:**
- The benchmark table in `BenchmarkHistory.md` now displays only user-configured `[Params]` values in the "Options" column, omitting infrastructure columns like Job, Toolchain, and others. Explanatory notes have been added to clarify this behavior.


**Coverlet.core performance improvement proposals**

| # | Proposal | Effort | Expected Impact | Risk |
|---|----------|--------|----------------|------|
| 2 | Cache type-exclusion results | Low | High | Low |
| 6 | Pre-compile filter expressions | Low | High | Low |
| 3 | Replace LINQ hot paths with loops | Low | Medium | Low |
| 4 | Pool `StringBuilder` in reporters | Low | Medium | Low |
| 1 | Avoid double module read | Medium | High | Medium |
| 5 | Parallelise `PrepareModules` | High | Very High | High |

