### PR TITLE
Fix silent zero coverage on .NET Framework since 8.0.0

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix Regression in branch coverage for lambda expressions [#1937](https://github.com/coverlet-coverage/coverlet/issues/1937)
 - Fix When using "is" with "or" in pattern matching, branch coverage is lower than normal [#1969](https://github.com/coverlet-coverage/coverlet/issues/1969)
+- Fix silent zero coverage on .NET Framework (console/collector) since 8.0.0: the injected tracker no longer references the net6+ `DefaultInterpolatedStringHandler` [#1984](https://github.com/coverlet-coverage/coverlet/issues/1984)
 
 ## Release date 2026-05-18
 

--- a/coverlet.slnx
+++ b/coverlet.slnx
@@ -17,6 +17,7 @@
   <Folder Name="/src/">
     <Project Path="src/coverlet.console/coverlet.console.csproj" />
     <Project Path="src/coverlet.core/coverlet.core.csproj" />
+    <Project Path="src/coverlet.template/coverlet.template.csproj" />
     <Project Path="src/coverlet.MTP/coverlet.MTP.csproj" />
     <Project Path="src/legacy/coverlet.collector/coverlet.collector.csproj" />
     <Project Path="src/legacy/coverlet.msbuild.tasks/coverlet.msbuild.tasks.csproj" />

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -440,7 +440,8 @@ namespace Coverlet.Core.Instrumentation
 
     private void AddCustomModuleTrackerToModule(ModuleDefinition module)
     {
-      using (var coverletInstrumentationAssembly = AssemblyDefinition.ReadAssembly(typeof(ModuleTrackerTemplate).Assembly.Location))
+      using Stream trackerTemplateStream = GetTrackerTemplateAssemblyStream();
+      using (var coverletInstrumentationAssembly = AssemblyDefinition.ReadAssembly(trackerTemplateStream))
       {
         TypeDefinition moduleTrackerTemplate = coverletInstrumentationAssembly.MainModule.GetType(
             "Coverlet.Core.Instrumentation", nameof(ModuleTrackerTemplate));
@@ -547,6 +548,37 @@ namespace Coverlet.Core.Instrumentation
 
       Debug.Assert(_customTrackerHitsArray != null);
       Debug.Assert(_customTrackerClassConstructorIl != null);
+    }
+
+    /// <summary>
+    /// Returns a stream over the netstandard2.0-compiled <see cref="ModuleTrackerTemplate"/> assembly
+    /// that is embedded in coverlet.core. The tracker IL injected into instrumented modules is copied
+    /// from this assembly rather than from the running coverlet.core build, so that a net8.0+ build of
+    /// coverlet.core never injects IL referencing net6+ only BCL types (e.g.
+    /// DefaultInterpolatedStringHandler) that cannot be JIT-compiled on .NET Framework.
+    /// </summary>
+    private static Stream GetTrackerTemplateAssemblyStream()
+    {
+      const string trackerTemplateResourceName = "coverlet.template.dll";
+
+      System.Reflection.Assembly coreAssembly = typeof(Instrumenter).Assembly;
+      string resourceName = Array.Find(
+          coreAssembly.GetManifestResourceNames(),
+          name => name.EndsWith(trackerTemplateResourceName, StringComparison.OrdinalIgnoreCase));
+
+      if (resourceName is null)
+      {
+        throw new InvalidOperationException(
+            $"Embedded tracker template '{trackerTemplateResourceName}' was not found in '{coreAssembly.FullName}'. " +
+            "This assembly is required to inject .NET Framework-safe coverage tracking code.");
+      }
+
+      using Stream resourceStream = coreAssembly.GetManifestResourceStream(resourceName);
+      // Cecil needs a seekable stream that stays readable for the duration of the copy; use memory.
+      var templateStream = new MemoryStream();
+      resourceStream.CopyTo(templateStream);
+      templateStream.Position = 0;
+      return templateStream;
     }
 
     /// <summary>

--- a/src/coverlet.core/coverlet.core.csproj
+++ b/src/coverlet.core/coverlet.core.csproj
@@ -50,4 +50,30 @@
     <PackageReference Include="System.Threading.Tasks.Extensions" />
   </ItemGroup>
 
+  <!--
+    Embed a netstandard2.0-compiled copy of ModuleTrackerTemplate. The Instrumenter reads the tracker
+    IL from this embedded assembly (see Instrumenter.AddCustomModuleTrackerToModule) instead of from
+    the running coverlet.core build. That keeps the injected IL safe to JIT on .NET Framework no matter
+    which TFM coverlet.core runs as: a net8.0+ build lowers the template's string interpolations to
+    DefaultInterpolatedStringHandler, a type absent on .NET Framework, which silently breaks coverage.
+  -->
+  <ItemGroup>
+    <ProjectReference Include="..\coverlet.template\coverlet.template.csproj"
+                      ReferenceOutputAssembly="false"
+                      Private="false"
+                      OutputItemType="_CoverletTrackerTemplateAssembly" />
+  </ItemGroup>
+
+  <Target Name="_EmbedCoverletTrackerTemplate"
+          DependsOnTargets="ResolveProjectReferences"
+          BeforeTargets="AssignTargetPaths">
+    <Error Condition="'@(_CoverletTrackerTemplateAssembly)' == ''"
+           Text="coverlet.template output could not be resolved; the tracker template cannot be embedded." />
+    <ItemGroup>
+      <EmbeddedResource Include="@(_CoverletTrackerTemplateAssembly)">
+        <LogicalName>coverlet.template.dll</LogicalName>
+      </EmbeddedResource>
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/coverlet.template/coverlet.template.csproj
+++ b/src/coverlet.template/coverlet.template.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    This project exists solely to compile ModuleTrackerTemplate to netstandard2.0. The resulting
+    assembly is embedded into coverlet.core (see coverlet.core.csproj) and used as the source of the
+    tracker IL that gets injected into instrumented modules.
+
+    Why netstandard2.0 and nothing else: when ModuleTrackerTemplate is compiled for net6.0+, the C#
+    compiler lowers its string interpolations to DefaultInterpolatedStringHandler, a type that does
+    not exist on .NET Framework. Injecting that IL into a .NET Framework module makes the tracker's
+    flush handler (UnloadModule) fail to JIT at process exit, silently losing all coverage.
+    Compiled for netstandard2.0 the same interpolations lower to string.Concat/string.Format, which
+    resolve against mscorlib on .NET Framework. Do NOT add PackageReferences that polyfill net6+ BCL
+    types (e.g. a DefaultInterpolatedStringHandler shim) - that would defeat the purpose.
+  -->
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <!-- ModuleTrackerTemplate's static fields are assigned by the instrumenter at IL-injection time,
+         never in source, so CS0649 ("field is never assigned") is a false positive here. coverlet.core
+         does not report it because its InternalsVisibleTo lets Roslyn assume external assignment. -->
+    <NoWarn>$(NoWarn);CS0649</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Single source of truth: the template lives in coverlet.core and is linked (not copied) here. -->
+    <Compile Include="..\coverlet.core\Instrumentation\ModuleTrackerTemplate.cs" Link="ModuleTrackerTemplate.cs" />
+  </ItemGroup>
+
+</Project>

--- a/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
+++ b/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
@@ -1064,6 +1064,125 @@ public class SampleClass
     }
 
     /// <summary>
+    /// Regression test for https://github.com/coverlet-coverage/coverlet/issues/1984
+    /// The tracker IL injected into a .NET Framework module must not reference
+    /// System.Runtime.CompilerServices.DefaultInterpolatedStringHandler (a .NET 6+ type). A net8.0+
+    /// build of coverlet.core lowers the template's string interpolations to that handler; injecting
+    /// it makes the tracker's UnloadModule flush handler fail to JIT on .NET Framework, silently
+    /// dropping all coverage while tests still pass. The fix sources the template from an embedded
+    /// netstandard2.0 build, whose interpolations lower to string.Concat/string.Format instead.
+    /// Note: the #1818 test above passes even with the bug present, because the scope-remap points the
+    /// missing handler at mscorlib - so a dedicated assertion on the type identity is required here.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "NetFramework")]
+    public void TestInstrument_NetFrameworkAssembly_TrackerDoesNotReferenceInterpolatedStringHandler()
+    {
+      // Skip on non-Windows or if .NET Framework sample not built
+      if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+      {
+        return;
+      }
+
+      string netFrameworkProjectPath = TestUtils.GetTestBinaryPath("coverlet.tests.projectsample.netframework");
+      string netFrameworkAssemblyPath = Path.Combine(
+          netFrameworkProjectPath,
+          TestUtils.GetBuildConfigurationString(),
+          "coverlet.tests.projectsample.netframework.dll");
+
+      if (!File.Exists(netFrameworkAssemblyPath))
+      {
+        return;
+      }
+
+      string identifier = Guid.NewGuid().ToString();
+      DirectoryInfo directory = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), identifier));
+      string destModule = "coverlet.tests.projectsample.netframework.dll";
+      string destPdb = "coverlet.tests.projectsample.netframework.pdb";
+
+      try
+      {
+        File.Copy(netFrameworkAssemblyPath, Path.Combine(directory.FullName, destModule), true);
+        string pdbPath = Path.ChangeExtension(netFrameworkAssemblyPath, ".pdb");
+        if (File.Exists(pdbPath))
+        {
+          File.Copy(pdbPath, Path.Combine(directory.FullName, destPdb), true);
+        }
+
+        string modulePath = Path.Combine(directory.FullName, destModule);
+
+        var instrumentationHelper = new InstrumentationHelper(
+            new ProcessExitHandler(),
+            new RetryHelper(),
+            new FileSystem(),
+            _mockLogger.Object,
+            new SourceRootTranslator(_mockLogger.Object, new FileSystem()));
+
+        var instrumenter = new Instrumenter(
+            modulePath,
+            identifier,
+            new CoverageParameters(),
+            _mockLogger.Object,
+            instrumentationHelper,
+            new FileSystem(),
+            new SourceRootTranslator(_mockLogger.Object, new FileSystem()),
+            new CecilSymbolHelper());
+
+        if (!instrumenter.CanInstrument())
+        {
+          return;
+        }
+
+        Assert.NotNull(instrumenter.Instrument());
+
+        using var instrumentedModule = ModuleDefinition.ReadModule(modulePath);
+
+        // Confirms it really is a .NET Framework assembly (core library mscorlib).
+        Assert.Equal("mscorlib", instrumentedModule.TypeSystem.CoreLibrary.Name);
+
+        TypeDefinition trackerType = instrumentedModule.Types.FirstOrDefault(
+            t => t.Namespace.StartsWith("Coverlet.Core.Instrumentation.Tracker"));
+        Assert.NotNull(trackerType);
+
+        foreach (MethodDefinition method in trackerType.Methods)
+        {
+          if (!method.HasBody)
+          {
+            continue;
+          }
+
+          foreach (VariableDefinition variable in method.Body.Variables)
+          {
+            AssertNotInterpolatedStringHandler(variable.VariableType, $"local in {method.Name}");
+          }
+
+          foreach (Instruction instr in method.Body.Instructions)
+          {
+            if (instr.Operand is MethodReference methodRef)
+            {
+              AssertNotInterpolatedStringHandler(methodRef.DeclaringType, $"method ref '{methodRef.FullName}' in {method.Name}");
+            }
+            else if (instr.Operand is TypeReference typeRef)
+            {
+              AssertNotInterpolatedStringHandler(typeRef, $"type ref in {method.Name}");
+            }
+          }
+        }
+      }
+      finally
+      {
+        try
+        {
+          directory.Delete(true);
+        }
+        catch
+        {
+          // Ignore cleanup errors
+        }
+      }
+    }
+
+    /// <summary>
     /// Regression test for https://github.com/coverlet-coverage/coverlet/issues/1828
     /// The injected Tracker class must carry [CompilerGenerated] and [ExcludeFromCodeCoverage]
     /// custom attributes so that reflection-based tooling can identify and skip it.
