### PR TITLE
Replicate in-proc collector improvements from PR #1987 to MTP handler

### DIFF
--- a/Documentation/Coverlet.MTP.Integration.md
+++ b/Documentation/Coverlet.MTP.Integration.md
@@ -523,7 +523,7 @@ sequenceDiagram
 | `COVERLET_MTP_COVERAGE_IDENTIFIER` | Unique ID for result correlation |
 | `COVERLET_MTP_HITS_FILE_PATH` | Directory for hit data files |
 | `COVERLET_MTP_INPROC_DEBUG` | Set to "1" to debug in-process handler |
-| `COVERLET_MTP_INPROC_EXCEPTIONLOG_ENABLED` | Set to "1" for detailed error logging |
+| `COVERLET_MTP_INPROC_EXCEPTIONLOG_ENABLED` | Set to "1" to rethrow exceptions from the in-process handler |
 
 ## Troubleshooting
 
@@ -598,11 +598,19 @@ set COVERLET_MTP_INSTRUMENTATION_DEBUG=1
 
 ### Enable Exception Logging
 
-To capture detailed exception information (Windows):
+To rethrow exceptions from the in-process handler (making failures visible as a test run error):
 
 ```shell
 set COVERLET_MTP_EXCEPTIONLOG_ENABLED=1
 ```
+
+Or alternatively, using the in-process specific variable:
+
+```shell
+set COVERLET_MTP_INPROC_EXCEPTIONLOG_ENABLED=1
+```
+
+By default, failures in the in-proc handler's module-unload step are recorded in the MTP diagnostics log but do not abort the test run. Setting this variable to `1` causes those failures to be rethrown.
 
 ### Using MTP Built-in Diagnostics
 

--- a/src/coverlet.MTP/EnvironmentVariables/CoverletExtensionEnvironmentVariableProvider.cs
+++ b/src/coverlet.MTP/EnvironmentVariables/CoverletExtensionEnvironmentVariableProvider.cs
@@ -77,7 +77,7 @@ internal sealed class CoverletExtensionEnvironmentVariableProvider : ITestHostEn
     {
       environmentVariables.SetVariable(
         new EnvironmentVariable(
-          CoverletMtpDebugConstants.ExceptionLogEnabled,
+          CoverletMtpEnvironmentVariables.InProcessExceptionLog,
           "1",
           isSecret: false,
           isLocked: false));

--- a/src/coverlet.MTP/InProcess/CoverletInProcessHandler.cs
+++ b/src/coverlet.MTP/InProcess/CoverletInProcessHandler.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Toni Solarin-Sodara
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Reflection;
 using Coverlet.MTP.EnvironmentVariables;
 using Coverlet.Core.Instrumentation;
 using Microsoft.Testing.Platform.Extensions.TestHost;
@@ -22,7 +22,6 @@ internal sealed class CoverletInProcessHandler : ITestSessionLifetimeHandler
   private readonly bool _coverageEnabled;
   private readonly string? _coverageIdentifier;
   private readonly bool _enableExceptionLog;
-  private readonly ILogger? _object; // Make nullable
 
   public string Uid => "Coverlet.MTP.InProcess";
   public string Version => typeof(CoverletExtension).Assembly.GetName().Version?.ToString() ?? "1.0.0";
@@ -48,10 +47,9 @@ internal sealed class CoverletInProcessHandler : ITestSessionLifetimeHandler
     _logger.LogDebug($"[Coverlet.MTP.InProcess] Initialized - CoverageEnabled={_coverageEnabled}, Identifier={_coverageIdentifier ?? "(null)"}");
   }
 
-  public CoverletInProcessHandler(ILogger @object)
+  public CoverletInProcessHandler(ILogger logger)
   {
-    _logger = @object;
-    _object = @object;
+    _logger = logger;
     // You may want to initialize other fields here as needed
   }
 
@@ -65,6 +63,11 @@ internal sealed class CoverletInProcessHandler : ITestSessionLifetimeHandler
     if (_coverageEnabled)
     {
       _logger.LogDebug($"[Coverlet.MTP.InProcess] Test session starting: {testSessionContext.SessionUid}");
+
+      // Pre-create the registry bag before any instrumented assembly is loaded.
+      AppDomain.CurrentDomain.SetData(
+          ModuleTrackerTemplate.ModuleTrackerRegistryKey,
+          new ConcurrentBag<EventHandler>());
     }
     return Task.CompletedTask;
   }
@@ -82,17 +85,7 @@ internal sealed class CoverletInProcessHandler : ITestSessionLifetimeHandler
 
     _logger.LogDebug($"[Coverlet.MTP.InProcess] Test session finishing: {testSessionContext.SessionUid}, flushing coverage data");
 
