### PR TITLE
Update dependencies and GitHub Actions to latest versions

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-reportgenerator-globaltool": {
-      "version": "5.5.7",
+      "version": "5.5.10",
       "commands": [
         "reportgenerator"
       ],

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,10 +38,10 @@ jobs:
     runs-on: windows-latest  # Using Windows as per the benchmark results context
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         global-json-file: ./global.json
 
@@ -53,7 +53,7 @@ jobs:
       run: ./coverlet.core.benchmark.tests.exe
 
     - name: Upload Benchmark Results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: benchmark-results
         path: |

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -15,7 +15,7 @@ env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 
 permissions:
-  contents: read  
+  contents: read
   checks: write
   pull-requests: write
 
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
 
     - name: Setup .NET 9.0
-      uses: actions/setup-dotnet@v5.0.1
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 9.0.x
 #        source-url: https://pkgs.dev.azure.com/tonerdo/coverlet/_packaging/coverlet-nightly/nuget/v3/index.json
@@ -45,7 +45,7 @@ jobs:
 #         NUGET_AUTH_TOKEN: ${{ secrets.AZURE_DEVOPS_TOKEN }}
 
     - name: Setup .NET 8.0
-      uses: actions/setup-dotnet@v5.0.1
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 8.0.x
 #        source-url: https://pkgs.dev.azure.com/tonerdo/coverlet/_packaging/coverlet-nightly/nuget/v3/index.json
@@ -109,12 +109,12 @@ jobs:
   #           fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
 
   #       - name: Setup .NET 9.0
-  #         uses: actions/setup-dotnet@v5.0.1
+  #         uses: actions/setup-dotnet@v5
   #         with:
   #           dotnet-version: 9.0.x
 
   #       - name: Setup dotnet 8.0
-  #         uses: actions/setup-dotnet@v5.0.1
+  #         uses: actions/setup-dotnet@v5
   #         with:
   #           dotnet-version: '8.0.x'
 
@@ -147,7 +147,7 @@ jobs:
     #     MSBUILDDISABLENODEREUSE: 1
 
     - name: ReportGenerator
-      uses: danielpalme/ReportGenerator-GitHub-Action@5.5.7
+      uses: danielpalme/ReportGenerator-GitHub-Action@5.5.10
       if: success() && matrix.os  == 'windows-latest'
       with:
         reports: ./artifacts/reports/**/*.cobertura.xml
@@ -187,7 +187,7 @@ jobs:
         compare_to_earlier_commit: false
 
     - name: Publish Test Results
-      uses: EnricoMi/publish-unit-test-result-action/macos@v2.21.0
+      uses: EnricoMi/publish-unit-test-result-action/macos@v2
       if: ${{ !cancelled() && matrix.os == 'macos-latest' }}
       with:
         files: |
@@ -198,7 +198,7 @@ jobs:
         compare_to_earlier_commit: false
 
     - name: Publish Test Results
-      uses: EnricoMi/publish-unit-test-result-action/windows@v2.21.0
+      uses: EnricoMi/publish-unit-test-result-action/windows@v2
       if: ${{ !cancelled() && matrix.os  == 'windows-latest' }}
       with:
         files: |

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,7 @@
     <MicrosoftCodeAnalysisVersion>5.3.0</MicrosoftCodeAnalysisVersion> <!-- .NET 8.0 support -->
     <NugetPackageVersion>7.6.0</NugetPackageVersion>
     <!-- Test Platform, .NET Test SDK and Object Model  -->
-    <MicrosoftNETTestSdkVersion>18.5.1</MicrosoftNETTestSdkVersion>
+    <MicrosoftNETTestSdkVersion>18.6.0</MicrosoftNETTestSdkVersion>
     <XunitV3Version>3.2.2</XunitV3Version>
     <XunitRunnerVisualstudioVersion>3.1.5</XunitRunnerVisualstudioVersion>
     <MicrosoftTestingPlatformVersion>2.2.3</MicrosoftTestingPlatformVersion>


### PR DESCRIPTION
- Bump ReportGenerator tool to 5.5.10 in dotnet-tools.json
- Update GitHub Actions (checkout, setup-dotnet, upload-artifact, ReportGenerator, publish-unit-test-result-action) to latest major/minor versions in benchmark.yml and dotnet.yml
- Upgrade Microsoft.NET.Test.Sdk to 18.6.0 in Directory.Packages.props
- Ensures improved stability, compatibility, and access to new features and fixes