### PR TITLE
Enhance benchmark subject with entry point and error handling

### DIFF
--- a/test/coverlet.benchmark.subject/Program.cs
+++ b/test/coverlet.benchmark.subject/Program.cs
@@ -17,10 +17,11 @@ namespace coverlet.benchmark.subject
   /// </remarks>
   internal static class Program
   {
+    private static int s_failures;
     private static int Main(string[] args)
     {
       Run();
-      return 0;
+      return s_failures == 0 ? 0 : 1;
     }
 
     private static void Run()
@@ -46,6 +47,7 @@ namespace coverlet.benchmark.subject
       }
       catch (Exception ex)
       {
+        s_failures++;
         Console.Error.WriteLine($"[subject] {workloadName} failed: {ex.GetType().FullName}: {ex.Message}");
       }
     }

--- a/test/coverlet.benchmark.subject/Program.cs
+++ b/test/coverlet.benchmark.subject/Program.cs
@@ -1,0 +1,273 @@
+﻿// Copyright (c) Toni Solarin-Sodara
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+using System.Collections.Generic;
+
+namespace coverlet.benchmark.subject
+{
+  /// <summary>
+  /// Benchmark subject entry point used by <c>coverlet.core.benchmark.tests</c>.
+  /// </summary>
+  /// <remarks>
+  /// This program intentionally executes representative paths across all workload types so
+  /// <c>CoverageWorkflowBenchmark</c> can run the instrumented assembly and produce tracker hit files.
+  /// It is benchmark harness code, not shipping product behavior.
+  /// </remarks>
+  internal static class Program
+  {
+    private static int Main(string[] args)
+    {
+      Run();
+      return 0;
+    }
+
+    private static void Run()
+    {
+      RunAsyncWorkload();
+      RunAutoPropsWorkload();
+      RunDeepNestingWorkload();
+      RunExcludedWorkload();
+      RunGenericWorkload();
+      RunIteratorWorkload();
+      RunLambdaWorkload();
+      RunSwitchWorkload();
+    }
+
+    private static void RunAsyncWorkload()
+    {
+      var workload = new AsyncWorkload();
+      _ = workload.ComputeAsync(1, 2).GetAwaiter().GetResult();
+      _ = workload.FormatAsync(42).GetAwaiter().GetResult();
+      _ = workload.NestedComputeAsync(1, 2, 3).GetAwaiter().GetResult();
+      _ = workload.NestedFormatAsync(1, 2).GetAwaiter().GetResult();
+      _ = workload.SumSequenceAsync([1, 2, 3]).GetAwaiter().GetResult();
+      _ = workload.FormatManyAsync([1, 2, 3]).GetAwaiter().GetResult();
+      _ = workload.SafeComputeAsync(1, 2).GetAwaiter().GetResult();
+      _ = workload.SafeFormatAsync(3).GetAwaiter().GetResult();
+      _ = workload.ComputeAndFormatAsync(2, 3).GetAwaiter().GetResult();
+      _ = workload.IsPositiveSumAsync(1, 2).GetAwaiter().GetResult();
+      _ = workload.ParallelComputeAsync([1, 2, 3]).GetAwaiter().GetResult();
+      _ = workload.FirstResultAsync(1, 2).GetAwaiter().GetResult();
+      _ = workload.ComputeWithTimeoutAsync(1, 2, 1000).GetAwaiter().GetResult();
+      _ = workload.ComputeValueTaskAsync(1, 2).AsTask().GetAwaiter().GetResult();
+      _ = workload.IsZeroAsync(0).AsTask().GetAwaiter().GetResult();
+      _ = workload.DeeplyNestedAsync(4).GetAwaiter().GetResult();
+      workload.FireAndForgetCompute(1, 2);
+    }
+
+    private static void RunAutoPropsWorkload()
+    {
+      _ = new AutoProps10();
+      _ = new AutoProps25();
+      var noCtor = new RecordNoCtor { Name = "A", Age = 1 };
+      var emptyCtor = new RecordEmptyCtor { Name = "B", Age = 2 };
+      var withCtor = new RecordWithPrimaryCtor("C", 3);
+      _ = noCtor.Display();
+      _ = emptyCtor.Display();
+      _ = withCtor.Display();
+      _ = new CircleRecord { Radius = 2 }.Area();
+      _ = new RectangleRecord { Width = 2, Height = 3 }.Area();
+      _ = new OrderRecord("id", 10, "pending").Describe();
+      _ = new ProductRecord("sku", "name", 5, 1).StockStatus();
+      var aggregator = new RecordAggregator
+      {
+        NoCtor = noCtor,
+        EmptyCtor = emptyCtor,
+        WithCtor = withCtor
+      };
+
+      _ = aggregator.Summary();
+    }
+
+    private static void RunDeepNestingWorkload()
+    {
+      var level1 = new Level1();
+      _ = level1.Compute(1);
+      _ = level1.Inner.Compute(1);
+      _ = level1.Inner.Inner.Compute(1);
+      _ = level1.Inner.Inner.Inner.Compute(1);
+      _ = level1.Inner.Inner.Inner.Inner.Compute(1);
+      _ = level1.Inner.Inner.Inner.Inner.IsPositive(1);
+      _ = level1.Inner.Inner.Inner.Inner.Label(1);
+      _ = level1.Label(1);
+      _ = level1.Inner.Label(1);
+      _ = level1.Inner.Inner.Label(1);
+
+      var covered = new CoveredOuter();
+      _ = covered.TopMethod(1);
+      _ = new CoveredOuter.CoveredInner1().Method(1);
+      _ = new CoveredOuter.CoveredInner1.CoveredSiblingInner2().Check(1);
+      _ = new CoveredOuter.CoveredInner1B().Label(1);
+      _ = new ContainerWithStaticNested().InstanceMethod(1);
+      _ = ContainerWithStaticNested.GetDefault();
+      _ = ContainerWithStaticNested.GetMaxRetries();
+
+      var host = new ModuleHost();
+      host.Register(new ModuleHost.DefaultPlugin());
+      host.Register(new ModuleHost.AdvancedPlugin("x"));
+      _ = host.Plugins.Count;
+
+      var deep = new Deep7();
+      _ = deep.Depth;
+      _ = new Deep7.L2.L3.L4.L5.L6.L7().IsMax(7);
+    }
+
+    private static void RunExcludedWorkload()
+    {
+      _ = new PartiallyExcludedClass().Add(1, 2);
+      _ = new PartiallyExcludedClass().Multiply(2, 3);
+      _ = new PartiallyExcludedClass().IsPositive(1);
+      _ = new PartiallyExcludedClass().Subtract(3, 1);
+
+      var propertyExclusion = new PropertyExclusionClass { Value = 1, Tag = "x" };
+      _ = propertyExclusion.Compute();
+
+      var outer = new OuterClass();
+      _ = outer.CoveredMethod(1);
+      _ = new OuterClass.CoveredNestedClass().Calc(2);
+      _ = new CoveredSiblingA().Method1(1);
+      _ = new CoveredSiblingC().Check(10);
+      _ = new CoveredSiblingE().Label(1);
+      _ = new MethodLevelCustomExclusion().Covered(1);
+      _ = new MethodLevelCustomExclusion().AlsoCovered(1);
+
+      IWorkItem item = new CoveredWorkItem(1);
+      item.Execute();
+      _ = item.Priority;
+    }
+
+    private static void RunGenericWorkload()
+    {
+      var pair = new Pair<int, string>(1, "a");
+      _ = pair.Swap();
+
+      var repository = new Repository<string>();
+      int id = repository.Add("x");
+      _ = repository.TryGet(id, out string? value);
+      _ = value;
+      _ = repository.Count;
+
+      var stack = new BoundedStack<int>(4);
+      _ = stack.TryPush(1);
+      _ = stack.TryPeek(out int top);
+      _ = top;
+
+      var workload = new GenericWorkload();
+      _ = workload.Identity(1);
+      _ = workload.FirstOrNull(["a", "b"], x => x == "a");
+      _ = workload.Transform(2, x => x + 1);
+      _ = workload.Select([1, 2, 3], x => x * 2);
+      _ = workload.Filter([1, 2, 3], x => x > 1);
+      _ = workload.MakePair(1, "b");
+      _ = workload.TryFind([1, 2, 3], x => x == 2);
+      _ = workload.Max(2, 3);
+      _ = workload.Min(2, 3);
+      _ = workload.Clamp(3, 1, 5);
+      _ = workload.Sort([3, 2, 1]);
+      _ = workload.Contains([1, 2, 3], 2);
+      _ = workload.BinarySearch([1, 2, 3], 2);
+      _ = workload.CreateDefault<List<int>>();
+      _ = workload.CreateList<List<int>>(2);
+      _ = workload.FillArray(3, 1);
+      _ = workload.FromNullable<int>(1);
+      _ = workload.AllSatisfy([1, 2, 3], x => x > 0);
+      _ = workload.Reduce([1, 2, 3], 0, (acc, x) => acc + x);
+    }
+
+    private static void RunIteratorWorkload()
+    {
+      var workload = new IteratorWorkload();
+      Consume(workload.Range(0, 3));
+      Consume(workload.Evens(4));
+      Consume(workload.Odds(5));
+      Consume(workload.Squares(3));
+      Consume(workload.Fibonacci(5));
+      Consume(workload.PositiveValues([-1, 0, 1, 2]));
+      Consume(workload.TakeWhilePositive([1, 2, 0, 3]));
+      Consume(workload.SkipNegatives([-2, -1, 0, 1]));
+      Consume(workload.ToStrings([-1, 0, 1], "p"));
+      Consume(workload.Flatten([[1, 2], [3, 4]]));
+      Consume(workload.Interleave([1, 3], [2, 4]));
+      Consume(workload.WithCleanup([1, 2], () => { }));
+      Consume(workload.SafeRange(0, 3));
+      Consume(workload.Indexed([1, 2, 3]));
+      Consume(workload.Batch([1, 2, 3, 4], 2));
+      Consume(workload.BoxedRange(0, 3));
+      Consume(workload.Chain(3));
+      Consume(workload.ZipSum([1, 2], [3, 4]));
+      Consume(workload.RunningSum([1, 2, 3]));
+      Consume(workload.MovingAverage([1, 2, 3, 4], 2));
+    }
+
+    private static void RunLambdaWorkload()
+    {
+      var workload = new LambdaWorkload();
+      _ = workload.ApplyTwice(x => x + 1, 1);
+      _ = workload.Adder(2)(3);
+      _ = workload.Multiplier(3)(2);
+      _ = workload.RangeChecker(1, 3)(2);
+
+      var log = new List<int>();
+      workload.BuildLogger(log)(1);
+
+      _ = workload.FilterAndDouble([1, 2, 3], 1);
+      _ = workload.TopN([1, 2, 3], 2, 1);
+      _ = workload.GroupBySign([-1, 0, 1]);
+      _ = workload.AnyAbove([1, 2, 3], 2);
+      _ = workload.SumPositive([-1, 1, 2]);
+      _ = workload.AverageNonZero([0.0, 2.0]);
+      _ = workload.TransformAndFilter([1, 2, 3], 1, 3);
+      _ = workload.FrequencyMap([1, 1, 2]);
+      _ = workload.SumRecursive(4);
+      _ = workload.FilterAndProcessLocal([1, 2, 3], 1);
+      _ = workload.BuildPipeline(1, 2, 1)(3);
+
+      workload.Subscribe(_ => { });
+      workload.Value = 1;
+
+      _ = workload.SortWithComparison([1, 3, 2], descending: true);
+      _ = workload.FilterWith([1, 2, 3], x => x > 1);
+      workload.ForEachIf([1, 2, 3], x => x > 1, _ => { });
+      _ = workload.Memoize(x => x + 1)(1);
+      _ = workload.Curry((a, b) => a + b)(1)(2);
+      _ = workload.Compose(x => x + 1, x => x * 2)(2);
+      _ = workload.ComposeMany([x => x + 1, x => x * 2])(2);
+      _ = workload.ConditionalTransform(true, 1)(2);
+      _ = workload.TryGet(() => 1, 0);
+      _ = workload.SafeTransform([1, 2, 3], x => x + 1);
+    }
+
+    private static void RunSwitchWorkload()
+    {
+      var workload = new SwitchWorkload();
+      _ = workload.ClassifyScore(80);
+      _ = workload.MapCodeToValue(10);
+      _ = workload.ParseMonthNumber("jan");
+      _ = workload.GetSeason(6);
+      _ = workload.DescribeObject("x");
+      _ = workload.ClassifyPair(1, -1);
+      _ = workload.ClassifyTriangle(3, 4, 5);
+      _ = workload.ComputePoints("gold", 10);
+      _ = workload.GetDeadlineHours(SwitchWorkload.Priority.High);
+      _ = workload.GetPriorityColor(SwitchWorkload.Priority.Critical);
+      _ = workload.ClassifyCharacter('x');
+      _ = workload.TransformArray([1, 2, 3], "square");
+      _ = workload.Dispatch(1, -1, 1);
+    }
+
+    private static void Consume<T>(IEnumerable<T> values)
+    {
+      foreach (T _ in values)
+      {
+      }
+    }
+
+    private static void Consume(IEnumerable values)
+    {
+      foreach (object _ in values)
+      {
+      }
+    }
+  }
+}

