### PR TITLE
Add ReportGenerator to baseline exclude filters (coverlet.MTP)

### DIFF
--- a/src/coverlet.MTP/Configuration/CoverageConfiguration.cs
+++ b/src/coverlet.MTP/Configuration/CoverageConfiguration.cs
@@ -18,7 +18,7 @@ internal sealed class CoverageConfiguration
 
   // Permanent baseline: coverlet assemblies must always be excluded regardless of source.
   // All other test-framework assemblies are discovered dynamically at runtime via IProcessAssemblyHelper.
-  private static readonly string[] s_baselineExcludeFilters = ["[coverlet.*]*", "[Microsoft.VisualStudio.TestPlatform.*]*", "[testhost*]*"];
+  private static readonly string[] s_baselineExcludeFilters = ["[coverlet.*]*", "[Microsoft.VisualStudio.TestPlatform.*]*", "[testhost*]*", "[ReportGenerator.*]*"];
 
   private static readonly string[] s_defaultExcludeByAttributes =
   [

--- a/test/coverlet.MTP.tests/Configuration/CoverageConfigurationDynamicExcludeTests.cs
+++ b/test/coverlet.MTP.tests/Configuration/CoverageConfigurationDynamicExcludeTests.cs
@@ -47,7 +47,7 @@ public sealed class CoverageConfigurationDynamicExcludeTests
   {
     _mockProcessAssemblyHelper
       .Setup(x => x.GetDepsJsonAssemblyNames(s_fakeModuleDir, TestAssemblyName))
-      .Returns(["xunit.core", "ReportGenerator.Mtp"]);
+      .Returns(["xunit.core"]);
     _mockProcessAssemblyHelper
       .Setup(x => x.GetLoadedAssemblyNames(TestAssemblyName))
       .Returns([]);
@@ -62,7 +62,6 @@ public sealed class CoverageConfigurationDynamicExcludeTests
     string[] result = config.GetExcludeFilters();
 
     Assert.Contains("[xunit.core]*", result);
-    Assert.Contains("[ReportGenerator.Mtp]*", result);
   }
 
   [Fact]
@@ -106,7 +105,7 @@ public sealed class CoverageConfigurationDynamicExcludeTests
 
     string[] result = config.GetExcludeFilters();
 
-    Assert.Equal(["[coverlet.*]*", "[Microsoft.VisualStudio.TestPlatform.*]*", "[testhost*]*"], result);
+    Assert.Equal(["[coverlet.*]*", "[Microsoft.VisualStudio.TestPlatform.*]*", "[testhost*]*", "[ReportGenerator.*]*"], result);
   }
 
   [Fact]
@@ -127,7 +126,7 @@ public sealed class CoverageConfigurationDynamicExcludeTests
 
     string[] result = config.GetExcludeFilters();
 
-    Assert.Equal(["[coverlet.*]*", "[Microsoft.VisualStudio.TestPlatform.*]*", "[testhost*]*"], result);
+    Assert.Equal(["[coverlet.*]*", "[Microsoft.VisualStudio.TestPlatform.*]*", "[testhost*]*", "[ReportGenerator.*]*"], result);
   }
 
   [Fact]
@@ -166,7 +165,7 @@ public sealed class CoverageConfigurationDynamicExcludeTests
 
     string[] result = config.GetExcludeFilters();
 
-    Assert.Equal(["[coverlet.*]*", "[Microsoft.VisualStudio.TestPlatform.*]*", "[testhost*]*"], result);
+    Assert.Equal(["[coverlet.*]*", "[Microsoft.VisualStudio.TestPlatform.*]*", "[testhost*]*", "[ReportGenerator.*]*"], result);
     _mockProcessAssemblyHelper.Verify(
       x => x.GetDepsJsonAssemblyNames(It.IsAny<string>(), It.IsAny<string>()),
       Times.Never);


### PR DESCRIPTION
Update CoverageConfiguration to exclude "[ReportGenerator.\*]\*" assemblies. Adjust related tests in CoverageConfigurationDynamicExcludeTests to reflect the new baseline filter and remove dynamic exclusion expectations for ReportGenerator.

#1934