### PR TITLE
coverlet.console: add trace diagnostics and actionable warnings for instrumentation/hit/empty-result failures

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-reportgenerator-globaltool": {
-      "version": "5.5.10",
+      "version": "5.5.11",
       "commands": [
         "reportgenerator"
       ],

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,6 +4,7 @@ This is a .NET based repository that contains the coverlet projects for code cov
 
 ## General Guidelines
 - Always ask before creating any documentation files (e.g., `.md`, `.txt`, `.rst`). Prioritize code and test changes only.
+- Always ask for explicit approval before running any tests (`dotnet test`, integration tests, test scripts, coverage test runs, or equivalent).
 - Create a single, well-organized proposal or resolution document per issue, located in `Documentation/Plans/`. This folder is Git-ignored and local-only; documents are NOT uploaded to GitHub.
 - Stop deep analysis once effort/usage for a topic reaches about 60%, and keep investigation focused and efficient.
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -41,7 +41,7 @@ jobs:
     - uses: actions/checkout@v7
 
     - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         global-json-file: ./global.json
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,7 +49,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@v4.37.3
       with:
         languages: ${{ matrix.language }}
         build-mode: "manual"
@@ -77,6 +77,6 @@ jobs:
         dotnet build coverlet.slnx --configuration Debug
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@v4.37.3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -62,7 +62,7 @@ jobs:
         # build-mode:Use "auto" for automatic build detection, or "none" to skip the build step.
 
     - name: Setup dotnet using global.json
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         global-json-file: global.json
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
 
     - name: Setup .NET 9.0
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 9.0.x
 #        source-url: https://pkgs.dev.azure.com/tonerdo/coverlet/_packaging/coverlet-nightly/nuget/v3/index.json
@@ -45,7 +45,7 @@ jobs:
 #         NUGET_AUTH_TOKEN: ${{ secrets.AZURE_DEVOPS_TOKEN }}
 
     - name: Setup .NET 8.0
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 8.0.x
 #        source-url: https://pkgs.dev.azure.com/tonerdo/coverlet/_packaging/coverlet-nightly/nuget/v3/index.json
@@ -109,12 +109,12 @@ jobs:
   #           fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
 
   #       - name: Setup .NET 9.0
-  #         uses: actions/setup-dotnet@v5
+  #         uses: actions/setup-dotnet@v6
   #         with:
   #           dotnet-version: 9.0.x
 
   #       - name: Setup dotnet 8.0
-  #         uses: actions/setup-dotnet@v5
+  #         uses: actions/setup-dotnet@v6
   #         with:
   #           dotnet-version: '8.0.x'
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -156,7 +156,7 @@ jobs:
         reporttypes: HtmlInline;Cobertura;MarkdownSummaryGithub;lcov
 
     - name: Add Coverage PR Comment
-      uses: marocchino/sticky-pull-request-comment@v3.0.4
+      uses: marocchino/sticky-pull-request-comment@v3.0.5
       if: success() && matrix.os  == 'windows-latest' && github.event_name == 'pull_request'
       with:
         recreate: true

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -147,7 +147,7 @@ jobs:
     #     MSBUILDDISABLENODEREUSE: 1
 
     - name: ReportGenerator
-      uses: danielpalme/ReportGenerator-GitHub-Action@5.5.10
+      uses: danielpalme/ReportGenerator-GitHub-Action@5.5.11
       if: success() && matrix.os  == 'windows-latest'
       with:
         reports: ./artifacts/reports/**/*.cobertura.xml

--- a/.github/workflows/issue-label-close.yml
+++ b/.github/workflows/issue-label-close.yml
@@ -19,7 +19,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@v11
         with:
           exempt-issue-labels: "tracking-external-issue,Known Issue"
           days-before-issue-close: ${{ env.DAYS_BEFORE_ISSUE_CLOSE }}

--- a/Documentation/GlobalTool.md
+++ b/Documentation/GlobalTool.md
@@ -22,7 +22,7 @@ Options:
   -t, --target <target> (REQUIRED)                                           Path to the test runner application.
   -a, --targetargs <targetargs>                                              Arguments to be passed to the test runner.
   -o, --output <output>                                                      Output of the generated coverage report
