### PR TITLE
Throw if resourceStream is null (guarding resourceStream)

### DIFF
--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -589,6 +589,12 @@ namespace Coverlet.Core.Instrumentation
       }
 
       using Stream resourceStream = coreAssembly.GetManifestResourceStream(resourceName);
+      if (resourceStream is null)
+      {
+        throw new InvalidOperationException(
+            $"Embedded tracker template stream '{resourceName}' was not found in '{coreAssembly.FullName}'. " +
+            "This assembly is required to inject .NET Framework-safe coverage tracking code.");
+      }
       // Cecil needs a seekable stream that stays readable for the duration of the copy; use memory.
       var templateStream = new MemoryStream();
       resourceStream.CopyTo(templateStream);


### PR DESCRIPTION
GetManifestResourceStream(...) can still return null even when a matching resource name was found. The current code will throw a NullReferenceException at resourceStream.CopyTo(...), which makes the failure mode much less actionable than the earlier resourceName check. Consider guarding resourceStream and throwing a clear InvalidOperationException if it’s unexpectedly null (and optionally make resourceName nullable to avoid nullable warnings when enabled).