-    try
-    {
-      FlushCoverageData();
-    }
-    catch (Exception ex)
-    {
-      if (_enableExceptionLog)
-      {
-        _logger.LogError($"[Coverlet.MTP.InProcess] Failed to flush coverage data: {ex}");
-      }
-    }
+    FlushCoverageData();
 
     return Task.CompletedTask;
   }
@@ -105,78 +98,30 @@ internal sealed class CoverletInProcessHandler : ITestSessionLifetimeHandler
   {
     int flushedCount = 0;
 
-    foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
-    {
-      Type? trackerType = GetInstrumentationTrackerType(assembly);
-      if (trackerType == null)
-        continue;
+    var registeredHandlers = (ConcurrentBag<EventHandler>?)AppDomain.CurrentDomain.GetData(ModuleTrackerTemplate.ModuleTrackerRegistryKey);
+    if (registeredHandlers is null)
+      return;
 
+    foreach (EventHandler handler in registeredHandlers)
+    {
+      string assemblyName = handler.Method?.DeclaringType?.Assembly?.GetName().Name ?? "(unknown)";
       try
       {
-        _logger.LogDebug($"[Coverlet.MTP.InProcess] Flushing coverage for '{assembly.GetName().Name}'");
-
-        // Call ModuleTrackerTemplate.UnloadModule to flush hit data
-        MethodInfo? unloadMethod = trackerType.GetMethod(
-          nameof(ModuleTrackerTemplate.UnloadModule),
-          [typeof(object), typeof(EventArgs)]);
-
-        if (unloadMethod != null)
-        {
-          unloadMethod.Invoke(null, [this, EventArgs.Empty]);
-          flushedCount++;
-          _logger.LogDebug($"[Coverlet.MTP.InProcess] Successfully flushed coverage for '{assembly.GetName().Name}'");
-        }
+        _logger.LogDebug($"[Coverlet.MTP.InProcess] Flushing coverage for '{assemblyName}'");
+        handler.Invoke(this, EventArgs.Empty);
+        flushedCount++;
+        _logger.LogDebug($"[Coverlet.MTP.InProcess] Successfully flushed coverage for '{assemblyName}'");
       }
       catch (Exception ex)
       {
+        _logger.LogError($"[Coverlet.MTP.InProcess] Failed to flush coverage for '{assemblyName}': {ex}");
         if (_enableExceptionLog)
         {
-          _logger.LogWarning($"[Coverlet.MTP.InProcess] Failed to flush coverage for '{assembly.GetName().Name}': {ex.Message}");
+          throw new InvalidOperationException($"[Coverlet.MTP.InProcess] Failed to flush coverage for '{assemblyName}'", ex);
         }
       }
     }
 
     _logger.LogDebug($"[Coverlet.MTP.InProcess] Flushed {flushedCount} instrumented assemblies");
   }
-
-  /// <summary>
-  /// Finds the injected tracker type in an assembly.
-  /// Tracker types are in namespace "Coverlet.Core.Instrumentation.Tracker"
-  /// with name pattern "{AssemblyName}_*".
-  /// </summary>
-  private Type? GetInstrumentationTrackerType(Assembly assembly)
-  {
-    try
-    {
-      string? assemblyName = assembly.GetName().Name;
-      if (string.IsNullOrEmpty(assemblyName))
-        return null;
-
-      foreach (Type type in assembly.GetTypes())
-      {
-        if (type.Namespace == "Coverlet.Core.Instrumentation.Tracker" &&
-            type.Name.StartsWith(assemblyName + "_", StringComparison.Ordinal))
-        {
-          return type;
-        }
-      }
-
-      return null;
-    }
-    catch (ReflectionTypeLoadException ex)
-    {
-      if (_enableExceptionLog)
-      {
-        string errors = string.Join(", ", ex.LoaderExceptions?.Select(e => e?.Message) ?? []);
-        _logger.LogDebug($"[Coverlet.MTP.InProcess] ReflectionTypeLoadException for '{assembly.GetName().Name}': {errors}");
-      }
-      return null;
-    }
-    catch
-    {
-      // Silently ignore assemblies that can't be inspected
-      return null;
-    }
-  }
-
 }

--- a/test/coverlet.MTP.tests/Environment/CoverletExtensionEnvironmentVariableProviderTests.cs
+++ b/test/coverlet.MTP.tests/Environment/CoverletExtensionEnvironmentVariableProviderTests.cs
@@ -168,7 +168,7 @@ public class CoverletExtensionEnvironmentVariableProviderTests
     // Assert
     mockEnvironmentVariables.Verify(
       x => x.SetVariable(It.Is<EnvironmentVariable>(
-        ev => ev.Variable == CoverletMtpDebugConstants.ExceptionLogEnabled && ev.Value == "1")),
+        ev => ev.Variable == CoverletMtpEnvironmentVariables.InProcessExceptionLog && ev.Value == "1")),
       Times.Once());
   }
 