-  -v, --verbosity <Detailed|Minimal|Normal|Quiet>                            Sets the verbosity level of the command. Allowed values are quiet, minimal, normal, detailed. [default: Normal]
+  -v, --verbosity <Detailed|Minimal|Normal|Quiet|Trace>                      Sets the verbosity level of the command. Allowed values are quiet, minimal, normal, detailed, trace. [default: Normal]
   -f, --format <format>                                                      Format of the generated coverage report. [default: json]
   --threshold <threshold>                                                    Exits with error if the coverage % is below value.
   --threshold-type <branch|line|method>                                      Coverage type to apply the threshold to. [default: line|branch|method]
@@ -40,6 +40,7 @@ Options:
   --does-not-return-attribute <does-not-return-attribute>                    Attributes that mark methods that do not return
   --exclude-assemblies-without-sources <exclude-assemblies-without-sources>  Specifies behavior of heuristic to ignore assemblies with missing source documents. [default: MissingAll]
   --source-mapping-file <source-mapping-file>                                Specifies the path to a SourceRootsMappings file.
+  --diag <diag>                                                              Writes detailed trace diagnostics to the specified file, regardless of --verbosity. Useful for troubleshooting CI-only failures.
   --version                                                                  Show version information
   -?, -h, --help                                                             Show help and usage information
 ```
@@ -58,6 +59,22 @@ or pass the multiple values as space separated sequence, i.e.
 ```
 
 For `--merge-with` [check the sample](Examples.md).
