### PR TITLE
Improve log formatting for multi-line messages in console

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Implement dynamic exclusion filters for assemblies (Coverlet.MTP) [#1946](https://github.com/coverlet-coverage/coverlet/pull/1946)
 - Replace legacy .sln files with modern .slnx format [#1966](https://github.com/coverlet-coverage/coverlet/pull/1966)
+- coverlet.console: add trace diagnostics and actionable warnings for instrumentation/hit/empty-result failures [#2005](https://github.com/coverlet-coverage/coverlet/pull/2005)
 
 ### Fixed
 

--- a/src/coverlet.console/Logging/ConsoleLogger.cs
+++ b/src/coverlet.console/Logging/ConsoleLogger.cs
@@ -102,7 +102,14 @@ namespace Coverlet.Console.Logging
       {
         try
         {
-          _diagWriter.WriteLine($"[{DateTime.UtcNow:O}] [{level}] {message}");
+          // Multiline messages (e.g. coverage summary table): write the timestamp header on its
+          // own line so the table body starts on the next line and renders cleanly in the file.
+          string header = $"[{DateTime.UtcNow:O}] [{level}]";
+          string entry = message.Contains('\n')
+              ? $"{header} \n{message}"
+              : $"{header} {message}";
+
+          _diagWriter.WriteLine(entry);
         }
         catch
         {

--- a/src/coverlet.console/Logging/ConsoleLogger.cs
+++ b/src/coverlet.console/Logging/ConsoleLogger.cs
@@ -106,7 +106,7 @@ namespace Coverlet.Console.Logging
           // own line so the table body starts on the next line and renders cleanly in the file.
           string header = $"[{DateTime.UtcNow:O}] [{level}]";
           string entry = message.Contains('\n')
-              ? $"{header} \n{message}"
+              ? $"{header}{Environment.NewLine}{message}"
               : $"{header} {message}";
 
           _diagWriter.WriteLine(entry);


### PR DESCRIPTION
- Update changelog for `coverlet.console` to note new trace diagnostics and actionable warnings for instrumentation, hit, and empty-result failures (PR #2005).
- Refine `ConsoleLogger.cs` so that when logging multi-line messages (e.g., coverage tables), the timestamp and log level header are written on a separate line from the message body, ensuring clean rendering of tables and summaries in log files.