@@ -219,7 +219,7 @@ public class CoverletExtensionEnvironmentVariableProviderTests
       Times.Once());
     mockEnvironmentVariables.Verify(
       x => x.SetVariable(It.Is<EnvironmentVariable>(
-        ev => ev.Variable == CoverletMtpDebugConstants.ExceptionLogEnabled)),
+        ev => ev.Variable == CoverletMtpEnvironmentVariables.InProcessExceptionLog)),
       Times.Once());
   }
 
@@ -327,7 +327,7 @@ public class CoverletExtensionEnvironmentVariableProviderTests
         Times.Once());
       mockEnvironmentVariables.Verify(
         x => x.SetVariable(It.Is<EnvironmentVariable>(
-          ev => ev.Variable == CoverletMtpDebugConstants.ExceptionLogEnabled)),
+          ev => ev.Variable == CoverletMtpEnvironmentVariables.InProcessExceptionLog)),
         Times.Once());
     }
     finally

--- a/test/coverlet.MTP.tests/InProcess/CoverletInProcessHandlerTests.cs
+++ b/test/coverlet.MTP.tests/InProcess/CoverletInProcessHandlerTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Toni Solarin-Sodara
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Concurrent;
+using Coverlet.Core.Instrumentation;
 using Coverlet.MTP.EnvironmentVariables;
 using Microsoft.Testing.Platform.Extensions.TestHost;
 using Microsoft.Testing.Platform.Logging;
@@ -349,22 +351,30 @@ public class CoverletInProcessHandlerTests : IDisposable
     var handler = new CoverletInProcessHandler(_mockLoggerFactory.Object);
     var mockSessionContext = new Mock<ITestSessionContext>();
     mockSessionContext.Setup(x => x.SessionUid).Returns(new Microsoft.Testing.Platform.TestHost.SessionUid("test-session-789"));
+    AppDomain.CurrentDomain.SetData(ModuleTrackerTemplate.ModuleTrackerRegistryKey, new ConcurrentBag<EventHandler>());
 
-    // Act
-    await ((ITestSessionLifetimeHandler)handler).OnTestSessionFinishingAsync(mockSessionContext.Object);
+    try
+    {
+      // Act
+      await ((ITestSessionLifetimeHandler)handler).OnTestSessionFinishingAsync(mockSessionContext.Object);
 
-    // Assert
-    _mockLogger.Verify(
-      x => x.Log(
-        It.Is<LogLevel>(l => l == LogLevel.Debug),
-        It.Is<string>(s => s.Contains("Flushed") && s.Contains("instrumented assemblies")),
-        It.IsAny<Exception?>(),
-        It.IsAny<Func<string, Exception?, string>>()),
-      Times.Once);
+      // Assert
+      _mockLogger.Verify(
+        x => x.Log(
+          It.Is<LogLevel>(l => l == LogLevel.Debug),
+          It.Is<string>(s => s.Contains("Flushed") && s.Contains("instrumented assemblies")),
+          It.IsAny<Exception?>(),
+          It.IsAny<Func<string, Exception?, string>>()),
+        Times.Once);
+    }
+    finally
+    {
+      AppDomain.CurrentDomain.SetData(ModuleTrackerTemplate.ModuleTrackerRegistryKey, null);
+    }
   }
 
   [Fact]