+
+## Troubleshooting instrumentation and coverage collection
+
+If `coverlet` runs without errors but produces an empty or unexpectedly small coverage report (for example, `coverage.json` has no modules, or all reported percentages are 0%), rerun with `trace` verbosity and write a diagnostic file for further analysis:
+
+```shell
+coverlet <ASSEMBLY> --target <TARGET> --targetargs <TARGETARGS> --verbosity trace --diag ./coverlet-trace.log
+```
+
+This surfaces actionable warnings for the most common silent-failure scenarios:
+
+* **Instrumentation failures** — a module could not be instrumented (e.g. missing/unsupported PDB, no local source documents matching `--exclude-assemblies-without-sources`, locked file, or unresolved assembly dependency). Coverlet logs a per-module reason and an aggregate warning when no modules were instrumented at all.
+* **No hits collected** — modules were instrumented but no hits were recorded (e.g. the target process exited abruptly, or instrumented code was never exercised). Coverlet logs an aggregate warning listing the number of instrumented modules with zero hits.
+* **Empty coverage result** — the generated `CoverageResult` has no modules at all. Coverlet logs a warning before the report is written, including counts of instrumented modules and modules with hits, so the report's emptiness is not silent.
+
+The `--diag <file>` option always writes these (and other verbose/trace-level) diagnostics to the specified file, independent of the console `--verbosity` setting, which is useful when only the console summary is captured by a CI system.
 
 ## Code Coverage
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.301",
+    "version": "10.0.302",
     "rollForward": "latestFeature"
   },
   "test": {

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -60,27 +60,27 @@ foreach ($fw in $frameworks) {
 
     # coverlet.MTP.tests
     dotnet build-server shutdown
-    dotnet exec "$WorkspaceRoot/artifacts/bin/coverlet.MTP.tests/$fwDir/coverlet.MTP.tests.dll" --diagnostic --diagnostic-verbosity trace --report-xunit-trx --report-xunit-trx-filename "coverlet.MTP.tests.${fwDir}.trx" --diagnostic-output-directory "$WorkspaceRoot/artifacts/log/" --diagnostic-file-prefix "coverlet.MTP.tests.${fwDir}" --results-directory "$WorkspaceRoot/artifacts/reports/" --no-progress
+    dotnet exec "$WorkspaceRoot/artifacts/bin/coverlet.MTP.tests/$fwDir/coverlet.MTP.tests.dll" --diagnostic --diagnostic-verbosity trace --report-xunit-trx --report-xunit-trx-filename "coverlet.MTP.tests.${fwDir}.trx" --diagnostic-output-directory "$WorkspaceRoot/artifacts/log/" --diagnostic-file-prefix "coverlet.MTP.tests.${fwDir}" --results-directory "$WorkspaceRoot/artifacts/reports/" --progress off
 
     # coverlet.core.tests
     dotnet build-server shutdown
-    dotnet exec "$WorkspaceRoot/artifacts/bin/coverlet.core.tests/$fwDir/coverlet.core.tests.dll" --diagnostic --diagnostic-verbosity trace --report-xunit-trx --report-xunit-trx-filename "coverlet.core.tests.${fwDir}.trx" --diagnostic-output-directory "$WorkspaceRoot/artifacts/log/" --diagnostic-file-prefix "coverlet.core.tests.${fwDir}" --results-directory "$WorkspaceRoot/artifacts/reports/" --no-progress
+    dotnet exec "$WorkspaceRoot/artifacts/bin/coverlet.core.tests/$fwDir/coverlet.core.tests.dll" --diagnostic --diagnostic-verbosity trace --report-xunit-trx --report-xunit-trx-filename "coverlet.core.tests.${fwDir}.trx" --diagnostic-output-directory "$WorkspaceRoot/artifacts/log/" --diagnostic-file-prefix "coverlet.core.tests.${fwDir}" --results-directory "$WorkspaceRoot/artifacts/reports/" --progress off
 
     # coverlet.core.coverage.tests - waits for keyboard input (strange behavior)
     # dotnet build-server shutdown
-    # dotnet exec "$WorkspaceRoot/artifacts/bin/coverlet.core.coverage.tests/$fwDir/coverlet.core.coverage.tests.dll" --diagnostic --diagnostic-verbosity trace --report-xunit-trx --report-xunit-trx-filename "coverlet.core.coverage.tests.${fwDir}.trx" --diagnostic-output-directory "$WorkspaceRoot/artifacts/log/" --diagnostic-file-prefix "coverlet.core.coverage.tests.${fwDir}" --results-directory "$WorkspaceRoot/artifacts/reports/" --no-progress
+    # dotnet exec "$WorkspaceRoot/artifacts/bin/coverlet.core.coverage.tests/$fwDir/coverlet.core.coverage.tests.dll" --diagnostic --diagnostic-verbosity trace --report-xunit-trx --report-xunit-trx-filename "coverlet.core.coverage.tests.${fwDir}.trx" --diagnostic-output-directory "$WorkspaceRoot/artifacts/log/" --diagnostic-file-prefix "coverlet.core.coverage.tests.${fwDir}" --results-directory "$WorkspaceRoot/artifacts/reports/" --progress off
 
     # coverlet.msbuild.tasks.tests
     dotnet build-server shutdown
-    dotnet exec "$WorkspaceRoot/artifacts/bin/coverlet.msbuild.tasks.tests/$fwDir/coverlet.msbuild.tasks.tests.dll" --diagnostic --diagnostic-verbosity trace --report-xunit-trx --report-xunit-trx-filename "coverlet.msbuild.tasks.tests.${fwDir}.trx" --diagnostic-output-directory "$WorkspaceRoot/artifacts/log/" --diagnostic-file-prefix "coverlet.msbuild.tasks.tests.${fwDir}" --results-directory "$WorkspaceRoot/artifacts/reports/" --no-progress
+    dotnet exec "$WorkspaceRoot/artifacts/bin/coverlet.msbuild.tasks.tests/$fwDir/coverlet.msbuild.tasks.tests.dll" --diagnostic --diagnostic-verbosity trace --report-xunit-trx --report-xunit-trx-filename "coverlet.msbuild.tasks.tests.${fwDir}.trx" --diagnostic-output-directory "$WorkspaceRoot/artifacts/log/" --diagnostic-file-prefix "coverlet.msbuild.tasks.tests.${fwDir}" --results-directory "$WorkspaceRoot/artifacts/reports/" --progress off
 
     # coverlet.integration.tests
     dotnet build-server shutdown
-    dotnet exec "$WorkspaceRoot/artifacts/bin/coverlet.integration.tests/$fwDir/coverlet.integration.tests.dll" --diagnostic --diagnostic-verbosity trace --report-xunit-trx --report-xunit-trx-filename "coverlet.integration.MTP.tests.${fwDir}.trx" --diagnostic-output-directory "$WorkspaceRoot/artifacts/log/" --diagnostic-file-prefix "coverlet.integration.MTP.tests.${fwDir}" --results-directory "$WorkspaceRoot/artifacts/reports/" --no-progress
+    dotnet exec "$WorkspaceRoot/artifacts/bin/coverlet.integration.tests/$fwDir/coverlet.integration.tests.dll" --diagnostic --diagnostic-verbosity trace --report-xunit-trx --report-xunit-trx-filename "coverlet.integration.MTP.tests.${fwDir}.trx" --diagnostic-output-directory "$WorkspaceRoot/artifacts/log/" --diagnostic-file-prefix "coverlet.integration.MTP.tests.${fwDir}" --results-directory "$WorkspaceRoot/artifacts/reports/" --progress off
 
     # coverlet.MTP.validation.tests
     dotnet build-server shutdown
-    dotnet exec "$WorkspaceRoot/artifacts/bin/coverlet.MTP.validation.tests/$fwDir/coverlet.MTP.validation.tests.dll" --diagnostic --diagnostic-verbosity trace --report-xunit-trx --report-xunit-trx-filename "coverlet.MTP.validation.tests.${fwDir}.trx" --diagnostic-output-directory "$WorkspaceRoot/artifacts/log/" --diagnostic-file-prefix "coverlet.MTP.validation.tests.${fwDir}" --results-directory "$WorkspaceRoot/artifacts/reports/" --no-progress
+    dotnet exec "$WorkspaceRoot/artifacts/bin/coverlet.MTP.validation.tests/$fwDir/coverlet.MTP.validation.tests.dll" --diagnostic --diagnostic-verbosity trace --report-xunit-trx --report-xunit-trx-filename "coverlet.MTP.validation.tests.${fwDir}.trx" --diagnostic-output-directory "$WorkspaceRoot/artifacts/log/" --diagnostic-file-prefix "coverlet.MTP.validation.tests.${fwDir}" --results-directory "$WorkspaceRoot/artifacts/reports/" --progress off
 }
 
  # --- Legacy tests (net8.0, net9.0) using the legacy global.json (SDK 9.0.x) ---

--- a/src/coverlet.console/Logging/ConsoleLogger.cs
+++ b/src/coverlet.console/Logging/ConsoleLogger.cs
@@ -16,13 +16,15 @@ namespace Coverlet.Console.Logging
     public LogLevel Level { get; set; } = LogLevel.Normal;
 
     /// <summary>
-    /// Enables writing all trace-level diagnostics to the specified file, regardless of the
-    /// configured console <see cref="Level"/>. Intended for CI troubleshooting (e.g. --diag).
+    /// Enables writing diagnostics to the specified file. All log messages (including trace-level
+    /// messages that may be suppressed from the console by <see cref="Level"/>) are written to the file.
+    /// Intended for CI troubleshooting (e.g. --diag).
     /// </summary>
     public void EnableDiagnosticFile(string path)
     {
       ArgumentNullException.ThrowIfNull(path);
 
+      StreamWriter newWriter = null;
       try
       {
         string directory = Path.GetDirectoryName(Path.GetFullPath(path));
@@ -31,11 +33,22 @@ namespace Coverlet.Console.Logging
           Directory.CreateDirectory(directory);
         }
 
-        _diagWriter = new StreamWriter(path, append: false) { AutoFlush = true };
+        newWriter = new StreamWriter(path, append: false) { AutoFlush = true };
+
+        lock (s_sync)
+        {
+          _diagWriter?.Dispose();
+          _diagWriter = newWriter;
+        }
       }
       catch (Exception ex)
       {
-        _diagWriter = null;
+        newWriter?.Dispose();
+        lock (s_sync)
+        {
+          _diagWriter = null;
+        }
+
         LogWarning($"Unable to create diagnostic file '{path}': {ex.Message}");
       }
     }