--- a/test/coverlet.benchmark.subject/Program.cs
+++ b/test/coverlet.benchmark.subject/Program.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Toni Solarin-Sodara
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -24,14 +25,29 @@ namespace coverlet.benchmark.subject
 
     private static void Run()
     {
-      RunAsyncWorkload();
-      RunAutoPropsWorkload();
-      RunDeepNestingWorkload();
-      RunExcludedWorkload();
-      RunGenericWorkload();
-      RunIteratorWorkload();
-      RunLambdaWorkload();
-      RunSwitchWorkload();
+      RunSafely(nameof(RunAsyncWorkload), RunAsyncWorkload);
+      RunSafely(nameof(RunAutoPropsWorkload), RunAutoPropsWorkload);
+      RunSafely(nameof(RunDeepNestingWorkload), RunDeepNestingWorkload);
+      RunSafely(nameof(RunExcludedWorkload), RunExcludedWorkload);
+      RunSafely(nameof(RunGenericWorkload), RunGenericWorkload);
+      RunSafely(nameof(RunIteratorWorkload), RunIteratorWorkload);
+      RunSafely(nameof(RunLambdaWorkload), RunLambdaWorkload);
+      RunSafely(nameof(RunSwitchWorkload), RunSwitchWorkload);
+    }
+
+    private static void RunSafely(string workloadName, Action action)
+    {
+      ArgumentNullException.ThrowIfNull(workloadName);
+      ArgumentNullException.ThrowIfNull(action);
+
+      try
+      {
+        action();
+      }
+      catch (Exception ex)
+      {
+        Console.Error.WriteLine($"[subject] {workloadName} failed: {ex.GetType().FullName}: {ex.Message}");
+      }
     }
 
     private static void RunAsyncWorkload()