@@ -1151,6 +1270,17 @@ public class SampleClass
             assemblyRef.Name == "System.Runtime",
             $"Type '{typeRef.FullName}' in {context} should not reference System.Runtime, but found scope: {assemblyRef.Name}");
       }
+    }
+
+    private static void AssertNotInterpolatedStringHandler(TypeReference typeRef, string context)
+    {
+      if (typeRef is null)
+        return;
+
+      Assert.False(
+          typeRef.GetElementType().FullName == "System.Runtime.CompilerServices.DefaultInterpolatedStringHandler",
+          $"The injected .NET Framework tracker must not reference DefaultInterpolatedStringHandler (found via {context}); " +
+          "the template must be sourced from the embedded netstandard2.0 build. See issue #1984.");
     }
   }
 }


### PR DESCRIPTION
Fixes #1984.

## Problem
`Instrumenter.AddCustomModuleTrackerToModule` copies the `ModuleTrackerTemplate` IL from the
**running** coverlet.core assembly (`typeof(ModuleTrackerTemplate).Assembly.Location`). Since 8.0.0
coverlet.core targets net8.0+, so the C# compiler lowers the template's string interpolations to
`DefaultInterpolatedStringHandler` — a type that does not exist on .NET Framework.

When that IL is injected into a .NET Framework module, the tracker's `UnloadModule` (the
`AppDomain.ProcessExit` / `DomainUnload` flush handler) fails to JIT at process exit. The CLR
swallows exceptions thrown from unload handlers, so **the test run passes green while the coverage
report is silently 0%**, with no error. The #1818 scope-remap doesn't save it — it points the
reference at `mscorlib`, where the type still doesn't exist.