--- a/src/coverlet.console/Logging/ConsoleLogger.cs
+++ b/src/coverlet.console/Logging/ConsoleLogger.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.IO;
 using Coverlet.Core.Abstractions;
 using static System.Console;
 
@@ -10,8 +11,34 @@ namespace Coverlet.Console.Logging
   class ConsoleLogger : ILogger
   {
     private static readonly object s_sync = new();
+    private StreamWriter _diagWriter;
 
     public LogLevel Level { get; set; } = LogLevel.Normal;
+
+    /// <summary>
+    /// Enables writing all trace-level diagnostics to the specified file, regardless of the
+    /// configured console <see cref="Level"/>. Intended for CI troubleshooting (e.g. --diag).
+    /// </summary>
+    public void EnableDiagnosticFile(string path)
+    {
+      ArgumentNullException.ThrowIfNull(path);
+
+      try
+      {
+        string directory = Path.GetDirectoryName(Path.GetFullPath(path));
+        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+        {
+          Directory.CreateDirectory(directory);
+        }
+
+        _diagWriter = new StreamWriter(path, append: false) { AutoFlush = true };
+      }
+      catch (Exception ex)
+      {
+        _diagWriter = null;
+        LogWarning($"Unable to create diagnostic file '{path}': {ex.Message}");
+      }
+    }
 
     public void LogError(string message) => Log(LogLevel.Quiet, message, ConsoleColor.Red);
 
@@ -21,10 +48,18 @@ namespace Coverlet.Console.Logging
 
     public void LogVerbose(string message) => Log(LogLevel.Detailed, message, ForegroundColor);
 
+    /// <summary>
+    /// Logs a trace-level diagnostic message. Only written to the console when verbosity is set to
+    /// <see cref="LogLevel.Trace"/>, but always written to the diagnostic file when one is configured.
+    /// </summary>
+    public void LogTrace(string message) => Log(LogLevel.Trace, message, ForegroundColor);
+
     public void LogWarning(string message) => Log(LogLevel.Quiet, message, ConsoleColor.Yellow);
 
     private void Log(LogLevel level, string message, ConsoleColor color)
     {
+      WriteToDiagnosticFile(level, message);
+
       if (level < Level) return;
 
       lock (s_sync)
@@ -40,6 +75,19 @@ namespace Coverlet.Console.Logging
         {
           WriteLine(message);
         }
+      }
+    }
+
+    private void WriteToDiagnosticFile(LogLevel level, string message)
+    {
+      if (_diagWriter is null)
+      {
+        return;
+      }
+
+      lock (s_sync)
+      {
+        _diagWriter.WriteLine($"[{DateTime.UtcNow:O}] [{level}] {message}");
       }
     }
   }

