### PR TITLE
Add preflight checks for locked/unresolvable assemblies

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -85,29 +85,45 @@ Extension methods are static methods that cannot be intercepted by Moq. Using th
 #### Example: Mocking ILogger
 
 ❌ **INCORRECT** - Will throw `NotSupportedException`:
+
+```cs
 // This will FAIL at runtime
 _mockLogger.Verify(x => x.LogInformation(It.IsAny<string>()), Times.Once);
 _mockLogger.Verify(x => x.LogInformation(It.Is<string>(s => s.Contains("json"))), Times.Once);
 _mockLogger.Setup(x => x.LogWarning(It.IsAny<string>()));
+```
+
 ✅ **CORRECT** - Mocks the underlying `Log` method:
+
+```cs
 // Verify LogInformation was called once
 _mockLogger.Verify(x => x.Log(LogLevel.Information, It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception?>(), It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
 // Verify LogInformation was called with a message containing "json"
 _mockLogger.Verify(x => x.Log(LogLevel.Information, It.IsAny<EventId>(), It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("json")), It.IsAny<Exception?>(), It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
 // Setup LogWarning behavior
 _mockLogger.Setup(x => x.Log(LogLevel.Warning, It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception?>(), It.IsAny<Func<It.IsAnyType, Exception?, string>>()));
+```
+
 #### Example: Mocking LogDebug
 
 ❌ **INCORRECT**:
+
+```cs
 // This will FAIL at runtime
 _mockLogger.Verify(x => x.LogDebug(It.IsAny<string>()), Times.Once);
+```
+
 ✅ **CORRECT** - Mocks the underlying `Log` method:
+
+```cs
 // Verify LogDebug was called once
 _mockLogger.Verify(x => x.Log(LogLevel.Debug, It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception?>(), It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
 // Verify LogDebug was called with a message containing "xml"
 _mockLogger.Verify(x => x.Log(LogLevel.Debug, It.IsAny<EventId>(), It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("xml")), It.IsAny<Exception?>(), It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
 // Setup LogError behavior
 _mockLogger.Setup(x => x.Log(LogLevel.Error, It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception?>(), It.IsAny<Func<It.IsAnyType, Exception?, string>>()));
+```
+
 **Key Points:**
 1. Always use `ILogger.Log()` with the appropriate `LogLevel` instead of extension methods.
 2. Use `It.IsAny<It.IsAnyType>()` for the state parameter.