-  public async Task OnTestSessionFinishingAsyncWhenExceptionOccursWithExceptionLogEnabledLogsError()
+  public async Task OnTestSessionFinishingAsyncWhenExceptionOccursWithExceptionLogEnabledLogsErrorAndRethrows()
   {
     // Arrange
     System.Environment.SetEnvironmentVariable(CoverletMtpEnvironmentVariables.CoverageEnabled, "true");
@@ -375,21 +385,35 @@ public class CoverletInProcessHandlerTests : IDisposable
     var mockSessionContext = new Mock<ITestSessionContext>();
     mockSessionContext.Setup(x => x.SessionUid).Returns(new Microsoft.Testing.Platform.TestHost.SessionUid("test-exception-session"));
 
-    // Act - This should complete without throwing, even if internal exceptions occur
-    await ((ITestSessionLifetimeHandler)handler).OnTestSessionFinishingAsync(mockSessionContext.Object);
+    // Inject a failing handler into the registry
+    var registry = new ConcurrentBag<EventHandler>
+    {
+        (s, e) => throw new InvalidOperationException("Test exception")
+    };
+    AppDomain.CurrentDomain.SetData(ModuleTrackerTemplate.ModuleTrackerRegistryKey, registry);
 
-    // Assert - Should not throw and should log debug messages
-    _mockLogger.Verify(
-      x => x.Log(
-        It.Is<LogLevel>(l => l == LogLevel.Debug),
-        It.IsAny<string>(),
-        It.IsAny<Exception?>(),
-        It.IsAny<Func<string, Exception?, string>>()),
-      Times.AtLeastOnce);
+    try
+    {
+      // Act
+      await Assert.ThrowsAsync<InvalidOperationException>(() => ((ITestSessionLifetimeHandler)handler).OnTestSessionFinishingAsync(mockSessionContext.Object));
+
+      // Assert
+      _mockLogger.Verify(
+        x => x.Log(
+          It.Is<LogLevel>(l => l == LogLevel.Error),
+          It.Is<string>(s => s.Contains("Failed to flush coverage for")),
+          It.IsAny<Exception?>(),
+          It.IsAny<Func<string, Exception?, string>>()),
+        Times.AtLeastOnce);
+    }
+    finally
+    {
+      AppDomain.CurrentDomain.SetData(ModuleTrackerTemplate.ModuleTrackerRegistryKey, null);
+    }
   }
 
   [Fact]
-  public async Task OnTestSessionFinishingAsyncWhenExceptionOccursWithExceptionLogDisabledDoesNotLogError()
+  public async Task OnTestSessionFinishingAsyncWhenExceptionOccursWithExceptionLogDisabledLogsErrorButDoesNotThrow()
   {
     // Arrange
     System.Environment.SetEnvironmentVariable(CoverletMtpEnvironmentVariables.CoverageEnabled, "true");
@@ -399,17 +423,31 @@ public class CoverletInProcessHandlerTests : IDisposable
     var mockSessionContext = new Mock<ITestSessionContext>();
     mockSessionContext.Setup(x => x.SessionUid).Returns(new Microsoft.Testing.Platform.TestHost.SessionUid("test-no-log-session"));
 
-    // Act
-    await ((ITestSessionLifetimeHandler)handler).OnTestSessionFinishingAsync(mockSessionContext.Object);
+    // Inject a failing handler into the registry
+    var registry = new ConcurrentBag<EventHandler>
+    {
+        (s, e) => throw new InvalidOperationException("Test exception")
+    };
+    AppDomain.CurrentDomain.SetData(ModuleTrackerTemplate.ModuleTrackerRegistryKey, registry);
 
-    // Assert - Should not throw
-    _mockLogger.Verify(
-      x => x.Log(
-        It.Is<LogLevel>(l => l == LogLevel.Error),
-        It.IsAny<string>(),
-        It.IsAny<Exception?>(),
-        It.IsAny<Func<string, Exception?, string>>()),
-      Times.Never);
+    try
+    {
+      // Act
+      await ((ITestSessionLifetimeHandler)handler).OnTestSessionFinishingAsync(mockSessionContext.Object);
+
+      // Assert - Should not throw
+      _mockLogger.Verify(
+        x => x.Log(
+          It.Is<LogLevel>(l => l == LogLevel.Error),
+          It.IsAny<string>(),
+          It.IsAny<Exception?>(),
+          It.IsAny<Func<string, Exception?, string>>()),
+        Times.AtLeastOnce);
+    }
+    finally
+    {
+      AppDomain.CurrentDomain.SetData(ModuleTrackerTemplate.ModuleTrackerRegistryKey, null);
+    }
   }
 
   #endregion


### PR DESCRIPTION
This PR applies the reliability improvements made to the legacy in-proc collector (PR #1987) to the new Microsoft Testing Platform (MTP) in-process handler:
1. Replace assembly scanning with `AppDomain` registry: `GetAssemblies()` + `GetTypes()` scanning silently drops any assembly that throws `ReflectionTypeLoadException`. By using the `ConcurrentBag<EventHandler>` registry populated during module load, we avoid reflection entirely and prevent silent coverage loss.
2. Always log flush failures: Exceptions thrown by `UnloadModule` are now logged unconditionally as errors. The `COVERLET_MTP_INPROC_EXCEPTIONLOG_ENABLED` environment variable now controls whether these exceptions are rethrown to abort the test run, rather than whether they are logged at all.
3. Fix environment variable propagation: Corrected a bug in `CoverletExtensionEnvironmentVariableProvider` where it was mistakenly passing the out-of-proc variable (`COVERLET_MTP_EXCEPTIONLOG_ENABLED`) to the test host instead of the correct in-proc variable (`COVERLET_MTP_INPROC_EXCEPTIONLOG_ENABLED`).