--- a/src/coverlet.console/Logging/ConsoleLogger.cs
+++ b/src/coverlet.console/Logging/ConsoleLogger.cs
@@ -100,7 +100,14 @@ namespace Coverlet.Console.Logging
 
       lock (s_sync)
       {
-        _diagWriter.WriteLine($"[{DateTime.UtcNow:O}] [{level}] {message}");
+        try
+        {
+          _diagWriter.WriteLine($"[{DateTime.UtcNow:O}] [{level}] {message}");
+        }
+        catch
+        {
+          _diagWriter = null;
+        }
       }
     }
   }

--- a/src/coverlet.console/Logging/LogLevel.cs
+++ b/src/coverlet.console/Logging/LogLevel.cs
@@ -9,6 +9,13 @@ namespace Coverlet.Console.Logging
   enum LogLevel
   {
     /// <summary>
+    /// Most verbose logging level. Used for troubleshooting instrumentation and coverage-collection
+    /// issues (e.g. skipped modules, missing hits, empty coverage results). Intended for diagnostic
+    /// scenarios such as CI failures that cannot be reproduced locally.
+    /// </summary>
+    Trace = -1,
+
+    /// <summary>
     /// Logs that track the general flow of the application. These logs should have long-term value.
     /// </summary>
     Detailed = 0,

--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -30,7 +30,7 @@ namespace Coverlet.Console
       Option<string> target = new("--target", "-t") { Description = "Path to the test runner application.", Arity = ArgumentArity.ZeroOrOne, Required = true };
       Option<string> targs = new("--targetargs", "-a") { Description = "Arguments to be passed to the test runner.", Arity = ArgumentArity.ZeroOrOne };
       Option<string> output = new("--output", "-o") { Description = "Output of the generated coverage report", Arity = ArgumentArity.ZeroOrOne };
-      Option<LogLevel> verbosity = new("--verbosity", "-v") { DefaultValueFactory = (_) => LogLevel.Normal, Description = "Sets the verbosity level of the command. Allowed values are quiet, minimal, normal, detailed.", Arity = ArgumentArity.ZeroOrOne };
+      Option<LogLevel> verbosity = new("--verbosity", "-v") { DefaultValueFactory = (_) => LogLevel.Normal, Description = "Sets the verbosity level of the command. Allowed values are quiet, minimal, normal, detailed, trace.", Arity = ArgumentArity.ZeroOrOne };
       Option<string[]> formats = new("--format", "-f") { DefaultValueFactory = (_) => new[] { "json" }, Description = "Format of the generated coverage report.", Arity = ArgumentArity.ZeroOrMore, AllowMultipleArgumentsPerToken = true };
       formats.AcceptOnlyFromAmong("json", "lcov", "opencover", "cobertura", "teamcity");
       Option<string> threshold = new("--threshold") { Description = "Exits with error if the coverage % is below value.", Arity = ArgumentArity.ZeroOrOne };
@@ -51,6 +51,7 @@ namespace Coverlet.Console
       Option<string> excludeAssembliesWithoutSources = new("--exclude-assemblies-without-sources") { DefaultValueFactory = (_) => "MissingAll", Description = "Specifies behavior of heuristic to ignore assemblies with missing source documents." };
       excludeAssembliesWithoutSources.AcceptOnlyFromAmong("MissingAll", "MissingAny", "None");
       Option<string> sourceMappingFile = new("--source-mapping-file") { Description = "Specifies the path to a SourceRootsMappings file.", Arity = ArgumentArity.ZeroOrOne };
+      Option<string> diagFile = new("--diag") { Description = "Writes detailed trace diagnostics to the specified file, regardless of --verbosity. Useful for troubleshooting CI-only failures (e.g. instrumentation failures, missing hits, empty coverage results).", Arity = ArgumentArity.ZeroOrOne };
 
       RootCommand rootCommand = new("Cross platform .NET Core code coverage tool");
       rootCommand.Arguments.Add(moduleOrAppDirectory);
@@ -75,6 +76,7 @@ namespace Coverlet.Console
       rootCommand.Options.Add(doesNotReturnAttributes);
       rootCommand.Options.Add(excludeAssembliesWithoutSources);
       rootCommand.Options.Add(sourceMappingFile);
+      rootCommand.Options.Add(diagFile);
 
       rootCommand.SetAction(async (parseResult) =>
       {
@@ -100,6 +102,7 @@ namespace Coverlet.Console
         string[] doesNotReturnAttributesValue = parseResult.GetValue(doesNotReturnAttributes);
         string excludeAssembliesWithoutSourcesValue = parseResult.GetValue(excludeAssembliesWithoutSources);
         string sourceMappingFileValue = parseResult.GetValue(sourceMappingFile);
+        string diagFileValue = parseResult.GetValue(diagFile);
 
         if (string.IsNullOrEmpty(moduleOrAppDirectoryValue) || string.IsNullOrWhiteSpace(moduleOrAppDirectoryValue))
           throw new ArgumentException("No test assembly or application directory specified.");
@@ -125,7 +128,8 @@ namespace Coverlet.Console
                       useSourceLinkValue,
                       doesNotReturnAttributesValue,
                       excludeAssembliesWithoutSourcesValue,
-                      sourceMappingFileValue);
+                      sourceMappingFileValue,
+                      diagFileValue);
 
         s_exitCode = taskStatus;
         return taskStatus;
@@ -156,7 +160,8 @@ namespace Coverlet.Console
                                                            bool useSourceLink,
                                                            string[] doesNotReturnAttributes,
                                                            string excludeAssembliesWithoutSources,
-                                                           string sourceMappingFile
+                                                           string sourceMappingFile,
+                                                           string diagFile
              )
     {
 
@@ -177,6 +182,10 @@ namespace Coverlet.Console
 
       // Adjust log level based on user input.
       logger.Level = verbosity;
+      if (!string.IsNullOrWhiteSpace(diagFile))
+      {
+        logger.EnableDiagnosticFile(diagFile);
+      }
       s_exitCode = (int)CommandExitCodes.Success;
 
       try

--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -142,7 +142,7 @@ namespace Coverlet.Core
         if (!instrumenter.CanInstrument(out string canInstrumentReason))
         {
           skippedByCanInstrument++;
-          _logger.LogWarning($"Skipping module '{module}': not eligible for instrumentation. {canInstrumentReason}");
+          _logger.LogVerbose($"Skipping module '{module}': not eligible for instrumentation. {canInstrumentReason}");
           continue;
         }
 

--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -60,6 +60,7 @@ namespace Coverlet.Core
     private readonly ICecilSymbolHelper _cecilSymbolHelper;
     private readonly List<InstrumenterResult> _results;
     private readonly CoverageParameters _parameters;
+    private int _modulesWithHits;
 
     public string Identifier { get; }
 
@@ -123,6 +124,10 @@ namespace Coverlet.Core
         _logger.LogVerbose($"Excluded module: '{excludedModule}'");
       }
 
