### PR TITLE
Fix EndOfStreamException

### DIFF
--- a/Documentation/KnownIssues.md
+++ b/Documentation/KnownIssues.md
@@ -2,62 +2,45 @@
 
 ## VSTest stops process execution early
 
-*Affected drivers*: msbuild (`dotnet test`) , dotnet tool(if you're using `--targetargs "test ... --no-build"`)
+*Affected drivers*: msbuild (`dotnet test`), dotnet tool (if you're using `--targetargs "test ... --no-build"`)
 
 *Symptoms:*
 
-* warning or error like:
+* Zero or missing coverage result, often only on CI.
 
-  `Unable to read beyond end of stream`
+* Warning messages in the build output:
 
-  `warning : [coverlet] Hits file:'C:\Users\REDACTED\AppData\Local\Temp\testApp_ac32258b-fd4a-4bb4-824c-a79061e97c31' not found for module: 'testApp'`
+  * ```
+    warning : [coverlet] Hits file not found for module 'testApp': 'C:\Users\REDACTED\AppData\Local\Temp\testApp_ac32258b-fd4a-4bb4-824c-a79061e97c31'. An incomplete write was detected; coverage data for this module is missing.
+    ```
 
-* zero coverage result (often only on CI but not on local)
+  * ```
+    warning : [coverlet] Hits file for module 'testApp' may be incomplete: a merge was in progress when the writer was killed. Coverage data from the merge is missing.
+    ```
 
-  ```bash
-  Calculating coverage result...
-  C:\Users\REDACTED\.nuget\packages\coverlet.msbuild\6.0.0\build\netstandard2.0\coverlet.msbuild.targets(21,5): warning : [coverlet] Hits file:'C:\Users\REDACTED\AppData\Local\Temp\testApp_ac32258b-fd4a-4bb4-824c-a79061e97c31' not found for module: 'testApp' [C:\Users\REDACTED\Documents\repo\testapp\testapp.Tests\testapp.Tests.csproj]
-  C:\Users\REDACTED\.nuget\packages\coverlet.msbuild\6.0.0\build\netstandard2.0\coverlet.msbuild.targets(21,5): warning : [coverlet] Hits file:'C:\Users\REDACTED\AppData\Local\Temp\testApp.Tests_ac32258b-fd4a-4bb4-824c-a79061e97c31' not found for module: 'testApp.Tests' [C:\Users\REDACTED\Documents\repo\testapp\testapp.Tests\testapp.Tests.csproj]
-    Generating report 'C:\Users\REDACTED\Documents\repo\testapp\lcov.info'
-
-  +---------------+------+--------+--------+
-  | Module        | Line | Branch | Method |
-  +---------------+------+--------+--------+
-  | testApp       | 0%   | 0%     | 0%     |
-  +---------------+------+--------+--------+
-  | testApp.Tests | 0%   | 100%   | 0%     |
-  +---------------+------+--------+--------+
-
-  +---------+------+--------+--------+
-  |         | Line | Branch | Method |
-  +---------+------+--------+--------+
-  | Total   | 0%   | 0%     | 0%     |
-  +---------+------+--------+--------+
-  | Average | 0%   | 0%     | 0%     |
-  +---------+------+--------+--------+
-
-  ```
-
-The issue is related to VSTest platform <https://github.com/microsoft/vstest/issues/1900#issuecomment-457488472>
+The issue is related to the VSTest platform ([vstest#1900](https://github.com/microsoft/vstest/issues/1900#issuecomment-457488472)):
 
 > However if testhost doesn't shut down within 100ms (as the execution is completed, we expect it to shutdown fast). vstest.console forcefully kills the process.
 
-Coverlet collects and writes hits data on process exit, if for some reason the process is too slow to close, it will be killed and we cannot collect coverage result.
-This happen also if there are other "piece of code" during testing that slow down process exit. We found problem for instance with tests that use RabbitMQ.
+`coverlet.msbuild` and the dotnet tool collect and write hits data on process exit. If the testhost is killed before that write completes, we cannot collect the coverage result.
+This can also happen if there are other "pieces of code" during testing that slow down process exit. We found problems for instance with tests that use RabbitMQ.
 
 *Solution:*
 
 The only way to get around this issue is to use **coverlet.collector** integration. With the collector, we're injected in test host through a in-proc collector that communicates with the VSTest platform so we can signal when we end our work.
 
+> [!NOTE]
+> `coverlet.collector` is normally not affected by this issue. But if the synchronous flush fails for a module, it falls back to writing on process exit as a safety net, and the same warnings above might be observed.
+
 ## Upgrade `coverlet.collector` to version > 1.0.0
 
 *Affected drivers*: VSTest integration `dotnet test --collect:"XPlat Code Coverage"`
 
-*Symptoms:* The same as "known issue 1".
+*Symptoms:* Zero coverage result, same as [VSTest stops process execution early](#vstest-stops-process-execution-early).
 
 There is a bug inside the VSTest platform: <https://github.com/microsoft/vstest/issues/2205>.
 
-If you upgrade the collector package with a version greater than 1.0.0, in-proc collector won't be loaded so you could incur "known issue number 1" and get zero coverage result
+If you upgrade the collector package with a version greater than 1.0.0, in-proc collector won't be loaded so you could incur the [issue above](#vstest-stops-process-execution-early) and get zero coverage result.
 
 *Solutions:*
 

--- a/Documentation/Troubleshooting.md
+++ b/Documentation/Troubleshooting.md
@@ -56,7 +56,7 @@ Test Run Successful.
 Test execution time: 4,6411 Seconds
 
 Calculating coverage result...
-Hits file:'C:\Users\Marco\AppData\Local\Temp\coverlet.core_703263e9-21f0-4d1c-9ce3-98ddeacecc01' not found for module: 'coverlet.core'
+Hits file: 'C:\Users\Marco\AppData\Local\Temp\coverlet.core_703263e9-21f0-4d1c-9ce3-98ddeacecc01' not found for module: 'coverlet.core'
   Generating report 'C:\git\coverlet\src\coverlet.console\bin\Debug\net8.0\coverage.json'
 +--------------------------------------------------+--------+--------+--------+
 | Module                                           | Line   | Branch | Method |
@@ -263,7 +263,7 @@ You can live attach and debug collectors with `COVERLET_DATACOLLECTOR_OUTOFPROC_
 ```
 
 You will be asked to attach a debugger through UI popup.
-To enable exceptions log for in-process data collectors
+To rethrow exceptions from in-process data collectors (making failures visible as a test run error)
 
 ```shell
  set COVERLET_DATACOLLECTOR_INPROC_EXCEPTIONLOG_ENABLED=1

--- a/Documentation/VSTestIntegration.md
+++ b/Documentation/VSTestIntegration.md
@@ -185,9 +185,9 @@ Take a look here for further information:<https://github.com/microsoft/vstest/bl
 Coverlet integration is implemented with the help of [datacollectors](https://github.com/microsoft/vstest/blob/main/docs/extensions/datacollector.md).
 When we specify `--collect:"XPlat Code Coverage"` VSTest platform tries to load coverlet collectors inside `coverlet.collector.dll`
 
-1. Out-of-proc Datacollector: The outproc collector run in a separate process(datacollector.exe/datacollector.dll) than the process in which tests are being executed(testhost*.exe/testhost.dll). This datacollector is responsible for calling into Coverlet APIs for instrumenting dlls, collecting coverage results and sending the coverage output file back to test platform.
+1. Out-of-proc Datacollector: The outproc collector run in a separate process (datacollector.exe/datacollector.dll) than the process in which tests are being executed (testhost*.exe/testhost.dll). This datacollector is responsible for calling into Coverlet APIs for instrumenting dlls, collecting coverage results and sending the coverage output file back to test platform.
 
-1. In-proc Datacollector: The in-proc collector is loaded in the testhost process executing the tests. This collector will be needed to remove the dependency on the process exit handler to flush the hit files and avoid to hit this [serious known issue](KnownIssues.md#1-vstest-stops-process-execution-earlydotnet-test)
+1. In-proc Datacollector: The in-proc collector is loaded in the testhost process executing the tests. This collector will be needed to remove the dependency on the process exit handler to flush the hit files and avoid to hit this [known issue](KnownIssues.md#vstest-stops-process-execution-early)
 
 ## Architecture
 

--- a/src/coverlet.MTP/InProcDataCollection/CoverletTestSessionHandler.cs
+++ b/src/coverlet.MTP/InProcDataCollection/CoverletTestSessionHandler.cs
@@ -72,10 +72,6 @@ public class CoverletTestSessionHandler : ITestSessionLifetimeHandler
           [typeof(object), typeof(EventArgs)]);
 
       unloadModule?.Invoke(null, [this, EventArgs.Empty]);
-
-      injectedInstrumentationClass
-          .GetField("FlushHitFile", BindingFlags.Static | BindingFlags.Public)?
-          .SetValue(null, false);
     }
 
     return Task.CompletedTask;

--- a/src/coverlet.MTP/InProcess/CoverletInProcessHandler.cs
+++ b/src/coverlet.MTP/InProcess/CoverletInProcessHandler.cs
@@ -98,8 +98,8 @@ internal sealed class CoverletInProcessHandler : ITestSessionLifetimeHandler
   }
 
   /// <summary>
-  /// Iterates through all loaded assemblies and calls UnloadModule on any
-  /// instrumented tracker classes to flush hit data to files.
+  /// Iterates through all loaded assemblies and calls UnloadModule on any instrumented tracker
+  /// classes to flush hit data to files.
   /// </summary>
   private void FlushCoverageData()
   {
@@ -123,11 +123,6 @@ internal sealed class CoverletInProcessHandler : ITestSessionLifetimeHandler
         if (unloadMethod != null)
         {
           unloadMethod.Invoke(null, [this, EventArgs.Empty]);
-
-          // Prevent double-flush on process exit
-          FieldInfo? flushField = trackerType.GetField("FlushHitFile", BindingFlags.Static | BindingFlags.Public);
-          flushField?.SetValue(null, false);
-
           flushedCount++;
           _logger.LogDebug($"[Coverlet.MTP.InProcess] Successfully flushed coverage for '{assembly.GetName().Name}'");
         }

--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Runtime.Serialization;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -392,85 +393,106 @@ namespace Coverlet.Core
           }
         }
 
-        if (!_fileSystem.Exists(result.HitsFilePath))
-        {
-          // Hits file could be missed mainly for two reason
-          // 1) Issue during module Unload()
-          // 2) Instrumented module is never loaded or used so we don't have any hit to register and
-          //    module tracker is never used
-          _logger.LogVerbose($"Hits file:'{result.HitsFilePath}' not found for module: '{result.Module}'");
-          continue;
-        }
+        string lockFilePath = result.HitsFilePath + ".lock";
+        string tmpFilePath = result.HitsFilePath + ".tmp";
 
-        // Calculate lines to skip for every hits start/end candidate
-        // Nested ranges win on outermost one
-        foreach (HitCandidate hitCandidate in result.HitCandidates)
+        // Hold a shared lock on the lock file while reading so the writer cannot slip in a new
+        // write between our existence check and our read. The OS releases the writer's exclusive
+        // lock on process death, so a crashed writer is also detected here.
+        using (FileStream lockFileHandle = TryAcquireReaderLockOnFile(lockFilePath, result.Module, _logger))
         {
-          if (hitCandidate.isBranch || hitCandidate.end == hitCandidate.start)
+          if (!_fileSystem.Exists(result.HitsFilePath))
           {
-            continue;
-          }
-
-          foreach (HitCandidate hitCandidateToCompare in result.HitCandidates.Where(x => x.docIndex.Equals(hitCandidate.docIndex)))
-          {
-            if (hitCandidate != hitCandidateToCompare && !hitCandidateToCompare.isBranch && hitCandidateToCompare.start > hitCandidate.start &&
-                 hitCandidateToCompare.end < hitCandidate.end)
+            if (!_fileSystem.Exists(tmpFilePath))
             {
-              for (int i = hitCandidateToCompare.start;
-                   i <= (hitCandidateToCompare.end == 0 ? hitCandidateToCompare.start : hitCandidateToCompare.end);
-                   i++)
-              {
-                (hitCandidate.AccountedByNestedInstrumentation ??= []).Add(i);
-              }
-            }
-          }
-        }
-
-        var documentsList = result.Documents.Values.ToList();
-        using (Stream fs = _fileSystem.NewFileStream(result.HitsFilePath, FileMode.Open, FileAccess.Read))
-        using (var br = new BinaryReader(fs))
-        {
-          int hitCandidatesCount = br.ReadInt32();
-
-          // TODO: hitCandidatesCount should be verified against result.HitCandidates.Count
-
-          for (int i = 0; i < hitCandidatesCount; ++i)
-          {
-            HitCandidate hitLocation = result.HitCandidates[i];
-            Document document = documentsList[hitLocation.docIndex];
-            int hits = br.ReadInt32();
-
-            if (hits == 0)
+              _logger.LogVerbose($"Hits file: '{result.HitsFilePath}' not found for module: '{result.Module}'");
               continue;
-
-            hits = hits < 0 ? int.MaxValue : hits;
-
-            if (hitLocation.isBranch)
-            {
-              Branch branch = document.Branches[new BranchKey(hitLocation.start, hitLocation.end)];
-              branch.Hits += hits;
-
-              if (branch.Hits < 0)
-                branch.Hits = int.MaxValue;
             }
-            else
+
+            // .tmp present, hits absent: the writer started but did not finish (crashed or killed).
+            if (!_fileSystem.Exists(result.HitsFilePath))
             {
-              for (int j = hitLocation.start; j <= hitLocation.end; j++)
+              _logger.LogWarning($"Hits file not found for module '{result.Module}': '{result.HitsFilePath}'. An incomplete write was detected; coverage data for this module is missing.");
+              continue;
+            }
+          }
+          else if (_fileSystem.Exists(tmpFilePath))
+          {
+            // Hits file exists but .tmp also present: merge write was killed mid-replace.
+            // The file reflects the pre-merge state; coverage data from the merge is lost.
+            _logger.LogWarning($"Hits file for module '{result.Module}' may be incomplete: a merge was in progress when the writer was killed. Coverage data from the merge is missing.");
+          }
+
+          // Calculate lines to skip for every hits start/end candidate
+          // Nested ranges win on outermost one
+          foreach (HitCandidate hitCandidate in result.HitCandidates)
+          {
+            if (hitCandidate.isBranch || hitCandidate.end == hitCandidate.start)
+            {
+              continue;
+            }
+
+            foreach (HitCandidate hitCandidateToCompare in result.HitCandidates.Where(x => x.docIndex.Equals(hitCandidate.docIndex)))
+            {
+              if (hitCandidate != hitCandidateToCompare && !hitCandidateToCompare.isBranch && hitCandidateToCompare.start > hitCandidate.start &&
+                   hitCandidateToCompare.end < hitCandidate.end)
               {
-                if (hitLocation.AccountedByNestedInstrumentation?.Contains(j) == true)
+                for (int i = hitCandidateToCompare.start;
+                     i <= (hitCandidateToCompare.end == 0 ? hitCandidateToCompare.start : hitCandidateToCompare.end);
+                     i++)
                 {
-                  continue;
+                  (hitCandidate.AccountedByNestedInstrumentation ??= []).Add(i);
                 }
-
-                Line line = document.Lines[j];
-                line.Hits += hits;
-
-                if (line.Hits < 0)
-                  line.Hits = int.MaxValue;
               }
             }
           }
-        }
+
+          var documentsList = result.Documents.Values.ToList();
+          using (Stream fs = _fileSystem.NewFileStream(result.HitsFilePath, FileMode.Open, FileAccess.Read))
+          using (var br = new BinaryReader(fs))
+          {
+            int hitCandidatesCount = br.ReadInt32();
+
+            // TODO: hitCandidatesCount should be verified against result.HitCandidates.Count
+
+            for (int i = 0; i < hitCandidatesCount; ++i)
+            {
+              HitCandidate hitLocation = result.HitCandidates[i];
+              Document document = documentsList[hitLocation.docIndex];
+              int hits = br.ReadInt32();
+
+              if (hits == 0)
+                continue;
+
+              hits = hits < 0 ? int.MaxValue : hits;
+
+              if (hitLocation.isBranch)
+              {
+                Branch branch = document.Branches[new BranchKey(hitLocation.start, hitLocation.end)];
+                branch.Hits += hits;
+
+                if (branch.Hits < 0)
+                  branch.Hits = int.MaxValue;
+              }
+              else
+              {
+                for (int j = hitLocation.start; j <= hitLocation.end; j++)
+                {
+                  if (hitLocation.AccountedByNestedInstrumentation?.Contains(j) == true)
+                  {
+                    continue;
+                  }
+
+                  Line line = document.Lines[j];
+                  line.Hits += hits;
+
+                  if (line.Hits < 0)
+                    line.Hits = int.MaxValue;
+                }
+              }
+            }
+          }
+        } // shared lock released here; safe to delete the lock file below
 
         try
         {
@@ -481,6 +503,51 @@ namespace Coverlet.Core
         {
           _logger.LogWarning($"Unable to remove hit file: {result.HitsFilePath} because : {ex.Message}");
         }
+
+        TryDeleteFile(tmpFilePath);
+        TryDeleteFile(lockFilePath);
+      }
+    }
+
+    private static FileStream TryAcquireReaderLockOnFile(string lockFilePath, string moduleName, ILogger logger)
+    {
+      if (!File.Exists(lockFilePath))
+        return null;
+
+      TimeSpan elapsed = TimeSpan.Zero;
+      TimeSpan interval = TimeSpan.FromMilliseconds(50);
+      TimeSpan timeout = TimeSpan.FromSeconds(10);
+      while (elapsed <= timeout)
+      {
+        try
+        {
+          return new FileStream(lockFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        }
+        catch (FileNotFoundException)
+        {
+          // Lock file was removed between File.Exists and FileStream open; no writer active.
+          return null;
+        }
+        catch (IOException)
+        {
+          // Writer holds the lock file exclusively; wait for it to finish or die.
+          Thread.Sleep(interval);
+          elapsed += interval;
+        }
+      }
+
+      logger.LogWarning($"Timed out waiting for write lock on hits file for module '{moduleName}'. Coverage data may be incomplete.");
+      return null;
+    }
+
+    private static void TryDeleteFile(string path)
+    {
+      try
+      {
+        File.Delete(path);
+      }
+      catch
+      {
       }
     }
 

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -473,7 +473,7 @@ namespace Coverlet.Core.Instrumentation
 
         foreach (MethodDefinition methodDef in moduleTrackerTemplate.Methods)
         {
-          var methodOnCustomType = new MethodDefinition(methodDef.Name, methodDef.Attributes, methodDef.ReturnType);
+          var methodOnCustomType = new MethodDefinition(methodDef.Name, methodDef.Attributes, ImportToCoreLibrary(module, methodDef.ReturnType));
 
           foreach (ParameterDefinition parameter in methodDef.Parameters)
           {
@@ -503,7 +503,7 @@ namespace Coverlet.Core.Instrumentation
               else
               {
                 // Move to the custom type
-                var updatedMethodReference = new MethodReference(methodReference.Name, methodReference.ReturnType, _customTrackerTypeDef);
+                var updatedMethodReference = new MethodReference(methodReference.Name, ImportToCoreLibrary(module, methodReference.ReturnType), _customTrackerTypeDef);
                 foreach (ParameterDefinition parameter in methodReference.Parameters)
                   updatedMethodReference.Parameters.Add(new ParameterDefinition(parameter.Name, parameter.Attributes, ImportToCoreLibrary(module, parameter.ParameterType)));
 

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -367,14 +367,6 @@ namespace Coverlet.Core.Instrumentation
 
       Instruction lastInstr = _customTrackerClassConstructorIl.Body.Instructions[_customTrackerClassConstructorIl.Body.Instructions.Count - 1];
 
-      if (!containsAppContext)
-      {
-        // For "normal" cases, where the instrumented assembly is not the core library, we add a call to
-        // RegisterUnloadEvents to the static constructor of the generated custom tracker. Due to static
-        // initialization constraints, the core library is handled separately below.
-        _customTrackerClassConstructorIl.InsertBefore(lastInstr, Instruction.Create(OpCodes.Call, _customTrackerRegisterUnloadEventsMethod));
-      }
-
       _customTrackerClassConstructorIl.InsertBefore(lastInstr, Instruction.Create(OpCodes.Ldc_I4, _result.HitCandidates.Count));
       _customTrackerClassConstructorIl.InsertBefore(lastInstr, Instruction.Create(OpCodes.Newarr, module.TypeSystem.Int32));
       _customTrackerClassConstructorIl.InsertBefore(lastInstr, Instruction.Create(OpCodes.Stsfld, _customTrackerHitsArray));
@@ -384,6 +376,16 @@ namespace Coverlet.Core.Instrumentation
       _customTrackerClassConstructorIl.InsertBefore(lastInstr, Instruction.Create(OpCodes.Stsfld, _customTrackerSingleHit));
       _customTrackerClassConstructorIl.InsertBefore(lastInstr, Instruction.Create(OpCodes.Ldc_I4_1));
       _customTrackerClassConstructorIl.InsertBefore(lastInstr, Instruction.Create(OpCodes.Stsfld, _customTrackerFlushHitFile));
+
+      if (!containsAppContext)
+      {
+        // For "normal" cases, where the instrumented assembly is not the core library, we add a call to
+        // RegisterUnloadEvents to the static constructor of the generated custom tracker. Due to static
+        // initialization constraints, the core library is handled separately below.
+        // NOTE: this insertion must follow the field initialisations above; HitsFilePath must be set
+        // before RegisterUnloadEvents runs.
+        _customTrackerClassConstructorIl.InsertBefore(lastInstr, Instruction.Create(OpCodes.Call, _customTrackerRegisterUnloadEventsMethod));
+      }
 
       if (containsAppContext)
       {

--- a/src/coverlet.core/Instrumentation/ModuleTrackerTemplate.cs
+++ b/src/coverlet.core/Instrumentation/ModuleTrackerTemplate.cs
@@ -104,82 +104,109 @@ namespace Coverlet.Core.Instrumentation
         mutex.WaitOne();
       }
 
-      if (FlushHitFile)
+      // Hold the lock file exclusively for the entire write so the out-of-proc reader can detect
+      // a write in progress and wait, or detect a crashed writer (the OS releases all file handles
+      // on process death, making the lock visible to readers immediately).
+      // A reader may briefly hold the file shared; retry a handful of times before giving up.
+      using (FileStream lockFile = TryAcquireExclusiveLockOnFile(HitsFilePath + ".lock"))
       {
-        try
+        if (lockFile == null)
+          throw new InvalidOperationException($"Failed to acquire lock file for '{HitsFilePath}' after retries.");
+
+        if (FlushHitFile)
         {
-          // Claim the current hits array and reset it to prevent double-counting scenarios.
-          int[] hitsArray = Interlocked.Exchange(ref HitsArray, new int[HitsArray.Length]);
-
-          WriteLog($"Unload called for '{Assembly.GetExecutingAssembly().Location}' by '{sender ?? "null"}'");
-          WriteLog($"Flushing hit file '{HitsFilePath}'");
-
-          bool failedToCreateNewHitsFile = false;
           try
           {
-            using var fs = new FileStream(HitsFilePath, FileMode.CreateNew);
-            using var bw = new BinaryWriter(fs);
-            bw.Write(hitsArray.Length);
-            foreach (int hitCount in hitsArray)
+            // Claim the current hits array and reset it to prevent double-counting scenarios.
+            int[] hitsArray = Interlocked.Exchange(ref HitsArray, new int[HitsArray.Length]);
+
+            WriteLog($"Unload called for '{Assembly.GetExecutingAssembly().Location}' by '{sender ?? "null"}'");
+            WriteLog($"Flushing hit file '{HitsFilePath}'");
+
+            string tmpFilePath = HitsFilePath + ".tmp";
+            if (File.Exists(HitsFilePath))
             {
-              bw.Write(hitCount);
+              // Another AppDomain already wrote HitsFilePath (only possible on .NET Framework).
+              // Read it, compute the merged result, then replace atomically.
+              int[] mergedHits = MergeHitsWithExistingFile(hitsArray);
+              WriteHitsToFile(tmpFilePath, mergedHits);
+              File.Replace(tmpFilePath, HitsFilePath, null);
             }
+            else
+            {
+              // First write: stage in .tmp so HitsFilePath only appears once the data is complete.
+              WriteHitsToFile(tmpFilePath, hitsArray);
+              File.Move(tmpFilePath, HitsFilePath);
+            }
+
+            WriteHits(sender);
+
+            WriteLog($"Hit file '{HitsFilePath}' flushed, size {new FileInfo(HitsFilePath).Length}");
+            WriteLog("--------------------------------");
           }
           catch (Exception ex)
           {
-            WriteLog($"Failed to create new hits file '{HitsFilePath}' -> '{ex.Message}'");
-            failedToCreateNewHitsFile = true;
+            WriteLog(ex.ToString());
+            throw;
           }
 
-          if (failedToCreateNewHitsFile)
-          {
-            // Update the number of hits by adding value on disk with the ones on memory.
-            // This path should be triggered only in the case of multiple AppDomain unloads.
-            using var fs = new FileStream(HitsFilePath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
-            using var br = new BinaryReader(fs);
-            using var bw = new BinaryWriter(fs);
-            int hitsLength = br.ReadInt32();
-            WriteLog($"Current hits found '{hitsLength}'");
-
-            if (hitsLength != hitsArray.Length)
-            {
-              throw new InvalidOperationException($"{HitsFilePath} has {hitsLength} entries but on memory {nameof(HitsArray)} has {hitsArray.Length}");
-            }
-
-            for (int i = 0; i < hitsLength; ++i)
-            {
-              int oldHitCount = br.ReadInt32();
-              bw.Seek(-sizeof(int), SeekOrigin.Current);
-              if (SingleHit)
-              {
-                bw.Write(hitsArray[i] + oldHitCount > 0 ? 1 : 0);
-              }
-              else
-              {
-                bw.Write(hitsArray[i] + oldHitCount);
-              }
-            }
-          }
-
-          WriteHits(sender);
-
-          WriteLog($"Hit file '{HitsFilePath}' flushed, size {new FileInfo(HitsFilePath).Length}");
-          WriteLog("--------------------------------");
+          // Clear the flag inside the mutex so that any concurrent caller (e.g. ProcessExit)
+          // that is waiting for the mutex will see FlushHitFile == false and skip a redundant write.
+          FlushHitFile = false;
         }
-        catch (Exception ex)
-        {
-          WriteLog(ex.ToString());
-          throw;
-        }
-
-        // Clear the flag inside the mutex so that any concurrent caller (e.g. ProcessExit)
-        // that is waiting for the mutex will see FlushHitFile == false and skip a redundant write.
-        FlushHitFile = false;
       }
 
       // On purpose this is not under a try-finally: it is better to have an exception if there was any error writing the hits file
       // this case is relevant when instrumenting corelib since multiple processes can be running against the same instrumented dll.
       mutex.ReleaseMutex();
+    }
+
+    private static FileStream TryAcquireExclusiveLockOnFile(string lockFilePath)
+    {
+      for (int i = 0; i < 25; i++)
+      {
+        try
+        {
+          return new FileStream(lockFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+        }
+        catch (IOException)
+        {
+          Thread.Sleep(20);
+        }
+      }
+      return null;
+    }
+
+    private static void WriteHitsToFile(string filePath, int[] hitsArray)
+    {
+      using var fs = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None);
+      using var bw = new BinaryWriter(fs);
+      bw.Write(hitsArray.Length);
+      foreach (int hitCount in hitsArray)
+      {
+        bw.Write(hitCount);
+      }
+    }
+
+    private static int[] MergeHitsWithExistingFile(int[] inMemoryHits)
+    {
+      using var fs = new FileStream(HitsFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+      using var br = new BinaryReader(fs);
+      int hitsLength = br.ReadInt32();
+      WriteLog($"Current hits found '{hitsLength}'");
+
+      if (hitsLength != inMemoryHits.Length)
+        throw new InvalidOperationException($"{HitsFilePath} has {hitsLength} entries but in-memory {nameof(HitsArray)} has {inMemoryHits.Length}");
+
+      int[] merged = new int[hitsLength];
+      for (int i = 0; i < hitsLength; ++i)
+      {
+        int existing = br.ReadInt32();
+        merged[i] = SingleHit
+          ? inMemoryHits[i] + existing > 0 ? 1 : 0
+          : inMemoryHits[i] + existing;
+      }
+      return merged;
     }
 
     private static void WriteHits(object sender)

--- a/src/coverlet.core/Instrumentation/ModuleTrackerTemplate.cs
+++ b/src/coverlet.core/Instrumentation/ModuleTrackerTemplate.cs
@@ -81,8 +81,9 @@ namespace Coverlet.Core.Instrumentation
 
     public static void UnloadModule(object sender, EventArgs e)
     {
-      // The same module can be unloaded multiple times in the same process via different app domains.
-      // Use a global mutex to ensure no concurrent access.
+      // The same module can be unloaded concurrently (different AppDomains, or ProcessExit racing an
+      // in-proc-collector call). A global mutex serialises access; FlushHitFile is cleared inside the
+      // lock so a waiting caller sees the updated value and skips a redundant write.
       using var mutex = new Mutex(true, Path.GetFileNameWithoutExtension(HitsFilePath) + "_Mutex", out bool createdNew);
       if (!createdNew)
       {
@@ -156,6 +157,10 @@ namespace Coverlet.Core.Instrumentation
           WriteLog(ex.ToString());
           throw;
         }
+
+        // Clear the flag inside the mutex so that any concurrent caller (e.g. ProcessExit)
+        // that is waiting for the mutex will see FlushHitFile == false and skip a redundant write.
+        FlushHitFile = false;
       }
 
       // On purpose this is not under a try-finally: it is better to have an exception if there was any error writing the hits file

--- a/src/coverlet.core/Instrumentation/ModuleTrackerTemplate.cs
+++ b/src/coverlet.core/Instrumentation/ModuleTrackerTemplate.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
@@ -22,6 +23,12 @@ namespace Coverlet.Core.Instrumentation
   [ExcludeFromCodeCoverage]
   internal static class ModuleTrackerTemplate
   {
+    /// <summary>
+    /// AppDomain data key under which a <see cref="ConcurrentBag{T}"/> of <see cref="EventHandler"/>
+    /// delegates, one per loaded instrumented module, is stored for use by the in-proc collector.
+    /// </summary>
+    internal const string ModuleTrackerRegistryKey = "Coverlet_RegisteredModuleTrackers";
+
     public static string HitsFilePath;
     public static int[] HitsArray;
     public static bool SingleHit;
@@ -41,6 +48,13 @@ namespace Coverlet.Core.Instrumentation
     // to UnloadModule will be injected in System.AppContext.OnProcessExit.
     public static void RegisterUnloadEvents()
     {
+      // HitsFilePath is already set before this call (the injected static constructor initialises
+      // all fields before calling RegisterUnloadEvents). If no in-proc collector created the
+      // registry (MSBuild / global-tool integration), GetData returns null and the Add is a
+      // deliberate no-op; the ProcessExit handler covers the flush in those paths.
+      var registry = (ConcurrentBag<EventHandler>)AppDomain.CurrentDomain.GetData(ModuleTrackerRegistryKey);
+      registry?.Add(new EventHandler(UnloadModule));
+
       AppDomain.CurrentDomain.ProcessExit += new EventHandler(UnloadModule);
       AppDomain.CurrentDomain.DomainUnload += new EventHandler(UnloadModule);
     }

--- a/src/legacy/coverlet.collector/InProcDataCollection/CoverletInProcDataCollector.cs
+++ b/src/legacy/coverlet.collector/InProcDataCollection/CoverletInProcDataCollector.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Reflection;
-using System.Text;
 using Coverlet.Collector.Utilities;
 using Coverlet.Core.Instrumentation;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection;
@@ -42,6 +41,11 @@ namespace Coverlet.Collector.DataCollection
 
       _eqtTrace = new TestPlatformEqtTrace();
       _eqtTrace.Verbose("Initialize CoverletInProcDataCollector");
+
+      // Pre-create the registry bag before any instrumented assembly is loaded.
+      AppDomain.CurrentDomain.SetData(
+          ModuleTrackerTemplate.ModuleTrackerRegistryKey,
+          new ConcurrentBag<EventHandler>());
     }
 
     public void TestCaseEnd(TestCaseEndArgs testCaseEndArgs)
@@ -54,20 +58,19 @@ namespace Coverlet.Collector.DataCollection
 
     public void TestSessionEnd(TestSessionEndArgs testSessionEndArgs)
     {
-      foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
-      {
-        Type injectedInstrumentationClass = GetInstrumentationClass(assembly);
-        if (injectedInstrumentationClass is null)
-        {
-          continue;
-        }
+      // Use the AppDomain registry populated by RegisterUnloadEvents at module-load time.
+      var registeredHandlers = (ConcurrentBag<EventHandler>)AppDomain.CurrentDomain.GetData(ModuleTrackerTemplate.ModuleTrackerRegistryKey);
+      if (registeredHandlers is null)
+        return;
 
+      foreach (EventHandler handler in registeredHandlers)
+      {
+        string assemblyName = handler.Method?.DeclaringType?.Assembly?.FullName ?? "(unknown)";
         try
         {
-          _eqtTrace.Verbose($"Calling ModuleTrackerTemplate.UnloadModule for '{injectedInstrumentationClass.Assembly.FullName}'");
-          MethodInfo unloadModule = injectedInstrumentationClass.GetMethod(nameof(ModuleTrackerTemplate.UnloadModule), new[] { typeof(object), typeof(EventArgs) });
-          unloadModule.Invoke(null, new[] { (object)this, EventArgs.Empty });
-          _eqtTrace.Verbose($"Called ModuleTrackerTemplate.UnloadModule for '{injectedInstrumentationClass.Assembly.FullName}'");
+          _eqtTrace.Verbose($"Calling ModuleTrackerTemplate.UnloadModule for '{assemblyName}'");
+          handler.Invoke(this, EventArgs.Empty);
+          _eqtTrace.Verbose($"Called ModuleTrackerTemplate.UnloadModule for '{assemblyName}'");
         }
         catch (Exception ex)
         {
@@ -84,44 +87,5 @@ namespace Coverlet.Collector.DataCollection
     {
     }
 
-    internal Type GetInstrumentationClass(Assembly assembly)
-    {
-      try
-      {
-        foreach (Type type in assembly.GetTypes())
-        {
-          if (type.Namespace == "Coverlet.Core.Instrumentation.Tracker"
-              && type.Name.StartsWith(assembly.GetName().Name + "_"))
-          {
-            return type;
-          }
-        }
-
-        return null;
-      }
-      catch (Exception ex)
-      {
-        if (_enableExceptionLog)
-        {
-          var exceptionString = new StringBuilder();
-          exceptionString.AppendFormat("{0}: Failed to get Instrumentation class for assembly '{1}' with error: {2}",
-              CoverletConstants.InProcDataCollectorName, assembly, ex);
-          exceptionString.AppendLine();
-
-          if (ex is ReflectionTypeLoadException rtle)
-          {
-            exceptionString.AppendLine("ReflectionTypeLoadException list:");
-            foreach (Exception loaderEx in rtle.LoaderExceptions)
-            {
-              exceptionString.AppendLine(loaderEx.ToString());
-            }
-          }
-
-          _eqtTrace.Warning(exceptionString.ToString());
-        }
-
-        return null;
-      }
-    }
   }
 }

--- a/src/legacy/coverlet.collector/InProcDataCollection/CoverletInProcDataCollector.cs
+++ b/src/legacy/coverlet.collector/InProcDataCollection/CoverletInProcDataCollector.cs
@@ -67,7 +67,6 @@ namespace Coverlet.Collector.DataCollection
           _eqtTrace.Verbose($"Calling ModuleTrackerTemplate.UnloadModule for '{injectedInstrumentationClass.Assembly.FullName}'");
           MethodInfo unloadModule = injectedInstrumentationClass.GetMethod(nameof(ModuleTrackerTemplate.UnloadModule), new[] { typeof(object), typeof(EventArgs) });
           unloadModule.Invoke(null, new[] { (object)this, EventArgs.Empty });
-          injectedInstrumentationClass.GetField("FlushHitFile", BindingFlags.Static | BindingFlags.Public).SetValue(null, false);
           _eqtTrace.Verbose($"Called ModuleTrackerTemplate.UnloadModule for '{injectedInstrumentationClass.Assembly.FullName}'");
         }
         catch (Exception ex)

--- a/src/legacy/coverlet.collector/InProcDataCollection/CoverletInProcDataCollector.cs
+++ b/src/legacy/coverlet.collector/InProcDataCollection/CoverletInProcDataCollector.cs
@@ -74,11 +74,9 @@ namespace Coverlet.Collector.DataCollection
         }
         catch (Exception ex)
         {
+          _eqtTrace.Error("{0}: Failed to unload module '{1}' with error: {2}", CoverletConstants.InProcDataCollectorName, assemblyName, ex);
           if (_enableExceptionLog)
-          {
-            _eqtTrace.Error("{0}: Failed to unload module with error: {1}", CoverletConstants.InProcDataCollectorName, ex);
             throw new CoverletDataCollectorException($"{CoverletConstants.InProcDataCollectorName}: Failed to unload module", ex);
-          }
         }
       }
     }

--- a/src/legacy/coverlet.collector/InProcDataCollection/CoverletInProcDataCollector.cs
+++ b/src/legacy/coverlet.collector/InProcDataCollection/CoverletInProcDataCollector.cs
@@ -16,6 +16,7 @@ namespace Coverlet.Collector.DataCollection
   {
     private TestPlatformEqtTrace _eqtTrace;
     private bool _enableExceptionLog;
+    private bool _disableInprocFlush;
 
     private void AttachDebugger()
     {
@@ -34,10 +35,19 @@ namespace Coverlet.Collector.DataCollection
       }
     }
 
+    private void DisableInprocFlush()
+    {
+      if (int.TryParse(Environment.GetEnvironmentVariable("COVERLET_DATACOLLECTOR_INPROC_FLUSH_DISABLED"), out int result) && result == 1)
+      {
+        _disableInprocFlush = true;
+      }
+    }
+
     public void Initialize(IDataCollectionSink dataCollectionSink)
     {
       AttachDebugger();
       EnableExceptionLog();
+      DisableInprocFlush();
 
       _eqtTrace = new TestPlatformEqtTrace();
       _eqtTrace.Verbose("Initialize CoverletInProcDataCollector");
@@ -58,6 +68,12 @@ namespace Coverlet.Collector.DataCollection
 
     public void TestSessionEnd(TestSessionEndArgs testSessionEndArgs)
     {
+      if (_disableInprocFlush)
+      {
+        _eqtTrace.Verbose("COVERLET_DATACOLLECTOR_INPROC_FLUSH_DISABLED is set; skipping in-proc flush, hits will be written by process-exit handlers");
+        return;
+      }
+
       // Use the AppDomain registry populated by RegisterUnloadEvents at module-load time.
       var registeredHandlers = (ConcurrentBag<EventHandler>)AppDomain.CurrentDomain.GetData(ModuleTrackerTemplate.ModuleTrackerRegistryKey);
       if (registeredHandlers is null)

--- a/test/coverlet.collector.tests/CoverletInProcDataCollectorTests.cs
+++ b/test/coverlet.collector.tests/CoverletInProcDataCollectorTests.cs
@@ -2,58 +2,44 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Reflection;
+using System.Collections.Concurrent;
 using Coverlet.Collector.DataCollection;
+using Coverlet.Core.Instrumentation;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollector.InProcDataCollector;
 using Moq;
 using Xunit;
 
 namespace Coverlet.Collector.Tests.DataCollection
 {
-  public class CoverletInProcDataCollectorTests
+  public class CoverletInProcDataCollectorTests : IDisposable
   {
     private readonly CoverletInProcDataCollector _dataCollector;
 
     public CoverletInProcDataCollectorTests()
     {
       _dataCollector = new CoverletInProcDataCollector();
+      _dataCollector.Initialize(new Mock<IDataCollectionSink>().Object);
+    }
+
+    public void Dispose()
+    {
+      // Remove any registry entries written during the test so other tests are not affected.
+      AppDomain.CurrentDomain.SetData(ModuleTrackerTemplate.ModuleTrackerRegistryKey, null);
     }
 
     [Fact]
-    public void GetInstrumentationClass_ShouldReturnNullForNonMatchingType_EnabledLogging()
+    public void TestSessionEnd_UsesRegistryWhenAvailable()
     {
-      // Arrange
-      var dataCollectionSink = new Mock<IDataCollectionSink>();
-      var mockAssembly = new Mock<Assembly>();
-      var mockType = new Mock<Type>();
-      mockType.Setup(t => t.Namespace).Returns("Coverlet.Core.Instrumentation.Tracker");
-      mockType.Setup(t => t.Name).Returns("MockAssembly_Tracker");
-      mockAssembly.Setup(a => a.GetTypes()).Returns(new[] { mockType.Object });
-      Environment.SetEnvironmentVariable("COVERLET_DATACOLLECTOR_INPROC_EXCEPTIONLOG_ENABLED", "1");
-      _dataCollector.Initialize(dataCollectionSink.Object);
+      // Regression test for Fix 1 in issue #1983: TestSessionEnd must invoke handlers from the AppDomain registry.
+      bool handlerCalled = false;
 
-      // Act & Assert
-      var results = _dataCollector.GetInstrumentationClass(mockAssembly.Object);
+      var bag = (ConcurrentBag<EventHandler>)AppDomain.CurrentDomain.GetData(ModuleTrackerTemplate.ModuleTrackerRegistryKey);
+      bag?.Add(new((_, _) => { handlerCalled = true; }));
 
-      // Assert
-      Assert.Null(results);
-    }
+      _dataCollector.TestSessionEnd(new TestSessionEndArgs());
 
-    [Fact]
-    public void GetInstrumentationClass_ShouldReturnNullForNonMatchingType()
-    {
-      // Arrange
-      var mockAssembly = new Mock<Assembly>();
-      var mockType = new Mock<Type>();
-      mockType.Setup(t => t.Namespace).Returns("NonMatchingNamespace");
-      mockType.Setup(t => t.Name).Returns("NonMatchingName");
-      mockAssembly.Setup(a => a.GetTypes()).Returns(new[] { mockType.Object });
-
-      // Act
-      var result = _dataCollector.GetInstrumentationClass(mockAssembly.Object);
-
-      // Assert
-      Assert.Null(result);
+      Assert.True(handlerCalled);
     }
   }
 }

--- a/test/coverlet.collector.tests/CoverletInProcDataCollectorTests.cs
+++ b/test/coverlet.collector.tests/CoverletInProcDataCollectorTests.cs
@@ -55,6 +55,31 @@ namespace Coverlet.Collector.Tests.DataCollection
     }
 
     [Fact]
+    public void TestSessionEnd_SkipsFlushWhenInprocFlushDisabled()
+    {
+      // Regression test: COVERLET_DATACOLLECTOR_INPROC_FLUSH_DISABLED=1 must cause TestSessionEnd to skip
+      // the in-proc flush entirely, leaving coverage data to be written by the process-exit handlers.
+      try
+      {
+        Environment.SetEnvironmentVariable("COVERLET_DATACOLLECTOR_INPROC_FLUSH_DISABLED", "1");
+        var collector = new CoverletInProcDataCollector();
+        collector.Initialize(new Mock<IDataCollectionSink>().Object);
+
+        bool handlerCalled = false;
+        var bag = (ConcurrentBag<EventHandler>)AppDomain.CurrentDomain.GetData(ModuleTrackerTemplate.ModuleTrackerRegistryKey);
+        bag?.Add(new((_, _) => { handlerCalled = true; }));
+
+        collector.TestSessionEnd(new TestSessionEndArgs());
+
+        Assert.False(handlerCalled);
+      }
+      finally
+      {
+        Environment.SetEnvironmentVariable("COVERLET_DATACOLLECTOR_INPROC_FLUSH_DISABLED", null);
+      }
+    }
+
+    [Fact]
     public void TestSessionEnd_RethrowsWhenHandlerThrowsAndExceptionLogEnabled()
     {
       // Regression test for Fix 4 in issue #1983: with COVERLET_DATACOLLECTOR_INPROC_EXCEPTIONLOG_ENABLED=1

--- a/test/coverlet.collector.tests/CoverletInProcDataCollectorTests.cs
+++ b/test/coverlet.collector.tests/CoverletInProcDataCollectorTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using Coverlet.Collector.DataCollection;
+using Coverlet.Collector.Utilities;
 using Coverlet.Core.Instrumentation;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollector.InProcDataCollector;
@@ -40,6 +41,39 @@ namespace Coverlet.Collector.Tests.DataCollection
       _dataCollector.TestSessionEnd(new TestSessionEndArgs());
 
       Assert.True(handlerCalled);
+    }
+
+    [Fact]
+    public void TestSessionEnd_DoesNotRethrowWhenHandlerThrows()
+    {
+      // Regression test for Fix 4 in issue #1983: a failing handler must be logged but must not
+      // propagate by default, so coverage failures do not abort the test run.
+      var bag = (ConcurrentBag<EventHandler>)AppDomain.CurrentDomain.GetData(ModuleTrackerTemplate.ModuleTrackerRegistryKey);
+      bag?.Add(new((_, _) => throw new InvalidOperationException("simulated flush failure")));
+
+      _dataCollector.TestSessionEnd(new TestSessionEndArgs());
+    }
+
+    [Fact]
+    public void TestSessionEnd_RethrowsWhenHandlerThrowsAndExceptionLogEnabled()
+    {
+      // Regression test for Fix 4 in issue #1983: with COVERLET_DATACOLLECTOR_INPROC_EXCEPTIONLOG_ENABLED=1
+      // a failing handler must be rethrown so the test run can surface coverage failures explicitly.
+      try
+      {
+        Environment.SetEnvironmentVariable("COVERLET_DATACOLLECTOR_INPROC_EXCEPTIONLOG_ENABLED", "1");
+        var collector = new CoverletInProcDataCollector();
+        collector.Initialize(new Mock<IDataCollectionSink>().Object);
+
+        var bag = (ConcurrentBag<EventHandler>)AppDomain.CurrentDomain.GetData(ModuleTrackerTemplate.ModuleTrackerRegistryKey);
+        bag?.Add(new((_, _) => throw new InvalidOperationException("simulated flush failure")));
+
+        Assert.Throws<CoverletDataCollectorException>(() => collector.TestSessionEnd(new TestSessionEndArgs()));
+      }
+      finally
+      {
+        Environment.SetEnvironmentVariable("COVERLET_DATACOLLECTOR_INPROC_EXCEPTIONLOG_ENABLED", null);
+      }
     }
   }
 }

--- a/test/coverlet.core.coverage.tests/Instrumentation/ModuleTrackerTemplateTests.cs
+++ b/test/coverlet.core.coverage.tests/Instrumentation/ModuleTrackerTemplateTests.cs
@@ -125,10 +125,39 @@ namespace Coverlet.Core.Tests.Instrumentation
         ModuleTrackerTemplate.HitsArray = [0, 3, 2, 1];
         ModuleTrackerTemplate.UnloadModule(null, null);
 
+        // Each AppDomain has its own copy of ModuleTrackerTemplate with FlushHitFile = true.
+        // Reset the flag to simulate a second AppDomain's unload.
+        ModuleTrackerTemplate.FlushHitFile = true;
         ModuleTrackerTemplate.HitsArray = [0, 1, 2, 3];
         ModuleTrackerTemplate.UnloadModule(null, null);
 
         int[] expectedHitsArray = [0, 4, 4, 4];
+        Assert.Equal(expectedHitsArray, ReadHitsFile());
+
+        return s_success;
+      });
+    }
+
+    [Fact]
+    public void FlushHitFileClearedInsideMutexPreventsDoubleWrite()
+    {
+      // Regression test for Fix 3 in issue #1983: FlushHitFile must be cleared inside the mutex so a
+      // concurrent ProcessExit caller that was waiting for the lock sees false and skips the
+      // write.
+      FunctionExecutor.Run(() =>
+      {
+        using var ctx = new TrackerContext();
+        ModuleTrackerTemplate.HitsArray = [1, 2, 3];
+
+        ModuleTrackerTemplate.UnloadModule(null, null);
+
+        // FlushHitFile must be false inside the mutex, not after it is released.
+        Assert.False(ModuleTrackerTemplate.FlushHitFile);
+
+        // Second call simulates ProcessExit in the old TOCTOU window; must be a no-op.
+        ModuleTrackerTemplate.UnloadModule(null, null);
+
+        int[] expectedHitsArray = [1, 2, 3];
         Assert.Equal(expectedHitsArray, ReadHitsFile());
 
         return s_success;

--- a/test/coverlet.core.coverage.tests/Instrumentation/ModuleTrackerTemplateTests.cs
+++ b/test/coverlet.core.coverage.tests/Instrumentation/ModuleTrackerTemplateTests.cs
@@ -28,8 +28,9 @@ namespace Coverlet.Core.Tests.Instrumentation
       {
         if (disposing)
         {
-          // Dispose managed resources
           File.Delete(ModuleTrackerTemplate.HitsFilePath);
+          File.Delete(ModuleTrackerTemplate.HitsFilePath + ".tmp");
+          File.Delete(ModuleTrackerTemplate.HitsFilePath + ".lock");
         }
 
         // Dispose unmanaged resources
@@ -190,6 +191,27 @@ namespace Coverlet.Core.Tests.Instrumentation
     }
 
     [Fact]
+    public void HitsFileWrittenAtomicallyLeavesNoTempFile()
+    {
+      // Regression test for Fix 2 in issue #1983: UnloadModule must write via a temp file and rename
+      // so the hit file appears at HitsFilePath only once it is complete. No .tmp residual should
+      // remain after a successful flush.
+      FunctionExecutor.Run(() =>
+      {
+        using var ctx = new TrackerContext();
+        ModuleTrackerTemplate.HitsArray = [1, 2, 3];
+        ModuleTrackerTemplate.UnloadModule(null, null);
+
+        Assert.True(File.Exists(ModuleTrackerTemplate.HitsFilePath));
+        Assert.False(File.Exists(ModuleTrackerTemplate.HitsFilePath + ".tmp"));
+        int[] expectedHitsArray = [1, 2, 3];
+        Assert.Equal(expectedHitsArray, ReadHitsFile());
+
+        return s_success;
+      });
+    }
+
+    [Fact]
     public void MutexBlocksMultipleWriters()
     {
       FunctionExecutor.Run(async () =>
@@ -221,6 +243,26 @@ namespace Coverlet.Core.Tests.Instrumentation
         return 0;
       });
 
+    }
+
+    [Fact]
+    public void LockFileHeldDuringWriteAndReleasedAfter()
+    {
+      FunctionExecutor.Run(() =>
+      {
+        using var ctx = new TrackerContext();
+        string lockPath = ModuleTrackerTemplate.HitsFilePath + ".lock";
+
+        ModuleTrackerTemplate.HitsArray = [1, 2, 3];
+        ModuleTrackerTemplate.UnloadModule(null, null);
+
+        // After a completed write the lock file must have been released.
+        // A successful exclusive open (FileShare.None) confirms no one holds it.
+        using var probe = new FileStream(lockPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+        Assert.True(probe.CanRead);
+
+        return s_success;
+      });
     }
 
     private static void WriteHitsFile(int[] hitsArray)

--- a/test/coverlet.core.coverage.tests/Instrumentation/ModuleTrackerTemplateTests.cs
+++ b/test/coverlet.core.coverage.tests/Instrumentation/ModuleTrackerTemplateTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
@@ -132,6 +133,30 @@ namespace Coverlet.Core.Tests.Instrumentation
         ModuleTrackerTemplate.UnloadModule(null, null);
 
         int[] expectedHitsArray = [0, 4, 4, 4];
+        Assert.Equal(expectedHitsArray, ReadHitsFile());
+
+        return s_success;
+      });
+    }
+
+    [Fact]
+    public void RegisterUnloadEventsPopulatesRegistry()
+    {
+      // Regression test for Fix 1 in issue #1983: RegisterUnloadEvents must record the module's
+      // UnloadModule delegate so the in-proc collector can flush all hit files.
+      FunctionExecutor.Run(() =>
+      {
+        using var ctx = new TrackerContext();
+        ModuleTrackerTemplate.HitsArray = [3, 1, 4];
+
+        // Simulate Initialize pre-creating the bag, then module load calling RegisterUnloadEvents.
+        var bag = new ConcurrentBag<EventHandler>();
+        AppDomain.CurrentDomain.SetData(ModuleTrackerTemplate.ModuleTrackerRegistryKey, bag);
+        ModuleTrackerTemplate.RegisterUnloadEvents();
+
+        EventHandler handler = Assert.Single(bag);
+        handler.Invoke(null, EventArgs.Empty);
+        int[] expectedHitsArray = [3, 1, 4];
         Assert.Equal(expectedHitsArray, ReadHitsFile());
 
         return s_success;


### PR DESCRIPTION
I'm pretty excited about this!

Not only does this PR eliminate the `EndOfStreamException` (which occurs because the in-proc reader starts while the out-of-proc writer hasn't completed yet), but it also enables the reader to detect that the writer is still running, wait for it to complete, or, if it gets killed midway, log a warning. Even with `COVERLET_DATACOLLECTOR_INPROC_FLUSH_DISABLED` active, it reported the same coverage in a stress test on my Windows pc (18757 tests targeting net10/9/8), while 25 sequential runs never reported any warnings. I haven't been able to stress-test on .NET Framework.

See the commit messages for implementation details.

Fixes #1983, fixes #1981.