@@ -144,10 +160,16 @@ This codebase uses **TWO different ILogger interfaces** with different signature
 **Common Pitfall - Microsoft.Testing.Platform.Logging.ILogger:**
 
 ❌ **INCORRECT** - Assumes `EventId` parameter (which doesn't exist in MTP Logger):
+
+```cs
 // BAD - Microsoft.Testing.Platform.Logging.ILogger does NOT have EventId
 _mockLogger.Verify(x => x.Log(LogLevel.Information, It.IsAny<EventId>(), // ⚠️ EventId does NOT exist in MTP LOGGER
      It.IsAny<It.IsAnyType>(), It.IsAny<Exception?>(), It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
+```
+
 ✅ **CORRECT** - Uses actual MTP ILogger API signature (async methods):
+
+```cs
 // GOOD - Microsoft.Testing.Platform.Logging.ILogger uses simple async methods
 _mockLogger.Verify(x => x.LogInformationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
 _mockLogger.Verify(x => x.LogErrorAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
@@ -157,6 +179,8 @@ _mockLogger.Verify(x => x.LogInformationAsync(It.Is<string>(s => s.Contains("exp
 // For synchronous extension methods (from LoggerExtensions):
 _mockLogger.Verify(x => x.LogInformation(It.IsAny<string>()), Times.Once);
 _mockLogger.Verify(x => x.LogInformation(It.Is<string>(s => s.Contains("Coverage reports generated"))), Times.Once);
+```
+
 **Verification Checklist:**
 - [ ] I have searched for the interface definition using `get_symbols_by_name`.
 - [ ] I have reviewed existing usage in the codebase using `code_search`.
@@ -176,6 +200,7 @@ When mocking interfaces, **reference actual adapter implementations** in the cod
 - `src/coverlet.core/Abstractions/ILogger.cs` - Coverlet's internal logger interface.
 
 **Example from CoverletLoggerAdapter.cs:**
+
 ```csharp
 // Shows actual MTP ILogger usage - simple methods, no EventId
 public void LogInformation(string message, bool important = false)
@@ -236,9 +261,10 @@ public void LogInformation(string message, bool important = false)
 4. **Avoid extension methods in Moq** - They cannot be intercepted and will cause runtime exceptions.
 5. **Use simulated paths** - Always use fake paths like `/fake/path/test.dll` in test mocks.
 6. **Verify existing tests** - Check for duplicates before adding new test methods.
-7. **Use Theory for parameterized tests** - Don't create multiple test methods for different input values
+7. **Use Theory for parameterized tests** - Don't create multiple test methods for different input values.
 
+## Issue-Specific Guidelines
 
-- @azure Rule - Use Azure Tools - When handling requests related to Azure, always use your tools.
-- @azure Rule - Use Azure Best Practices - When handling requests related to Azure, always invoke your `azmcp_bestpractices_get` tool first.
-- @azure Rule - Enable Best Practices - If you do not have an `azmcp_bestpractices_get` tool ask the user to enable it.
+- For issue #1965, identify problematic assemblies before instrumentation and skip them, rather than relying on partial-restore/non-fatal restore behavior after failure.
+- For assembly-level instrumentation viability, preflight logic should only check lock and resolvability, not PDB/source-based exclusion; PDB/source exclusion remains handled by existing assembly-without-sources filtering via CanInstrument/options.
+- **Prefer calling `instrumenter.CanInstrument()` before preflight** so assemblies already excluded by existing coverage filters (no PDB/no local sources) skip preflight probing.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -176,9 +176,9 @@ _mockLogger.Verify(x => x.LogErrorAsync(It.IsAny<string>(), It.IsAny<Cancellatio
 _mockLogger.Verify(x => x.LogWarningAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
 // To verify message content:
 _mockLogger.Verify(x => x.LogInformationAsync(It.Is<string>(s => s.Contains("expected text")), It.IsAny<CancellationToken>()), Times.Once);
-// For synchronous extension methods (from LoggerExtensions):
-_mockLogger.Verify(x => x.LogInformation(It.IsAny<string>()), Times.Once);
-_mockLogger.Verify(x => x.LogInformation(It.Is<string>(s => s.Contains("Coverage reports generated"))), Times.Once);
+ // For synchronous LoggerExtensions (extension methods):
+ // NOTE: These are extension methods and cannot be verified with Moq; verify the underlying Log(...) call instead.
+ _mockLogger.Verify(x => x.Log(LogLevel.Information, It.Is<string>(s => s.Contains("Coverage reports generated")), It.IsAny<Exception?>(), It.IsAny<Func<string, Exception?, string>>()), Times.Once);
 ```
 
 **Verification Checklist:**

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,6 +25,7 @@
         "reportgenerator",
         "reporttypes",
         "runsettings",
+        "slnx",
         "targetargs",
         "TARGETARGS",
         "targetdir",

--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -9,13 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
-- Implement dynamic exclusion filters for assemblies (Coverlet.MTP)  [#1946](https://github.com/coverlet-coverage/coverlet/pull/1946)
-- Replace legacy .sln files with modern .slnx format [1966](https://github.com/coverlet-coverage/coverlet/pull/1966)
+- Implement dynamic exclusion filters for assemblies (Coverlet.MTP) [#1946](https://github.com/coverlet-coverage/coverlet/pull/1946)
+- Add preflight checks for locked/unresolvable assemblies [#1967](https://github.com/coverlet-coverage/coverlet/pull/1967)
+- Replace legacy .sln files with modern .slnx format [#1966](https://github.com/coverlet-coverage/coverlet/pull/1966)
 
 ### Fixed
 
 - Fix Regression in branch coverage for lambda expressions [#1937](https://github.com/coverlet-coverage/coverlet/issues/1937)
-- Fix coverlet.MTP crashes during instrumentation (ReportGenerator.MTP) [#1934](https://github.com/coverlet-coverage/coverlet/issues/1934)
 
 ## Release date 2026-05-18
 

--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -133,25 +133,34 @@ namespace Coverlet.Core
                                             _sourceRootTranslator,
                                             _cecilSymbolHelper);
 
-        if (instrumenter.CanInstrument())
+        if (!instrumenter.CanInstrument())
         {
-          _instrumentationHelper.BackupOriginalModule(module, Identifier, _parameters.DisableManagedInstrumentationRestore);
+          continue;
+        }
 
-          // Guard code path and restore if instrumentation fails.
-          try
+        InstrumentationPreflightResult preflightResult = instrumenter.Preflight();
+        if (preflightResult.Status != InstrumentationPreflightStatus.Ready)
+        {
+          _logger.LogWarning($"Skipping module '{module}': {preflightResult.Status}. {preflightResult.Reason}");
+          continue;
+        }
+
+        _instrumentationHelper.BackupOriginalModule(module, Identifier, _parameters.DisableManagedInstrumentationRestore);
+
+        // Guard code path and restore if instrumentation fails.
+        try
+        {
+          InstrumenterResult result = instrumenter.Instrument();
+          if (!instrumenter.SkipModule)
           {
-            InstrumenterResult result = instrumenter.Instrument();
-            if (!instrumenter.SkipModule)
-            {
-              _results.Add(result);
-              _logger.LogVerbose($"Instrumented module: '{module}'");
-            }
+            _results.Add(result);
+            _logger.LogVerbose($"Instrumented module: '{module}'");
           }
-          catch (Exception ex)
-          {
-            _logger.LogWarning($"Unable to instrument module: {module}\n{ex}");
-            _instrumentationHelper.RestoreOriginalModule(module, Identifier);
-          }
+        }
+        catch (Exception ex)
+        {
+          _logger.LogWarning($"Unable to instrument module: {module}\n{ex}");
+          _instrumentationHelper.RestoreOriginalModule(module, Identifier);
         }
       }
 

--- a/src/coverlet.core/Instrumentation/CecilAssemblyResolver.cs
+++ b/src/coverlet.core/Instrumentation/CecilAssemblyResolver.cs
@@ -133,6 +133,12 @@ namespace Coverlet.Core.Instrumentation
             return asm;
           }
 
+          asm = TryWithNetFrameworkRuntimeResolver(name);
+          if (asm != null)
+          {
+            return asm;
+          }
+
           throw;
         }
       }
@@ -142,6 +148,43 @@ namespace Coverlet.Core.Instrumentation
     {
       // object for .NET Framework is inside mscorlib.dll
       return Path.GetFileName(typeof(object).Assembly.Location) == "System.Private.CoreLib.dll";
+    }
+
+    internal AssemblyDefinition TryWithNetFrameworkRuntimeResolver(AssemblyNameReference name)
+    {
+      _logger.LogVerbose($"TryWithNetFrameworkRuntimeResolver for {name}");
+
+      if (IsDotNetCore())
+      {
+        return null;
+      }
+
+      string runtimeDirectory = Path.GetDirectoryName(typeof(object).Assembly.Location);
+      if (string.IsNullOrWhiteSpace(runtimeDirectory) || !Directory.Exists(runtimeDirectory))
+      {
+        return null;
+      }
+
+      foreach (string extension in new[] { ".dll", ".exe" })
+      {
+        string candidate = Path.Combine(runtimeDirectory, name.Name + extension);
+        if (!File.Exists(candidate))
+        {
+          continue;
+        }
+
+        try
+        {
+          _logger.LogVerbose($"TryWithNetFrameworkRuntimeResolver loading '{candidate}'");
+          return AssemblyDefinition.ReadAssembly(candidate, new ReaderParameters { AssemblyResolver = this });
+        }
+        catch (Exception ex)
+        {
+          _logger.LogVerbose($"TryWithNetFrameworkRuntimeResolver exception loading '{candidate}': {ex}");
+        }
+      }
+
+      return null;
     }
 
     /// <summary>

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Toni Solarin-Sodara
+﻿// Copyright (c) Toni Solarin-Sodara
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -21,6 +21,26 @@ using Mono.Cecil.Rocks;
 
 namespace Coverlet.Core.Instrumentation
 {
+  internal enum InstrumentationPreflightStatus
+  {
+    Ready = 0,
+    Locked,
+    UnresolvableDependencies,
+    UnknownError
+  }
+
+  internal struct InstrumentationPreflightResult
+  {
+    public InstrumentationPreflightStatus Status { get; }
+    public string Reason { get; }
+
+    public InstrumentationPreflightResult(InstrumentationPreflightStatus status, string reason)
+    {
+      Status = status;
+      Reason = reason ?? string.Empty;
+    }
+  }
+
   internal class Instrumenter
   {
     private readonly string _module;
@@ -96,6 +116,64 @@ namespace Coverlet.Core.Instrumentation
           .SelectMany(a => a.EndsWith("Attribute") ? [a] : new[] { a, $"{a}Attribute" })
           // The default custom attributes used to exclude from coverage.
           .Union(defaultAttrs)];
+    }
+
+    public InstrumentationPreflightResult Preflight()
+    {
+      try
+      {
+        try
+        {
+          using Stream _ = _fileSystem.NewFileStream(_module, FileMode.Open, FileAccess.ReadWrite);
+        }
+        catch (IOException ex)
+        {
+          return new InstrumentationPreflightResult(InstrumentationPreflightStatus.Locked, ex.Message);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+          return new InstrumentationPreflightResult(InstrumentationPreflightStatus.Locked, ex.Message);
+        }
+
+        if (!CanResolveModuleAssemblyReferences(out string reason))
+        {
+          return new InstrumentationPreflightResult(InstrumentationPreflightStatus.UnresolvableDependencies, reason);
+        }
+
+        return new InstrumentationPreflightResult(InstrumentationPreflightStatus.Ready, string.Empty);
+      }
+      catch (Exception ex)
+      {
+        return new InstrumentationPreflightResult(InstrumentationPreflightStatus.UnknownError, ex.Message);
+      }
+    }
+
+    private bool CanResolveModuleAssemblyReferences(out string reason)
+    {
+      reason = string.Empty;
+
+      using Stream stream = _fileSystem.NewFileStream(_module, FileMode.Open, FileAccess.Read);
+      using var resolver = new NetstandardAwareAssemblyResolver(_module, _logger);
+      resolver.AddSearchDirectory(Path.GetDirectoryName(_module));
+      var parameters = new ReaderParameters { ReadSymbols = false, AssemblyResolver = resolver };
+
+      using var module = ModuleDefinition.ReadModule(stream, parameters);
+
+      foreach (AssemblyNameReference reference in module.AssemblyReferences)
+      {
+        try
+        {
+          resolver.Resolve(reference);
+        }
+        catch (Exception ex)
+        {
+          reason = $"Failed to resolve assembly reference '{reference.FullName}': {ex.Message}";
+          _logger.LogVerbose($"Preflight unresolved reference '{reference.FullName}' for module '{_module}'.");
+          return false;
+        }
+      }
+
+      return true;
     }
 
     public bool CanInstrument()

--- a/src/coverlet.core/Instrumentation/ReachabilityHelper.cs
+++ b/src/coverlet.core/Instrumentation/ReachabilityHelper.cs
@@ -313,7 +313,7 @@ namespace Coverlet.Core.Instrumentation.Reachability
               unresolvedMethodReferenceWarnings++;
               if (unresolvedMethodReferenceWarnings <= MaxUnresolvedMethodWarnings)
               {
-                logger.LogWarning($"Unable to resolve method reference \"{calledMtd.FullName}\", assuming calls to will return");
+                logger.LogWarning($"Unable to resolve method reference \"{calledMtd.FullName}\", assuming calls to it will return");
               }
               else if (!unresolvedMethodReferenceWarningSuppressed)
               {
@@ -322,7 +322,7 @@ namespace Coverlet.Core.Instrumentation.Reachability
               }
               else
               {
-                logger.LogVerbose($"Suppressed unresolved method reference \"{calledMtd.FullName}\", assuming calls to will return");
+                logger.LogVerbose($"Suppressed unresolved method reference \"{calledMtd.FullName}\", assuming calls to it will return");
               }
 
               mtdDef = null;

--- a/src/coverlet.core/Instrumentation/ReachabilityHelper.cs
+++ b/src/coverlet.core/Instrumentation/ReachabilityHelper.cs
@@ -16,6 +16,8 @@ namespace Coverlet.Core.Instrumentation.Reachability
   /// </summary>
   internal class ReachabilityHelper
   {
+    private const int MaxUnresolvedMethodWarnings = 25;
+
     internal readonly struct UnreachableRange
     {
       /// <summary>
@@ -260,6 +262,8 @@ namespace Coverlet.Core.Instrumentation.Reachability
 
       ImmutableHashSet<MetadataToken> processedMethods = ImmutableHashSet<MetadataToken>.Empty;
       ImmutableHashSet<MetadataToken>.Builder doNotReturn = ImmutableHashSet.CreateBuilder<MetadataToken>();
+      int unresolvedMethodReferenceWarnings = 0;
+      bool unresolvedMethodReferenceWarningSuppressed = false;
       foreach (TypeDefinition type in module.Types)
       {
         foreach (MethodDefinition mtd in type.Methods)
@@ -306,7 +310,21 @@ namespace Coverlet.Core.Instrumentation.Reachability
             }
             catch
             {
-              logger.LogWarning($"Unable to resolve method reference \"{calledMtd.FullName}\", assuming calls to will return");
+              unresolvedMethodReferenceWarnings++;
+              if (unresolvedMethodReferenceWarnings <= MaxUnresolvedMethodWarnings)
+              {
+                logger.LogWarning($"Unable to resolve method reference \"{calledMtd.FullName}\", assuming calls to will return");
+              }
+              else if (!unresolvedMethodReferenceWarningSuppressed)
+              {
+                logger.LogWarning($"Further unresolved method reference warnings are suppressed after {MaxUnresolvedMethodWarnings} occurrences. Enable verbose diagnostics to inspect additional entries.");
+                unresolvedMethodReferenceWarningSuppressed = true;
+              }
+              else
+              {
+                logger.LogVerbose($"Suppressed unresolved method reference \"{calledMtd.FullName}\", assuming calls to will return");
+              }
+
               mtdDef = null;
             }
 

--- a/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
+++ b/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Toni Solarin-Sodara
+﻿// Copyright (c) Toni Solarin-Sodara
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -238,6 +238,64 @@ namespace Coverlet.Core.Tests.Instrumentation
       instrumenterTest.Directory.Delete(true);
     }
 
+    [Fact]
+    public void TestPreflight_LockedModule_ReturnsLocked()
+    {
+      InstrumenterTest instrumenterTest = CreateInstrumentor();
+      try
+      {
+        using var moduleLock = new FileStream(instrumenterTest.Module, FileMode.Open, FileAccess.Read, FileShare.Read);
+
+        InstrumentationPreflightResult preflightResult = instrumenterTest.Instrumenter.Preflight();
+
+        Assert.Equal(InstrumentationPreflightStatus.Locked, preflightResult.Status);
+      }
+      finally
+      {
+        instrumenterTest.Directory.Delete(true);
+      }
+    }
+
+    [Fact]
+    public void TestPreflight_UnresolvableDependency_ReturnsUnresolvableDependencies()
+    {
+      string tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+      Directory.CreateDirectory(tempDirectory);
+      string modulePath = Path.Combine(tempDirectory, "preflight-unresolvable.dll");
+
+      try
+      {
+        var assemblyName = new AssemblyNameDefinition("preflight-unresolvable", new Version(1, 0, 0, 0));
+        using (AssemblyDefinition assemblyDefinition = AssemblyDefinition.CreateAssembly(assemblyName, "preflight-unresolvable", ModuleKind.Dll))
+        {
+          assemblyDefinition.MainModule.AssemblyReferences.Add(new AssemblyNameReference("Definitely.Missing.Dependency", new Version(1, 0, 0, 0)));
+          assemblyDefinition.Write(modulePath);
+        }
+
+        var instrumentationHelper =
+            new InstrumentationHelper(new ProcessExitHandler(), new RetryHelper(), new FileSystem(), new Mock<ILogger>().Object,
+                                      new SourceRootTranslator(new Mock<ILogger>().Object, new FileSystem()));
+
+        var instrumenter = new Instrumenter(modulePath,
+                                            Guid.NewGuid().ToString("N"),
+                                            new CoverageParameters(),
+                                            _mockLogger.Object,
+                                            instrumentationHelper,
+                                            new FileSystem(),
+                                            new SourceRootTranslator(_mockLogger.Object, new FileSystem()),
+                                            new CecilSymbolHelper());
+
+        InstrumentationPreflightResult preflightResult = instrumenter.Preflight();
+
+        Assert.Equal(InstrumentationPreflightStatus.UnresolvableDependencies, preflightResult.Status);
+        Assert.Contains("Definitely.Missing.Dependency", preflightResult.Reason, StringComparison.Ordinal);
+      }
+      finally
+      {
+        Directory.Delete(tempDirectory, true);
+      }
+    }
+
     private InstrumenterTest CreateInstrumentor(bool fakeCoreLibModule = false, string[] attributesToIgnore = null, string[] excludedFiles = null, bool singleHit = false)
     {
       string module = GetType().Assembly.Location;
@@ -415,7 +473,7 @@ namespace Coverlet.Core.Tests.Instrumentation
                                         }};
     }
 
-    [Theory]
+    [Theory(DisableDiscoveryEnumeration = true)]
     [MemberData(nameof(TestInstrument_ExcludedFilesHelper_Data))]
     public void TestInstrument_ExcludedFilesHelper(string[] excludeFilterHelper, ValueTuple<string, bool, bool>[] result)
     {

--- a/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
+++ b/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
@@ -244,9 +244,26 @@ namespace Coverlet.Core.Tests.Instrumentation
       InstrumenterTest instrumenterTest = CreateInstrumentor();
       try
       {
-        using var moduleLock = new FileStream(instrumenterTest.Module, FileMode.Open, FileAccess.Read, FileShare.Read);
+        var fileSystemMock = new Mock<FileSystem>();
+        fileSystemMock.CallBase = true;
+        fileSystemMock
+          .Setup(fs => fs.NewFileStream(instrumenterTest.Module, FileMode.Open, FileAccess.ReadWrite))
+          .Throws(new IOException("The process cannot access the file because it is being used by another process."));
 
-        InstrumentationPreflightResult preflightResult = instrumenterTest.Instrumenter.Preflight();
+        var instrumentationHelper =
+          new InstrumentationHelper(new ProcessExitHandler(), new RetryHelper(), fileSystemMock.Object, new Mock<ILogger>().Object,
+                                    new SourceRootTranslator(new Mock<ILogger>().Object, fileSystemMock.Object));
+
+        var instrumenter = new Instrumenter(instrumenterTest.Module,
+                                            instrumenterTest.Identifier,
+                                            new CoverageParameters(),
+                                            _mockLogger.Object,
+                                            instrumentationHelper,
+                                            fileSystemMock.Object,
+                                            new SourceRootTranslator(_mockLogger.Object, fileSystemMock.Object),
+                                            new CecilSymbolHelper());
+
+        InstrumentationPreflightResult preflightResult = instrumenter.Preflight();
 
         Assert.Equal(InstrumentationPreflightStatus.Locked, preflightResult.Status);
       }


### PR DESCRIPTION
Introduce Instrumenter.Preflight() to skip locked or unresolvable assemblies before instrumentation. Update Coverage.cs to use preflight results and log warnings. Add unit tests for preflight logic. Improve Moq and ILogger mocking guidance in documentation. Minor test stability improvement.
This pull request introduces a preflight check mechanism to the instrumentation process, ensuring that problematic assemblies (such as locked files or those with unresolvable dependencies) are identified and skipped before attempting instrumentation. This proactive approach improves reliability and error messaging during coverage runs. Additionally, the documentation has been updated to clarify mocking strategies for different `ILogger` interfaces, and new tests have been added to verify the preflight logic. 
#1965 

**Instrumentation improvements:**

* Added `InstrumentationPreflightStatus` and `InstrumentationPreflightResult` types, and implemented a `Preflight()` method in `Instrumenter` to check if a module is locked or has unresolvable dependencies before instrumentation. This method attempts to open the file for writing and resolves all assembly references, returning a status and reason if preflight fails. (`src/coverlet.core/Instrumentation/Instrumenter.cs`)
* Updated `Coverage.PrepareModules()` to call `instrumenter.Preflight()` after `CanInstrument()`, skipping modules that fail preflight and logging a warning with the reason. (`src/coverlet.core/Coverage.cs`)

**Testing enhancements:**

* Added unit tests for `Instrumenter.Preflight()` to verify correct handling of locked modules and unresolvable dependencies, ensuring the new logic is robust. (`test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs`)
* Minor test attribute update: disabled discovery enumeration for a theory test to improve test suite reliability. (`test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs`)

**Documentation updates:**

* Expanded `.github/copilot-instructions.md` with clearer examples and guidance for mocking `ILogger` interfaces, including the distinction between Microsoft.Extensions.Logging.ILogger and Microsoft.Testing.Platform.Logging.ILogger, and added guidelines for handling issue #1965 and assembly-level preflight checks. 

These changes make the instrumentation step safer and more transparent, improve developer guidance, and ensure new logic is well-tested.