+      int skippedByCanInstrument = 0;
+      int skippedByPreflight = 0;
+      int instrumentationExceptions = 0;
+
       foreach (string module in validModules)
       {
         var instrumenter = new Instrumenter(module,
@@ -134,14 +139,17 @@ namespace Coverlet.Core
                                             _sourceRootTranslator,
                                             _cecilSymbolHelper);
 
-        if (!instrumenter.CanInstrument())
+        if (!instrumenter.CanInstrument(out string canInstrumentReason))
         {
+          skippedByCanInstrument++;
+          _logger.LogWarning($"Skipping module '{module}': not eligible for instrumentation. {canInstrumentReason}");
           continue;
         }
 
         InstrumentationPreflightResult preflightResult = instrumenter.Preflight();
         if (preflightResult.Status != InstrumentationPreflightStatus.Ready)
         {
+          skippedByPreflight++;
           _logger.LogWarning($"Skipping module '{module}': {preflightResult.Status}. {preflightResult.Reason}");
           continue;
         }
@@ -160,9 +168,19 @@ namespace Coverlet.Core
         }
         catch (Exception ex)
         {
+          instrumentationExceptions++;
           _logger.LogWarning($"Unable to instrument module: {module}\n{ex}");
           _instrumentationHelper.RestoreOriginalModule(module, Identifier);
         }
