### PR TITLE
Update documentation to clarify MTP v2 compatibility

### DIFF
--- a/Documentation/KnownIssues.md
+++ b/Documentation/KnownIssues.md
@@ -47,7 +47,7 @@ This happen also if there are other "piece of code" during testing that slow dow
 
 *Solution:*
 
-The only way to get around this issue is to use collectors integration <https://github.com/coverlet-coverage/coverlet#vstest-integration-preferred-due-to-known-issue-supports-only-net-core-application>. With the collector, we're injected in test host through a in-proc collector that communicates with the VSTest platform so we can signal when we end our work.
+The only way to get around this issue is to use **coverlet.collector** integration. With the collector, we're injected in test host through a in-proc collector that communicates with the VSTest platform so we can signal when we end our work.
 
 ## Upgrade `coverlet.collector` to version > 1.0.0
 

--- a/Documentation/MSBuildIntegration.md
+++ b/Documentation/MSBuildIntegration.md
@@ -1,5 +1,14 @@
 # Coverlet integration with MSBuild
 
+> [!IMPORTANT]
+> **`coverlet.msbuild` is not compatible with the Microsoft Testing Platform (MTP v2).**
+>
+> This is particularly important if you're using the native `dotnet test` integration introduced in **.NET 10**, which can run tests through the Microsoft Testing Platform.
+>
+> The `coverlet.msbuild` package relies on **MSBuild test targets** that are part of the **VSTest** execution model. Because the **Microsoft Testing Platform** uses a different test execution architecture and does not invoke these targets, `coverlet.msbuild` cannot collect code coverage when running with MTP v2.
+>
+> For more information, see: [*Use Microsoft.Testing.Platform in the VSTest mode of `dotnet test`*](https://learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-integration-dotnet-test).
+
 In this mode, Coverlet doesn't require any additional setup other than including the `coverlet.msbuild` NuGet package in the unit test project. It integrates with the `dotnet test` infrastructure built into the .NET Core CLI and when enabled, will automatically generate coverage results after tests are run.
 
 If a property takes multiple comma-separated values please note that [you will have to add escaped quotes around the string](https://github.com/Microsoft/msbuild/issues/2999#issuecomment-366078677) like this: `/p:Exclude=\"[coverlet.*]*,[*]Coverlet.Core*\"`, `/p:Include=\"[coverlet.*]*,[*]Coverlet.Core*\"`, or `/p:CoverletOutputFormat=\"json,opencover\"`.

--- a/Documentation/VSTestIntegration.md
+++ b/Documentation/VSTestIntegration.md
@@ -1,5 +1,14 @@
 # Coverlet integration with VSTest (a.k.a. Visual Studio Test Platform)
 
+> [!IMPORTANT]
+> **`coverlet.collector` is not compatible with the Microsoft Testing Platform (MTP v2).**
+>
+> This is particularly important if you're using the native `dotnet test` integration introduced in **.NET 10**, which can run tests through the Microsoft Testing Platform.
+>
+> The `coverlet.collector` package is built on the **VSTest** data collector infrastructure. Because the **Microsoft Testing Platform** uses a different test execution architecture and does not support VSTest data collectors, `coverlet.collector` cannot be used with MTP v2.
+>
+> For more information, see: [*Use Microsoft.Testing.Platform in the VSTest mode of `dotnet test`*](https://learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-integration-dotnet-test).
+
 **Supported runtime versions**:
 
 Since version `8.0.0`


### PR DESCRIPTION
This pull request updates the documentation to clarify compatibility issues between Coverlet packages (`coverlet.msbuild` and `coverlet.collector`) and the Microsoft Testing Platform (MTP v2), especially in the context of .NET 10 and the new `dotnet test` integration. It also improves guidance on resolving known issues with test coverage collection.

### Compatibility clarifications:

* Added a prominent warning to `Documentation/MSBuildIntegration.md` stating that `coverlet.msbuild` is not compatible with Microsoft Testing Platform (MTP v2), explaining why, and linking to official Microsoft documentation for further details.
* Added a similar warning to `Documentation/VSTestIntegration.md` indicating that `coverlet.collector` is not compatible with MTP v2, with an explanation and reference link.

### Guidance improvements:

* Updated `Documentation/KnownIssues.md` to recommend using the `coverlet.collector` integration directly (rather than a generic "collectors integration") for improved clarity when resolving coverage collection issues.