Affected drivers: `coverlet.console` and `coverlet.collector` (both run the net8.0+ core).
`coverlet.msbuild` is unaffected because it runs the netstandard2.0 core, where the same
interpolations lower to `string.Format`.

## Fix
Add a small `coverlet.template` project that compiles `ModuleTrackerTemplate` to **netstandard2.0**
(linking the existing source file — single source of truth), embed that assembly into coverlet.core,
and read the injected template IL from the embedded resource instead of from the running build. The
injected IL is then .NET Framework-safe regardless of which TFM coverlet.core runs as. No new file
ships and there is no type collision (the reference uses `ReferenceOutputAssembly="false"`).

## Verification
1. **Regression test** — new `TestInstrument_NetFrameworkAssembly_TrackerDoesNotReferenceInterpolatedStringHandler`
   (`[Trait("Category", "NetFramework")]`) instruments the net-framework sample and asserts the injected
   tracker references no `DefaultInterpolatedStringHandler`. It fails on `master` and passes with this
   change. (The existing #1818 test can't catch this — the scope-remap makes its "not System.Runtime"
   assertion pass while the type is still missing.)
2. **No regressions** — full `InstrumenterTests` suite green (55/55).
3. **End-to-end** — built `coverlet.console` from this branch and ran it over a stock SDK-style **net48**
   library + NUnit tests via `nunit3-console`, on the same sample used in #1984 (Windows x64, .NET SDK 10):

   | coverlet.console | Tests | Coverage collected |
   |---|---|---|
   | 10.0.1 (shipped) | 7/7 passed | **0 / 13 sequence points (0%)** — silent bug |
   | this branch | 7/7 passed | **13 / 13 (100%)** |

A minimal standalone reproduction is attached to #1984.