+      }
+
+      if (validModules.Count > 0 && _results.Count == 0)
+      {
+        _logger.LogWarning(
+            $"No modules were instrumented. Selected: {validModules.Count}, Instrumented: 0 " +
+            $"(skipped - not eligible: {skippedByCanInstrument}, preflight: {skippedByPreflight}, exceptions: {instrumentationExceptions}). " +
+            "Most common causes: missing PDB/local sources, unresolved dependencies, or locked files. " +
+            "Run with higher verbosity for details.");
       }
 
       return new CoveragePrepareResult()
@@ -340,6 +358,15 @@ namespace Coverlet.Core
         }
       }
 
+      if (coverageResult.Modules is null || coverageResult.Modules.Count == 0)
+      {
+        _logger.LogWarning(
+            $"Coverage result has no modules. Instrumented modules: {_results.Count}; modules with hits: {_modulesWithHits}. " +
+            "The generated report will be empty. This can happen if no modules were instrumented, " +
+            "the target process exited abruptly, or no instrumented code was exercised. " +
+            "Run with higher verbosity for details.");
+      }
+
       return coverageResult;
     }
 
@@ -380,8 +407,10 @@ namespace Coverlet.Core
 
     private void CalculateCoverage()
     {
+      _modulesWithHits = 0;
       foreach (InstrumenterResult result in _results)
       {
+        bool moduleHasNonZeroHits = false;
         var documents = result.Documents.Values.ToList();
         if (_parameters.UseSourceLink && result.SourceLink != null)
         {
@@ -464,6 +493,7 @@ namespace Coverlet.Core
               if (hits == 0)
                 continue;
 
+              moduleHasNonZeroHits = true;
               hits = hits < 0 ? int.MaxValue : hits;
 
               if (hitLocation.isBranch)
@@ -494,6 +524,11 @@ namespace Coverlet.Core
           }
         } // shared lock released here; safe to delete the lock file below
 
+        if (moduleHasNonZeroHits)
+        {
+          _modulesWithHits++;
+        }
+
         try
         {
           _instrumentationHelper.DeleteHitsFile(result.HitsFilePath);
@@ -506,6 +541,14 @@ namespace Coverlet.Core
 
         TryDeleteFile(tmpFilePath);
         TryDeleteFile(lockFilePath);
+      }
+
+      if (_results.Count > 0 && _modulesWithHits == 0)
+      {
+        _logger.LogWarning(
+            $"No coverage hits were collected from any of the {_results.Count} instrumented module(s). " +
+            "This can happen if the target process exits abruptly, instrumented code was not exercised, " +
+            "or hit files were not flushed. Run with higher verbosity for details.");
       }
     }
 

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -215,8 +215,8 @@ namespace Coverlet.Core.Instrumentation
       }
       catch (Exception ex)
       {
-        reason = $"Exception while probing module for instrumentation eligibility: {ex.Message}";
-        _logger.LogWarning($"Unable to instrument module: '{_module}'\n{ex}");
+        reason = $"Exception while probing module for instrumentation eligibility: {ex.GetType().Name}: {ex.Message}";
+        _logger.LogWarning($"Unable to probe module for instrumentation eligibility: '{_module}'\n{ex}");
         return false;
       }
     }

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -176,8 +176,16 @@ namespace Coverlet.Core.Instrumentation
       return true;
     }
 