@@ -53,7 +69,6 @@ namespace coverlet.benchmark.subject
       _ = workload.ComputeValueTaskAsync(1, 2).AsTask().GetAwaiter().GetResult();
       _ = workload.IsZeroAsync(0).AsTask().GetAwaiter().GetResult();
       _ = workload.DeeplyNestedAsync(4).GetAwaiter().GetResult();
-      workload.FireAndForgetCompute(1, 2);
     }
 
     private static void RunAutoPropsWorkload()

--- a/test/coverlet.benchmark.subject/coverlet.benchmark.subject.csproj
+++ b/test/coverlet.benchmark.subject/coverlet.benchmark.subject.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <IsTestProject>false</IsTestProject>
     <Nullable>enable</Nullable>

--- a/test/coverlet.core.benchmark.tests/HowTo.md
+++ b/test/coverlet.core.benchmark.tests/HowTo.md
@@ -16,6 +16,49 @@ cd artifacts/bin/coverlet.core.benchmark.tests/release_net10.0
 ./coverlet.core.benchmark.tests.exe
 ```
 
+### Run a specific benchmark with `--filter`
+
+When CLI arguments are provided, benchmark execution is delegated to `BenchmarkSwitcher`,
+so BenchmarkDotNet built-in filters are honored.
+
+List benchmarks (full names):
+
+```bash
+./coverlet.core.benchmark.tests.exe --list flat
+```
+
+Current benchmark full names:
+
+```text
+coverlet.core.benchmark.tests.AutoPropsBenchmarks.InstrumentAutoPropsAndRecords
+coverlet.core.benchmark.tests.CoverageBenchmarks.GetCoverageBenchmark
+coverlet.core.benchmark.tests.CoverageWorkflowBenchmark.SimulateWorkflow
+coverlet.core.benchmark.tests.InstrumentationOptionsBenchmarks.InstrumentWithOptions
+coverlet.core.benchmark.tests.InstrumenterBenchmarks.InstrumenterBenchmark
+coverlet.core.benchmark.tests.ReportFormatBenchmarks.GetCoverageAndReport
+```
+
+Run one benchmark by full name:
+
+```bash
+./coverlet.core.benchmark.tests.exe --filter "coverlet.core.benchmark.tests.CoverageWorkflowBenchmark.SimulateWorkflow"
+```
+
+Run benchmarks by glob pattern:
+
+```bash
+./coverlet.core.benchmark.tests.exe --filter "*.InstrumenterBenchmarks.*"
+```
+
+### Enable verbose benchmark subject logs (troubleshooting)
+
+By default, benchmark subject stdout/stderr logs are suppressed and only emitted on failures.
+To force verbose subject logs, set this environment variable before running benchmarks:
+
+```powershell
+$env:COVERLET_BENCHMARK_VERBOSE_SUBJECT_LOGS='1'
+```
+
 > [!TIP]
 > If an error occurs about a missing `TestAssets\System.Private.CoreLib.dll` or
 > `TestAssets\System.Private.CoreLib.pdb`, copy the files from

--- a/test/coverlet.core.benchmark.tests/Program.cs
+++ b/test/coverlet.core.benchmark.tests/Program.cs
@@ -69,6 +69,8 @@ namespace coverlet.core.benchmark.tests
       {
         // When CLI arguments are provided, delegate to BenchmarkSwitcher so built-in
         // BenchmarkDotNet filters like --filter are honored.
+        CultureInfo.DefaultThreadCurrentCulture = noGroupSeparatorCulture;
+        CultureInfo.DefaultThreadCurrentUICulture = noGroupSeparatorCulture;
         BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
         return;
       }

--- a/test/coverlet.core.benchmark.tests/Program.cs
+++ b/test/coverlet.core.benchmark.tests/Program.cs
@@ -65,6 +65,14 @@ namespace coverlet.core.benchmark.tests
             .AddExporter(new CsvExporter(CsvSeparator.Semicolon), JsonExporter.Default, MarkdownExporter.GitHub)
             .AddDiagnoser(MemoryDiagnoser.Default);
 
+      if (args.Length > 0)
+      {
+        // When CLI arguments are provided, delegate to BenchmarkSwitcher so built-in
+        // BenchmarkDotNet filters like --filter are honored.
+        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+        return;
+      }
+
       var summary = BenchmarkRunner.Run(new[]{
             BenchmarkConverter.TypeToBenchmarks( typeof(CoverageBenchmarks), config),
             BenchmarkConverter.TypeToBenchmarks( typeof(InstrumenterBenchmarks), config),
@@ -73,9 +81,6 @@ namespace coverlet.core.benchmark.tests
             BenchmarkConverter.TypeToBenchmarks( typeof(ReportFormatBenchmarks), config),
             BenchmarkConverter.TypeToBenchmarks( typeof(AutoPropsBenchmarks), vsProfilingConfig),
             });
-
-      // Use this to select benchmarks from the console and execute with additional options e.g. 'coverlet.core.benchmark.tests.exe --profiler EP'
-      //var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
     }
   }
 }

--- a/test/coverlet.core.benchmark.tests/Simulator.cs
+++ b/test/coverlet.core.benchmark.tests/Simulator.cs
@@ -155,9 +155,14 @@ namespace coverlet.core.benchmark.tests
     [Benchmark(Description = "Simulate Workflow")]
     public void SimulateWorkflow()
     {
-      _logger.LogInformation($"SimulateWorkflow Directory: {Directory.GetCurrentDirectory()}");
-      _coverletTestSubjectArtifactPath = Directory.GetCurrentDirectory();
-      _coverletTestSubjectDllPath = Path.Combine(Directory.GetCurrentDirectory(), "coverlet.benchmark.subject.dll");
+      _coverletTestSubjectArtifactPath = AppContext.BaseDirectory;
+      _coverletTestSubjectDllPath = Path.Combine(_coverletTestSubjectArtifactPath, "coverlet.benchmark.subject.dll");
+      _logger.LogInformation($"SimulateWorkflow Artifact Directory: {_coverletTestSubjectArtifactPath}");
+
+      if (!File.Exists(_coverletTestSubjectDllPath))
+      {
+        throw new FileNotFoundException($"Test subject DLL not found at: {_coverletTestSubjectDllPath}");
+      }
 
       string pdbPath = Path.ChangeExtension(_coverletTestSubjectDllPath, ".pdb");
       if (!File.Exists(pdbPath))
@@ -300,11 +305,15 @@ namespace coverlet.core.benchmark.tests
         throw new FileNotFoundException($"Instrumented assembly not found at: {_coverletTestSubjectDllPath}");
       }
 
-      Process.RunToCompletion(
+      int exitCode = Process.RunToCompletion(
           DotnetMuxer.Path.FullName,
           $"\"{_coverletTestSubjectDllPath}\"",
           workingDirectory: _coverletTestSubjectArtifactPath);
 
+      if (exitCode != 0)
+      {
+        throw new InvalidOperationException($"Benchmark subject exited with code {exitCode}");
+      }
     }
 
     /// <summary>

--- a/test/coverlet.core.benchmark.tests/Simulator.cs
+++ b/test/coverlet.core.benchmark.tests/Simulator.cs
@@ -175,7 +175,7 @@ namespace coverlet.core.benchmark.tests
         Module = _coverletTestSubjectDllPath,
         IncludeFilters = ["[coverlet.benchmark.subject]*"],
         IncludeDirectories = [_coverletTestSubjectArtifactPath],
-        ExcludeFilters = null,
+        ExcludeFilters = ["[coverlet.benchmark.subject]coverlet.benchmark.subject.Program*"],
         ExcludedSourceFiles = null,
         ExcludeAttributes = null,
         IncludeTestAssembly = true,
@@ -305,10 +305,32 @@ namespace coverlet.core.benchmark.tests
         throw new FileNotFoundException($"Instrumented assembly not found at: {_coverletTestSubjectDllPath}");
       }
 
+      var stdOut = new List<string>();
+      var stdErr = new List<string>();
       int exitCode = Process.RunToCompletion(
           DotnetMuxer.Path.FullName,
           $"\"{_coverletTestSubjectDllPath}\"",
+          line => stdOut.Add(line),
+          line => stdErr.Add(line),
           workingDirectory: _coverletTestSubjectArtifactPath);
+
+      bool logSubjectOutput = string.Equals(
+          Environment.GetEnvironmentVariable("COVERLET_BENCHMARK_VERBOSE_SUBJECT_LOGS"),
+          "1",
+          StringComparison.Ordinal);
+
+      if (logSubjectOutput || exitCode != 0)
+      {
+        foreach (string line in stdOut)
+        {
+          _logger.LogVerbose($"[subject stdout] {line}");
+        }
+
+        foreach (string line in stdErr)
+        {
+          _logger.LogWarning($"[subject stderr] {line}");
+        }
+      }
 
       if (exitCode != 0)
       {


### PR DESCRIPTION
This pull request enhances the benchmarking infrastructure for `coverlet.core.benchmark.tests` by introducing a dedicated executable subject harness, improving logging and diagnostics, and expanding documentation for running and filtering benchmarks. The main changes include adding a new `Program.cs` entry point for the benchmark subject, updating the test harness to use this executable, improving error handling and output logging, and clarifying usage instructions.

**Benchmark subject harness improvements:**

* Added a new `Program.cs` entry point to `coverlet.benchmark.subject` that exercises all representative code paths for benchmarking and coverage, ensuring all workloads are executed in a controlled manner. (`test/coverlet.benchmark.subject/Program.cs`)
* Updated the project file to build the benchmark subject as an executable (`OutputType=Exe`). (`test/coverlet.benchmark.subject/coverlet.benchmark.subject.csproj`)

**Test harness and diagnostics enhancements:**

* Changed the test harness to locate the benchmark subject DLL using `AppContext.BaseDirectory` for greater reliability, added explicit error handling if the DLL is missing, and improved logging of artifact locations. (`test/coverlet.core.benchmark.tests/Simulator.cs`)
* Excluded the new benchmark subject's `Program` class from coverage analysis to avoid instrumenting the harness itself. (`test/coverlet.core.benchmark.tests/Simulator.cs`)
* Captured and optionally logged the stdout/stderr output from the subject process, with verbose logging controlled by the `COVERLET_BENCHMARK_VERBOSE_SUBJECT_LOGS` environment variable; errors now throw with clear messages. (`test/coverlet.core.benchmark.tests/Simulator.cs`)

**Benchmark runner and documentation updates:**

* Modified the benchmark runner to delegate to `BenchmarkSwitcher` when CLI arguments are provided, enabling native support for filters and other BenchmarkDotNet options. (`test/coverlet.core.benchmark.tests/Program.cs`) 
* Expanded documentation with instructions for listing and filtering benchmarks, and for enabling verbose subject logs for troubleshooting. (`test/coverlet.core.benchmark.tests/HowTo.md`)