-    public bool CanInstrument()
+    public bool CanInstrument() => CanInstrument(out _);
+
+    /// <summary>
+    /// Determines whether the module is eligible for instrumentation and, when not, exposes a
+    /// human-readable reason (e.g. missing PDB, no local sources, probing exception). Used to give
+    /// actionable diagnostics for silently-skipped modules.
+    /// </summary>
+    public bool CanInstrument(out string reason)
     {
+      reason = string.Empty;
       try
       {
         if (_instrumentationHelper.HasPdb(_module, out bool embeddedPdb))
@@ -187,22 +195,27 @@ namespace Coverlet.Core.Instrumentation
             return true;
           }
 
-          if (embeddedPdb)
+          bool hasLocalSource = embeddedPdb
+              ? _instrumentationHelper.EmbeddedPortablePdbHasLocalSource(_module, _excludeAssembliesWithoutSources)
+              : _instrumentationHelper.PortablePdbHasLocalSource(_module, _excludeAssembliesWithoutSources);
+
+          if (!hasLocalSource)
           {
-            return _instrumentationHelper.EmbeddedPortablePdbHasLocalSource(_module, _excludeAssembliesWithoutSources);
+            reason = $"Module has no local source documents matching heuristic '{_excludeAssembliesWithoutSources}' " +
+                     $"({(embeddedPdb ? "embedded" : "portable")} PDB).";
           }
-          else
-          {
-            return _instrumentationHelper.PortablePdbHasLocalSource(_module, _excludeAssembliesWithoutSources);
-          }
+
+          return hasLocalSource;
         }
         else
         {
+          reason = "Module has no PDB (or an unsupported PDB format) and cannot be instrumented.";
           return false;
         }
       }
       catch (Exception ex)
       {
+        reason = $"Exception while probing module for instrumentation eligibility: {ex.Message}";
         _logger.LogWarning($"Unable to instrument module: '{_module}'\n{ex}");
         return false;
       }


### PR DESCRIPTION
### Summary

This PR improves troubleshooting in coverlet.console when coverage output is empty or unexpectedly 0% (especially in CI-only repros).
It adds:

•	Trace verbosity support.
•	--diag <path> option to write detailed diagnostics to file.
•	Better warning/error reporting across:
1.	instrumentation eligibility/failures,
2.	no-hit scenarios,
3.	empty coverage result scenarios.
 
### Problem

coverlet.console can complete successfully while producing an empty coverage report (no modules) or all-zero results, with limited diagnostics.
In CI, this is hard to root-cause because skipped instrumentation and missing-hit conditions are not summarized clearly.
 
### Changes

1) coverlet.console trace diagnostics
•	Extended LogLevel with Trace.
•	Updated CLI verbosity help to include trace.
•	Added --diag <path> option in Program:
•	writes timestamped diagnostics to file,
•	useful for CI artifact collection,
•	does not break normal console behavior.

2) Console logger enhancements
•	Added diagnostic file sink support (EnableDiagnosticFile).
•	Added trace logging method usage path (file + console depending on level).
•	Preserved existing thread-safe console output behavior.

3) Instrumentation diagnostics improvements (coverlet.core)
•	Added reason-aware CanInstrument(out string reason) overload in Instrumenter.
•	Coverage.PrepareModules() now logs explicit skip reasons and aggregates:
•	skipped not eligible,
•	skipped preflight,
•	instrumentation exceptions.
•	Added warning when selected modules exist but none are instrumented.

4) Hit collection and empty-result diagnostics
•	Coverage.CalculateCoverage() now tracks modules with non-zero hits.
•	Added warning when instrumented modules exist but no hits are collected.
•	Coverage.GetCoverageResult() now warns when final CoverageResult.Modules is empty and includes context counts.

5) Documentation update
•	Updated Documentation/GlobalTool.md:
•	Trace verbosity listed in options.
•	--diag option documented.
•	Added troubleshooting guidance for:
•	instrumentation failures,
•	no-hit runs,
•	empty coverage result output.
 
### Why this helps

With this PR, CI logs (and optional diag artifacts) provide direct guidance instead of silent/ambiguous 0% output.
This reduces time-to-diagnose for environment-specific instrumentation and coverage collection issues.
 
### Backward Compatibility

•	Default behavior remains unchanged.
•	Existing command lines continue to work.
•	New diagnostics are additive.
•	No breaking exit-code changes introduced.

### Example usage

```shell
coverlet "<test_bin_dir>" `
  --target "dotnet" `
  --targetargs "<test_dll_path>" `
  --output "<results>\coverage.coverlet-console.json" `
  --verbosity trace `
  --diag "<results>\coverlet.console.trace.log"
```
