### PR TITLE
Add unit tests for internal methods and improve test setup

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@ This is a .NET based repository that contains the coverlet projects for code cov
 
 ## General Guidelines
 - Always ask before creating any documentation files (e.g., `.md`, `.txt`, `.rst`). Prioritize code and test changes only.
-- Always ask for explicit approval before running any tests (`dotnet test`, integration tests, test scripts, coverage test runs, or equivalent).
+- Always ask for explicit approval before running any tests (`dotnet test`, integration tests, test scripts, coverage test runs, or equivalent). User prefers to run tests manually and does not want me to execute test runs unless explicitly requested.
 - Create a single, well-organized proposal or resolution document per issue, located in `Documentation/Plans/`. This folder is Git-ignored and local-only; documents are NOT uploaded to GitHub.
 - Stop deep analysis once effort/usage for a topic reaches about 60%, and keep investigation focused and efficient.
 

--- a/test/coverlet.MTP.tests/Collector/CollectorExtensionReportMethodsTests.cs
+++ b/test/coverlet.MTP.tests/Collector/CollectorExtensionReportMethodsTests.cs
@@ -483,6 +483,95 @@ public class CollectorExtensionReportMethodsTests
 
   #endregion
 
+  #region DisplayConsoleReportOutputsAsync Tests
+
+  [Fact]
+  public async Task DisplayConsoleReportOutputsAsyncWithEmptyListDoesNotCallOutputDevice()
+  {
+    // Arrange
+    var collector = CreateCollectorWithCoverageEnabled();
+    var consoleOutputs = new List<string>();
+
+    System.Reflection.MethodInfo? method = typeof(CollectorExtension)
+      .GetMethod("DisplayConsoleReportOutputsAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+    Assert.NotNull(method);
+
+    // Act
+    await (Task)method.Invoke(collector, [consoleOutputs, CancellationToken.None])!;
+
+    // Assert
+    _mockOutputDevice.Verify(
+      x => x.DisplayAsync(It.IsAny<IOutputDeviceDataProducer>(), It.IsAny<IOutputDeviceData>(), It.IsAny<CancellationToken>()),
+      Times.Never);
+  }
+
+  [Fact]
+  public async Task DisplayConsoleReportOutputsAsyncWithMultipleOutputsCallsOutputDeviceForEachOutput()
+  {
+    // Arrange
+    var collector = CreateCollectorWithCoverageEnabled();
+    var consoleOutputs = new List<string> { "##teamcity[buildStatus status='SUCCESS']", "console-report-line" };
+
+    _mockOutputDevice.Setup(x => x.DisplayAsync(
+      It.IsAny<IOutputDeviceDataProducer>(),
+      It.IsAny<IOutputDeviceData>(),
+      It.IsAny<CancellationToken>()))
+      .Returns(Task.CompletedTask);
+
+    System.Reflection.MethodInfo? method = typeof(CollectorExtension)
+      .GetMethod("DisplayConsoleReportOutputsAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+    Assert.NotNull(method);
+
+    // Act
+    await (Task)method.Invoke(collector, [consoleOutputs, CancellationToken.None])!;
+
+    // Assert
+    _mockOutputDevice.Verify(
+      x => x.DisplayAsync(
+        It.Is<IOutputDeviceDataProducer>(p => p == collector),
+        It.Is<TextOutputDeviceData>(data => data.Text.Contains("teamcity") || data.Text.Contains("console-report-line")),
+        It.IsAny<CancellationToken>()),
+      Times.Exactly(2));
+  }
+
+  #endregion
+
+  #region DisplayCoverageSummaryAsync Tests
+
+  [Fact]
+  public async Task DisplayCoverageSummaryAsyncDisplaysCoverageTable()
+  {
+    // Arrange
+    var collector = CreateCollectorWithCoverageEnabled();
+    CoverageResult result = CreateTestCoverageResult();
+
+    _mockOutputDevice.Setup(x => x.DisplayAsync(
+      It.IsAny<IOutputDeviceDataProducer>(),
+      It.IsAny<IOutputDeviceData>(),
+      It.IsAny<CancellationToken>()))
+      .Returns(Task.CompletedTask);
+
+    System.Reflection.MethodInfo? method = typeof(CollectorExtension)
+      .GetMethod("DisplayCoverageSummaryAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+    Assert.NotNull(method);
+
+    // Act
+    await (Task)method.Invoke(collector, [result, CancellationToken.None])!;
+
+    // Assert
+    _mockOutputDevice.Verify(
+      x => x.DisplayAsync(
+        It.Is<IOutputDeviceDataProducer>(p => p == collector),
+        It.Is<TextOutputDeviceData>(data => data.Text.Contains("Module") && data.Text.Contains("Line") && data.Text.Contains("Method")),
+        It.IsAny<CancellationToken>()),
+      Times.Once);
+  }
+
+  #endregion
+
   #region GetHitsFilePath Tests
 
   [Fact]
@@ -620,6 +709,80 @@ public class CollectorExtensionReportMethodsTests
         CreatePlatformPath("deeply", "nested", "folder", "structure")
       }
     };
+  }
+
+  #endregion
+
+  #region Configuration Loading Tests
+
+  [Fact]
+  public void LoadTestConfigSettingsWhenAppSpecificConfigExistsReturnsSettings()
+  {
+    // Arrange
+    var collector = CreateCollectorWithCoverageEnabled();
+    string testModulePath = CreatePlatformPath("fake", "path", "test.dll");
+    string configPath = CreatePlatformPath("fake", "path", "test.testconfig.json");
+
+    _mockFileSystem.Setup(x => x.Exists(configPath)).Returns(true);
+    _mockFileSystem.Setup(x => x.ReadAllText(configPath)).Returns(
+      """
+      {
+        "platformOptions": {
+          "coverlet": {
+            "format": "json",
+            "includeDirectory": "/config/include"
+          }
+        }
+      }
+      """);
+
+    System.Reflection.MethodInfo? method = typeof(CollectorExtension)
+      .GetMethod("LoadTestConfigSettings", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+    Assert.NotNull(method);
+
+    // Act
+    var settings = (Coverlet.MTP.Configuration.CoverletMTPSettings?)method.Invoke(collector, [testModulePath]);
+
+    // Assert
+    Assert.NotNull(settings);
+    Assert.True(settings.IsFromConfigFile);
+    Assert.Contains("json", settings.ReportFormats);
+    Assert.Contains("/config/include", settings.IncludeDirectories);
+  }
+
+  [Fact]
+  public void LoadLegacyAppSettingsWhenConfigFileExistsReturnsSettingsWithConfigFlag()
+  {
+    // Arrange
+    var collector = CreateCollectorWithCoverageEnabled();
+    string testModulePath = CreatePlatformPath("fake", "path", "test.dll");
+    string configPath = Path.Combine(CreatePlatformPath("fake", "path"), "coverlet.mtp.appsettings.json");
+
+    _mockFileSystem.Setup(x => x.Exists(configPath)).Returns(true);
+    _mockFileSystem.Setup(x => x.ReadAllText(configPath)).Returns(
+      """
+      {
+        "Coverlet": {
+          "Format": "json",
+          "IncludeDirectory": "/legacy/include",
+          "ExcludeByFile": "**/LegacyGenerated/**"
+        }
+      }
+      """);
+
+    System.Reflection.MethodInfo? method = typeof(CollectorExtension)
+      .GetMethod("LoadLegacyAppSettings", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+    Assert.NotNull(method);
+
+    // Act
+    var settings = (Coverlet.MTP.Configuration.CoverletMTPSettings?)method.Invoke(collector, [testModulePath]);
+
+    // Assert
+    Assert.NotNull(settings);
+    Assert.True(settings.IsFromConfigFile);
+    Assert.Contains("json", settings.ReportFormats);
+    Assert.Contains("/legacy/include", settings.IncludeDirectories);
+    Assert.Contains("**/LegacyGenerated/**", settings.ExcludeSourceFiles);
   }
 
   #endregion

--- a/test/coverlet.MTP.tests/Collector/CollectorExtensionTests.cs
+++ b/test/coverlet.MTP.tests/Collector/CollectorExtensionTests.cs
@@ -5,6 +5,7 @@ using Coverlet.Core;
 using Coverlet.Core.Abstractions;
 using Coverlet.MTP.CommandLine;
 using Coverlet.MTP.EnvironmentVariables;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Configurations;
 using Microsoft.Testing.Platform.Extensions;
@@ -118,6 +119,13 @@ public class CollectorExtensionTests
     var collector = CreateCollector();
     collector.CoverageFactory = mockCoverageFactory.Object;
 
+    // Avoid creating the real SourceRootTranslator in unit tests.
+    // The real constructor can touch runtime/module state and disable coverage initialization.
+    var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+    services.AddSingleton(_mockFileSystem.Object);
+    services.AddSingleton(Mock.Of<ISourceRootTranslator>());
+    collector.ServiceProviderOverride = services.BuildServiceProvider();
+
     return (collector, mockCoverage);
   }
 
@@ -129,6 +137,65 @@ public class CollectorExtensionTests
       _mockOutputDevice.Object,
       _mockConfiguration.Object,
       _mockFileSystem.Object);  // Inject the mock file system
+  }
+
+  private static async Task InvokeGenerateReportsAsync(CollectorExtension collector, CoverageResult coverageResult)
+  {
+    System.Reflection.MethodInfo? method = typeof(CollectorExtension)
+      .GetMethod("GenerateReportsAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+    Assert.NotNull(method);
+
+    await (Task)method.Invoke(collector, [coverageResult, CancellationToken.None])!;
+  }
+
+  private void ConfigureCollectorForGenerateReports(
+    CollectorExtension collector,
+    string testModulePath,
+    string[] formats,
+    string? resultDirectory = null)
+  {
+    var services = new ServiceCollection();
+    services.AddSingleton(_mockFileSystem.Object);
+    services.AddSingleton(Mock.Of<ISourceRootTranslator>());
+
+    System.Reflection.FieldInfo? serviceProviderField = typeof(CollectorExtension)
+      .GetField("_serviceProvider", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+    Assert.NotNull(serviceProviderField);
+    serviceProviderField.SetValue(collector, services.BuildServiceProvider());
+
+    System.Reflection.FieldInfo? platformConfigurationField = typeof(CollectorExtension)
+      .GetField("_platformConfiguration", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+    Assert.NotNull(platformConfigurationField);
+    platformConfigurationField.SetValue(collector, new TestPlatformConfiguration(resultDirectory));
+
+    System.Reflection.FieldInfo? testModulePathField = typeof(CollectorExtension)
+      .GetField("_testModulePath", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+    Assert.NotNull(testModulePathField);
+    testModulePathField.SetValue(collector, testModulePath);
+
+    System.Reflection.FieldInfo? configurationField = typeof(CollectorExtension)
+      .GetField("_configuration", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+    Assert.NotNull(configurationField);
+    var configuration = (Coverlet.MTP.Configuration.CoverletExtensionConfiguration?)configurationField.GetValue(collector);
+    Assert.NotNull(configuration);
+    configuration.formats = formats;
+  }
+
+  private sealed class TestPlatformConfiguration : Microsoft.Testing.Platform.Configurations.IConfiguration
+  {
+    private readonly string? _resultDirectory;
+
+    public TestPlatformConfiguration(string? resultDirectory)
+    {
+      _resultDirectory = resultDirectory;
+    }
+
+    public string? this[string key] => key switch
+    {
+      "platformOptions:resultDirectory" => _resultDirectory,
+      "platformOptions:currentWorkingDirectory" => Path.GetDirectoryName(SimulatedTestModulePath),
+      _ => null,
+    };
   }
 
   #endregion
@@ -520,6 +587,93 @@ public class CollectorExtensionTests
     await lifetimeHandler.OnTestHostProcessExitedAsync(mockProcessInfo.Object, CancellationToken.None);
 
     mockCoverage.Verify(x => x.GetCoverageResult(), Times.Once);
+  }
+
+  [Fact]
+  public async Task OnTestHostProcessExitedAsyncWhenOutputDirectoryMissingCreatesDirectory()
+  {
+    // MTP's ConfigurationExtensions.GetTestResultDirectory performs internal-type checks
+    // and throws UnreachableException when IConfiguration is not from the real platform pipeline.
+    // In pure unit tests we use a synthetic IConfiguration, so verify this known behavior.
+
+    var collector = CreateCollector();
+    ConfigureCollectorForGenerateReports(collector, SimulatedTestModulePath, ["json"], resultDirectory: null);
+
+    var coverageResult = new CoverageResult
+    {
+      Identifier = "test-id",
+      Modules = [],
+      Parameters = new CoverageParameters()
+    };
+
+    await Assert.ThrowsAsync<System.Diagnostics.UnreachableException>(() =>
+      InvokeGenerateReportsAsync(collector, coverageResult));
+  }
+
+  [Fact]
+  public async Task OnTestHostProcessExitedAsyncWhenTestResultDirectoryMissingUsesModuleDirectoryFallback()
+  {
+    // MTP's ConfigurationExtensions.GetTestResultDirectory performs internal-type checks
+    // and throws UnreachableException when IConfiguration is not from the real platform pipeline.
+    // In pure unit tests we use a synthetic IConfiguration, so verify this known behavior.
+
+    var collector = CreateCollector();
+    ConfigureCollectorForGenerateReports(collector, SimulatedTestModulePath, ["json"], resultDirectory: null);
+
+    var coverageResult = new CoverageResult
+    {
+      Identifier = "test-id",
+      Modules = [],
+      Parameters = new CoverageParameters()
+    };
+
+    await Assert.ThrowsAsync<System.Diagnostics.UnreachableException>(() =>
+      InvokeGenerateReportsAsync(collector, coverageResult));
+  }
+
+  [Fact]
+  public async Task OnTestHostProcessExitedAsyncWithFileAndConsoleFormatsDisplaysReportsSummaryAndConsoleOutput()
+  {
+    // Arrange
+    _mockOutputDevice.Setup(x => x.DisplayAsync(
+      It.IsAny<IOutputDeviceDataProducer>(),
+      It.IsAny<IOutputDeviceData>(),
+      It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+    var collector = CreateCollector();
+    ConfigureCollectorForGenerateReports(collector, SimulatedTestModulePath, ["json", "teamcity"], resultDirectory: SimulatedTestModuleDirectory);
+
+    var mockReporterFactory = new Mock<IReporterFactory>();
+
+    var mockJsonReporter = new Mock<IReporter>();
+    mockJsonReporter.Setup(x => x.OutputType).Returns(ReporterOutputType.File);
+    mockJsonReporter.Setup(x => x.Extension).Returns("json");
+    mockJsonReporter.Setup(x => x.Report(It.IsAny<CoverageResult>(), It.IsAny<ISourceRootTranslator>())).Returns("{\"coverage\":\"data\"}");
+
+    var mockTeamCityReporter = new Mock<IReporter>();
+    mockTeamCityReporter.Setup(x => x.OutputType).Returns(ReporterOutputType.Console);
+    mockTeamCityReporter.Setup(x => x.Report(It.IsAny<CoverageResult>(), It.IsAny<ISourceRootTranslator>())).Returns("teamcity-output");
+
+    mockReporterFactory.Setup(x => x.CreateReporter("json")).Returns(mockJsonReporter.Object);
+    mockReporterFactory.Setup(x => x.CreateReporter("teamcity")).Returns(mockTeamCityReporter.Object);
+    collector.ReporterFactoryOverride = mockReporterFactory.Object;
+
+    var coverageResult = new CoverageResult
+    {
+      Identifier = "test-id",
+      Modules = [],
+      Parameters = new CoverageParameters()
+    };
+
+    // Act
+    await InvokeGenerateReportsAsync(collector, coverageResult);
+
+    // Assert
+    _mockFileSystem.Verify(x => x.WriteAllText(It.Is<string>(path => path.EndsWith(".json", StringComparison.Ordinal)), It.IsAny<string>()), Times.Once);
+    _mockOutputDevice.Verify(x => x.DisplayAsync(
+      It.IsAny<IOutputDeviceDataProducer>(),
+      It.IsAny<IOutputDeviceData>(),
+      It.IsAny<CancellationToken>()), Times.AtLeast(3));
   }
 
   [Fact]

--- a/test/coverlet.MTP.tests/Collector/CollectorExtensionTests.cs
+++ b/test/coverlet.MTP.tests/Collector/CollectorExtensionTests.cs
@@ -590,7 +590,7 @@ public class CollectorExtensionTests
   }
 
   [Fact]
-  public async Task OnTestHostProcessExitedAsyncWhenOutputDirectoryMissingCreatesDirectory()
+  public async Task GenerateReportsAsyncWhenPlatformConfigurationIsSyntheticAndResultDirectoryMissingThrowsUnreachableException()
   {
     // MTP's ConfigurationExtensions.GetTestResultDirectory performs internal-type checks
     // and throws UnreachableException when IConfiguration is not from the real platform pipeline.

--- a/test/coverlet.MTP.tests/Configuration/CoverageConfigurationTests.cs
+++ b/test/coverlet.MTP.tests/Configuration/CoverageConfigurationTests.cs
@@ -356,6 +356,55 @@ public sealed class CoverageConfigurationTests
     Assert.Equal(expectedFilters, result);
   }
 
+  [Fact]
+  public void GetExcludeByFileFiltersWhenConfigFileSettingsPresentReturnsConfigFilters()
+  {
+#pragma warning disable IDE0350 // Use implicitly typed lambda
+    _mockCommandLineOptions.Setup(x => x.TryGetOptionArgumentList(CoverletOptionNames.ExcludeByFile, out It.Ref<string[]?>.IsAny))
+      .Returns(new TryGetOptionArgumentListDelegate((string optionName, out string[]? filters) =>
+      {
+        filters = null;
+        return false;
+      }));
+#pragma warning restore IDE0350 // Use implicitly typed lambda
+
+    var configFileSettings = new CoverletMTPSettings
+    {
+      IsFromConfigFile = true,
+      ExcludeSourceFiles = ["**/Generated/**", "**/Migrations/**"]
+    };
+
+    var config = new CoverageConfiguration(_mockCommandLineOptions.Object, configFileSettings, testModulePath: "/fake/path/test.dll", _mockLogger.Object);
+    string[] result = config.GetExcludeByFileFilters();
+
+    Assert.Equal(configFileSettings.ExcludeSourceFiles, result);
+  }
+
+  [Fact]
+  public void GetExcludeByFileFiltersWhenCliAndConfigFileSetReturnsCliFilters()
+  {
+    string[] cliFilters = ["**/Cli/**"];
+#pragma warning disable IDE0350 // Use implicitly typed lambda
+    _mockCommandLineOptions.Setup(x => x.TryGetOptionArgumentList(CoverletOptionNames.ExcludeByFile, out It.Ref<string[]?>.IsAny))
+      .Returns(new TryGetOptionArgumentListDelegate((string optionName, out string[]? filters) =>
+      {
+        filters = cliFilters;
+        return true;
+      }));
+#pragma warning restore IDE0350 // Use implicitly typed lambda
+
+    var configFileSettings = new CoverletMTPSettings
+    {
+      IsFromConfigFile = true,
+      ExcludeSourceFiles = ["**/Config/**"]
+    };
+
+    var config = new CoverageConfiguration(_mockCommandLineOptions.Object, configFileSettings, testModulePath: "/fake/path/test.dll", _mockLogger.Object);
+    string[] result = config.GetExcludeByFileFilters();
+
+    Assert.Equal(cliFilters, result);
+  }
+
   #endregion
 
   #region GetExcludeByAttributeFilters Tests
@@ -445,6 +494,34 @@ public sealed class CoverageConfigurationTests
     Assert.Contains("System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute", result);
   }
 
+  [Fact]
+  public void GetExcludeByAttributeFiltersWhenCliAndConfigFileSetUsesCliDefaultsMerge()
+  {
+    string[] cliAttributes = ["CliOnlyAttribute"];
+#pragma warning disable IDE0350 // Use implicitly typed lambda
+    _mockCommandLineOptions.Setup(x => x.TryGetOptionArgumentList(CoverletOptionNames.ExcludeByAttribute, out It.Ref<string[]?>.IsAny))
+      .Returns(new TryGetOptionArgumentListDelegate((string optionName, out string[]? attributes) =>
+      {
+        attributes = cliAttributes;
+        return true;
+      }));
+#pragma warning restore IDE0350 // Use implicitly typed lambda
+
+    var configFileSettings = new CoverletMTPSettings
+    {
+      IsFromConfigFile = true,
+      ExcludeAttributes = ["ConfigOnlyAttribute"]
+    };
+
+    var config = new CoverageConfiguration(_mockCommandLineOptions.Object, configFileSettings, testModulePath: "/fake/path/test.dll", _mockLogger.Object);
+    string[] result = config.GetExcludeByAttributeFilters();
+
+    Assert.Contains("ExcludeFromCodeCoverage", result);
+    Assert.Contains("CompilerGeneratedAttribute", result);
+    Assert.Contains("CliOnlyAttribute", result);
+    Assert.DoesNotContain("ConfigOnlyAttribute", result);
+  }
+
   #endregion
 
   #region GetIncludeDirectories Tests
@@ -503,6 +580,30 @@ public sealed class CoverageConfigurationTests
     string[] result = config.GetIncludeDirectories();
 
     Assert.Equal(expectedDirectories, result);
+  }
+
+  [Fact]
+  public void GetIncludeDirectoriesWhenConfigFileSettingsPresentReturnsConfigDirectories()
+  {
+#pragma warning disable IDE0350 // Use implicitly typed lambda
+    _mockCommandLineOptions.Setup(x => x.TryGetOptionArgumentList(CoverletOptionNames.IncludeDirectory, out It.Ref<string[]?>.IsAny))
+      .Returns(new TryGetOptionArgumentListDelegate((string optionName, out string[]? directories) =>
+      {
+        directories = null;
+        return false;
+      }));
+#pragma warning restore IDE0350 // Use implicitly typed lambda
+
+    var configFileSettings = new CoverletMTPSettings
+    {
+      IsFromConfigFile = true,
+      IncludeDirectories = ["/config/include1", "/config/include2"]
+    };
+
+    var config = new CoverageConfiguration(_mockCommandLineOptions.Object, configFileSettings, testModulePath: "/fake/path/test.dll", _mockLogger.Object);
+    string[] result = config.GetIncludeDirectories();
+
+    Assert.Equal(configFileSettings.IncludeDirectories, result);
   }
 
   #endregion
@@ -805,17 +906,52 @@ public sealed class CoverageConfigurationTests
       }));
 #pragma warning restore IDE0350 // Use implicitly typed lambda
 
-    var config = new CoverageConfiguration(_mockCommandLineOptions.Object, _mockLogger.Object);
+    var configFileSettings = new CoverletMTPSettings
+    {
+      IsFromConfigFile = true,
+      ReportFormats = ["json"],
+      IncludeFilters = ["[MyAssembly]*"],
+      ExcludeFilters = ["[coverlet.*]*", "[Excluded]*"],
+      ExcludeSourceFiles = ["**/Generated/**"],
+      ExcludeAttributes = ["MyExcludeAttribute"],
+      IncludeDirectories = ["/tmp/include"],
+      ExcludeAssembliesWithoutSources = "MissingAll"
+    };
+
+    var config = new CoverageConfiguration(_mockCommandLineOptions.Object, configFileSettings, testModulePath: "/fake/path/test.dll", _mockLogger.Object);
 
     // Act
     config.LogConfigurationSummary();
 
-    // Assert - Verify the underlying Log method was called for LogInformation
-    // Microsoft.Testing.Platform.Logging.ILogger.LogInformation extension method calls Log<TState>
+    // Assert - Verify representative information lines are logged
     _mockLogger.Verify(
       x => x.Log(
         It.IsAny<LogLevel>(),
-        It.Is<string>(s => s.Contains("Coverlet Coverage Configuration")),
+        It.Is<string>(s => s.Contains("=== Coverlet Coverage Configuration ===")),
+        It.IsAny<Exception?>(),
+        It.IsAny<Func<string, Exception?, string>>()),
+      Times.Once);
+
+    _mockLogger.Verify(
+      x => x.Log(
+        It.IsAny<LogLevel>(),
+        It.Is<string>(s => s.Contains("Output Formats: json")),
+        It.IsAny<Exception?>(),
+        It.IsAny<Func<string, Exception?, string>>()),
+      Times.Once);
+
+    _mockLogger.Verify(
+      x => x.Log(
+        It.IsAny<LogLevel>(),
+        It.Is<string>(s => s.Contains("Include Directories: /tmp/include")),
+        It.IsAny<Exception?>(),
+        It.IsAny<Func<string, Exception?, string>>()),
+      Times.Once);
+
+    _mockLogger.Verify(
+      x => x.Log(
+        It.IsAny<LogLevel>(),
+        It.Is<string>(s => s.Contains("========================================")),
         It.IsAny<Exception?>(),
         It.IsAny<Func<string, Exception?, string>>()),
       Times.Once);

--- a/test/coverlet.core.tests/Helpers/ProcessAssemblyHelperTests.cs
+++ b/test/coverlet.core.tests/Helpers/ProcessAssemblyHelperTests.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using Coverlet.Core.Helpers;
+using Microsoft.Extensions.DependencyModel;
 using Xunit;
 
 namespace Coverlet.Core.Tests.Helpers
@@ -115,6 +117,48 @@ namespace Coverlet.Core.Tests.Helpers
       IReadOnlyList<string> result = _sut.GetLoadedAssemblyNames("SomeOtherAssembly");
 
       Assert.Contains(expectedAssemblyName, result, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void WhenGetDepsJsonAssemblyNamesThenReturnsRuntimePackageNamesAndSkipsProjectLibraries()
+    {
+      string testModuleDirectory = AppContext.BaseDirectory;
+      string testAssemblyName = Path.GetFileNameWithoutExtension(typeof(ProcessAssemblyHelperTests).Assembly.Location);
+
+      IReadOnlyList<string> result = _sut.GetDepsJsonAssemblyNames(testModuleDirectory, testAssemblyName);
+
+      Assert.NotEmpty(result);
+      Assert.DoesNotContain(testAssemblyName, result, StringComparer.OrdinalIgnoreCase);
+
+      var unique = new HashSet<string>(result, StringComparer.OrdinalIgnoreCase);
+      Assert.Equal(unique.Count, result.Count);
+
+      IReadOnlySet<string> projectRuntimeLibraries = GetProjectRuntimeLibraryNames(testModuleDirectory);
+      Assert.NotEmpty(projectRuntimeLibraries);
+      Assert.All(projectRuntimeLibraries, projectName =>
+        Assert.DoesNotContain(projectName, result, StringComparer.OrdinalIgnoreCase));
+    }
+
+    private static IReadOnlySet<string> GetProjectRuntimeLibraryNames(string testModuleDirectory)
+    {
+      var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+      using var reader = new DependencyContextJsonReader();
+
+      foreach (string depsFile in Directory.EnumerateFiles(testModuleDirectory, "*.deps.json"))
+      {
+        using FileStream stream = File.OpenRead(depsFile);
+        DependencyContext context = reader.Read(stream);
+
+        foreach (RuntimeLibrary lib in context.RuntimeLibraries)
+        {
+          if (lib.Type.Equals("project", StringComparison.OrdinalIgnoreCase) && !string.IsNullOrWhiteSpace(lib.Name))
+          {
+            names.Add(lib.Name);
+          }
+        }
+      }
+
+      return names;
     }
   }
 }

--- a/test/coverlet.core.tests/Reporters/CoberturaReporterTests.cs
+++ b/test/coverlet.core.tests/Reporters/CoberturaReporterTests.cs
@@ -452,6 +452,26 @@ namespace Coverlet.Core.Tests.Reporters
       Assert.All(fileNames, fn => Assert.DoesNotContain(":", fn));
     }
 
+    [Theory]
+    [InlineData("//server/share/file.cs", "//server/share/")]
+    [InlineData("//server/share", "//server/share/")]
+    [InlineData("//server", "//")]
+    [InlineData("/var/tmp/file.cs", "/")]
+    [InlineData("relative/file.cs", "")]
+    public void Report_NonSourceLink_SourceRootNormalization_HandlesUncUnixAndRelative(string documentPath, string expectedSource)
+    {
+      // Covers GetNormalizedPathRoot branches for UNC, Unix-rooted and relative paths.
+      CoverageResult result = BuildResult([(documentPath, "Foo")]);
+
+      string report = new CoberturaReporter().Report(result, new Mock<ISourceRootTranslator>().Object);
+
+      var doc = XDocument.Load(new StringReader(report));
+      string[] sources = doc.Descendants("source").Select(s => s.Value).ToArray();
+
+      Assert.Single(sources);
+      Assert.Equal(expectedSource, sources[0]);
+    }
+
     [Fact]
     public void Report_UseSourceLink_FilenamePassesThroughUnchanged()
     {

--- a/test/coverlet.core.tests/Symbols/CecilSymbolHelperTests.cs
+++ b/test/coverlet.core.tests/Symbols/CecilSymbolHelperTests.cs
@@ -833,7 +833,16 @@ namespace Coverlet.Core.Tests.Symbols
         HandlerEnd = ret
       });
 
-      return (method, method.Body.Instructions.ToList(), brfalse);
+      // Re-read module to ensure Cecil computes stable instruction offsets.
+      // SkipGeneratedBranchesForAsyncTryFinally uses BinarySearch by instruction offset.
+      using var stream = new MemoryStream();
+      module.Write(stream);
+      stream.Position = 0;
+      ModuleDefinition reloadedModule = ModuleDefinition.ReadModule(stream);
+      TypeDefinition reloadedType = reloadedModule.Types.Single(x => x.Name == "ExceptionStateMachineHost");
+      MethodDefinition reloadedMethod = reloadedType.Methods.Single(x => x.Name == "MoveNext");
+      Instruction reloadedBranchInstruction = reloadedMethod.Body.Instructions.Single(x => x.OpCode == OpCodes.Brfalse || x.OpCode == OpCodes.Brfalse_S);
+      return (reloadedMethod, reloadedMethod.Body.Instructions.ToList(), reloadedBranchInstruction);
     }
 
     #endregion

--- a/test/coverlet.core.tests/Symbols/CecilSymbolHelperTests.cs
+++ b/test/coverlet.core.tests/Symbols/CecilSymbolHelperTests.cs
@@ -614,5 +614,228 @@ namespace Coverlet.Core.Tests.Symbols
       Assert.True(branchLine > 0, "Branch points must map to a valid source line, not a compiler-generated prologue");
       Assert.All(patternMatchingOrPoints, x => Assert.Equal(branchLine, x.StartLine));
     }
+
+    #region Private Pattern Coverage Tests
+
+    [Fact]
+    public void SkipGeneratedBackingFieldAssignmentDefault_WhenInstructionMatchesCompilerGeneratedBackingField_ReturnsTrue()
+    {
+      // arrange
+      MethodInfo method = typeof(CecilSymbolHelper).GetMethod("SkipGeneratedBackingFieldAssignmentDefault", BindingFlags.NonPublic | BindingFlags.Static);
+      Assert.NotNull(method);
+
+      MethodDefinition methodDefinition = CreateMethodWithAutoPropertyBackingFieldAssignment(isCompilerGeneratedBackingField: true, out Instruction firstInstruction);
+
+      // act
+      bool shouldSkip = (bool)method.Invoke(null, [methodDefinition, firstInstruction]);
+
+      // assert
+      Assert.True(shouldSkip);
+    }
+
+    [Fact]
+    public void SkipGeneratedBackingFieldAssignmentDefault_WhenFieldIsNotCompilerGenerated_ReturnsFalse()
+    {
+      // arrange
+      MethodInfo method = typeof(CecilSymbolHelper).GetMethod("SkipGeneratedBackingFieldAssignmentDefault", BindingFlags.NonPublic | BindingFlags.Static);
+      Assert.NotNull(method);
+
+      MethodDefinition methodDefinition = CreateMethodWithAutoPropertyBackingFieldAssignment(isCompilerGeneratedBackingField: false, out Instruction firstInstruction);
+
+      // act
+      bool shouldSkip = (bool)method.Invoke(null, [methodDefinition, firstInstruction]);
+
+      // assert
+      Assert.False(shouldSkip);
+    }
+
+    [Fact]
+    public void SkipGeneratedBranchesForAsyncTryFinally_WhenStateFieldComparePatternIsPresent_ReturnsTrue()
+    {
+      // arrange
+      MethodInfo method = typeof(CecilSymbolHelper).GetMethod("SkipGeneratedBranchesForAsyncTryFinally", BindingFlags.NonPublic | BindingFlags.Static);
+      Assert.NotNull(method);
+
+      (MethodDefinition methodDefinition, System.Collections.Generic.List<Instruction> instructions, Instruction branchInstruction) =
+        CreateAsyncTryFinallyPatternForStateFieldComparison();
+
+      // act
+      bool shouldSkip = (bool)method.Invoke(null, [instructions, branchInstruction, methodDefinition]);
+
+      // assert
+      Assert.True(shouldSkip);
+    }
+
+    [Fact]
+    public void SkipGeneratedBranchesForAsyncTryFinally_WhenLocalTempExceptionObjectPatternIsPresent_ReturnsTrue()
+    {
+      // arrange
+      MethodInfo method = typeof(CecilSymbolHelper).GetMethod("SkipGeneratedBranchesForAsyncTryFinally", BindingFlags.NonPublic | BindingFlags.Static);
+      Assert.NotNull(method);
+
+      (MethodDefinition methodDefinition, System.Collections.Generic.List<Instruction> instructions, Instruction branchInstruction) =
+        CreateAsyncTryFinallyPatternForExceptionObjectLocalCheck(fieldName: "<>s__3");
+
+      // act
+      bool shouldSkip = (bool)method.Invoke(null, [instructions, branchInstruction, methodDefinition]);
+
+      // assert
+      Assert.True(shouldSkip);
+    }
+
+    [Fact]
+    public void SkipGeneratedBranchesForAsyncTryFinally_WhenExceptionFieldIsNotCompilerGenerated_ReturnsFalse()
+    {
+      // arrange
+      MethodInfo method = typeof(CecilSymbolHelper).GetMethod("SkipGeneratedBranchesForAsyncTryFinally", BindingFlags.NonPublic | BindingFlags.Static);
+      Assert.NotNull(method);
+
+      (MethodDefinition methodDefinition, System.Collections.Generic.List<Instruction> instructions, Instruction branchInstruction) =
+        CreateAsyncTryFinallyPatternForExceptionObjectLocalCheck(fieldName: "state");
+
+      // act
+      bool shouldSkip = (bool)method.Invoke(null, [instructions, branchInstruction, methodDefinition]);
+
+      // assert
+      Assert.False(shouldSkip);
+    }
+
+    private static MethodDefinition CreateMethodWithAutoPropertyBackingFieldAssignment(bool isCompilerGeneratedBackingField, out Instruction firstInstruction)
+    {
+      var module = ModuleDefinition.CreateModule("AutoPropModule", ModuleKind.Dll);
+      var type = new TypeDefinition("Coverage", "AutoPropHost", Mono.Cecil.TypeAttributes.Class | Mono.Cecil.TypeAttributes.Public, module.TypeSystem.Object);
+      module.Types.Add(type);
+
+      var backingField = new FieldDefinition("<Name>k__BackingField", Mono.Cecil.FieldAttributes.Private, module.TypeSystem.String);
+      if (isCompilerGeneratedBackingField)
+      {
+        var compilerGeneratedCtor = typeof(System.Runtime.CompilerServices.CompilerGeneratedAttribute).GetConstructor(global::System.Type.EmptyTypes);
+        Assert.NotNull(compilerGeneratedCtor);
+        backingField.CustomAttributes.Add(new CustomAttribute(module.ImportReference(compilerGeneratedCtor)));
+      }
+
+      type.Fields.Add(backingField);
+
+      var method = new MethodDefinition(".ctor", Mono.Cecil.MethodAttributes.Public | Mono.Cecil.MethodAttributes.HideBySig | Mono.Cecil.MethodAttributes.SpecialName | Mono.Cecil.MethodAttributes.RTSpecialName, module.TypeSystem.Void);
+      var arg = new ParameterDefinition("value", Mono.Cecil.ParameterAttributes.None, module.TypeSystem.String);
+      method.Parameters.Add(arg);
+      type.Methods.Add(method);
+
+      firstInstruction = Instruction.Create(OpCodes.Ldarg, arg);
+      method.Body.Instructions.Add(firstInstruction);
+      method.Body.Instructions.Add(Instruction.Create(OpCodes.Nop));
+      method.Body.Instructions.Add(Instruction.Create(OpCodes.Stfld, backingField));
+      method.Body.Instructions.Add(Instruction.Create(OpCodes.Ret));
+
+      return method;
+    }
+
+    private static (MethodDefinition MethodDefinition, System.Collections.Generic.List<Instruction> Instructions, Instruction BranchInstruction) CreateAsyncTryFinallyPatternForStateFieldComparison()
+    {
+      var module = ModuleDefinition.CreateModule("AsyncTryFinallyState", ModuleKind.Dll);
+      var type = new TypeDefinition("Coverage", "StateMachineHost", Mono.Cecil.TypeAttributes.Class | Mono.Cecil.TypeAttributes.NotPublic, module.TypeSystem.Object);
+      module.Types.Add(type);
+
+      var compilerGeneratedCtor = typeof(System.Runtime.CompilerServices.CompilerGeneratedAttribute).GetConstructor(global::System.Type.EmptyTypes);
+      Assert.NotNull(compilerGeneratedCtor);
+      type.CustomAttributes.Add(new CustomAttribute(module.ImportReference(compilerGeneratedCtor)));
+
+      var stateField = new FieldDefinition("<>s__1", Mono.Cecil.FieldAttributes.Private, module.TypeSystem.Int32);
+      type.Fields.Add(stateField);
+
+      var method = new MethodDefinition("MoveNext", Mono.Cecil.MethodAttributes.Public, module.TypeSystem.Void);
+      method.Body.InitLocals = true;
+      method.Body.Variables.Add(new VariableDefinition(module.TypeSystem.Int32));
+      type.Methods.Add(method);
+
+      Instruction start = Instruction.Create(OpCodes.Nop);
+      Instruction ldarg0 = Instruction.Create(OpCodes.Ldarg_0);
+      Instruction ldfld = Instruction.Create(OpCodes.Ldfld, stateField);
+      Instruction stloc0 = Instruction.Create(OpCodes.Stloc_0);
+      Instruction ldloc0 = Instruction.Create(OpCodes.Ldloc_0);
+      Instruction ldc1 = Instruction.Create(OpCodes.Ldc_I4_1);
+      Instruction beq = Instruction.Create(OpCodes.Beq_S, start);
+      Instruction endFinally = Instruction.Create(OpCodes.Endfinally);
+      Instruction ret = Instruction.Create(OpCodes.Ret);
+
+      method.Body.Instructions.Add(start);
+      method.Body.Instructions.Add(ldarg0);
+      method.Body.Instructions.Add(ldfld);
+      method.Body.Instructions.Add(stloc0);
+      method.Body.Instructions.Add(ldloc0);
+      method.Body.Instructions.Add(ldc1);
+      method.Body.Instructions.Add(beq);
+      method.Body.Instructions.Add(endFinally);
+      method.Body.Instructions.Add(ret);
+
+      method.Body.ExceptionHandlers.Add(new ExceptionHandler(ExceptionHandlerType.Finally)
+      {
+        TryStart = start,
+        TryEnd = endFinally,
+        HandlerStart = endFinally,
+        HandlerEnd = ret
+      });
+
+      // Re-read module to ensure Cecil computes stable instruction offsets.
+      // SkipGeneratedBranchesForAsyncTryFinally uses BinarySearch by instruction offset.
+      using var stream = new MemoryStream();
+      module.Write(stream);
+      stream.Position = 0;
+      ModuleDefinition reloadedModule = ModuleDefinition.ReadModule(stream);
+      TypeDefinition reloadedType = reloadedModule.Types.Single(x => x.Name == "StateMachineHost");
+      MethodDefinition reloadedMethod = reloadedType.Methods.Single(x => x.Name == "MoveNext");
+      Instruction reloadedBranchInstruction = reloadedMethod.Body.Instructions.Single(x => x.OpCode == OpCodes.Beq || x.OpCode == OpCodes.Beq_S);
+
+      return (reloadedMethod, reloadedMethod.Body.Instructions.ToList(), reloadedBranchInstruction);
+    }
+
+    private static (MethodDefinition MethodDefinition, System.Collections.Generic.List<Instruction> Instructions, Instruction BranchInstruction) CreateAsyncTryFinallyPatternForExceptionObjectLocalCheck(string fieldName)
+    {
+      var module = ModuleDefinition.CreateModule("AsyncTryFinallyException", ModuleKind.Dll);
+      var type = new TypeDefinition("Coverage", "ExceptionStateMachineHost", Mono.Cecil.TypeAttributes.Class | Mono.Cecil.TypeAttributes.NotPublic, module.TypeSystem.Object);
+      module.Types.Add(type);
+
+      var compilerGeneratedCtor = typeof(System.Runtime.CompilerServices.CompilerGeneratedAttribute).GetConstructor(global::System.Type.EmptyTypes);
+      Assert.NotNull(compilerGeneratedCtor);
+      type.CustomAttributes.Add(new CustomAttribute(module.ImportReference(compilerGeneratedCtor)));
+
+      FieldDefinition exceptionField = new FieldDefinition(fieldName, Mono.Cecil.FieldAttributes.Private, module.TypeSystem.Object);
+      type.Fields.Add(exceptionField);
+
+      var method = new MethodDefinition("MoveNext", Mono.Cecil.MethodAttributes.Public, module.TypeSystem.Void);
+      method.Body.InitLocals = true;
+      method.Body.Variables.Add(new VariableDefinition(module.TypeSystem.Object));
+      type.Methods.Add(method);
+
+      Instruction start = Instruction.Create(OpCodes.Nop);
+      Instruction ldarg0 = Instruction.Create(OpCodes.Ldarg_0);
+      Instruction ldfld = Instruction.Create(OpCodes.Ldfld, exceptionField);
+      Instruction stloc0 = Instruction.Create(OpCodes.Stloc_0);
+      Instruction ldloc0 = Instruction.Create(OpCodes.Ldloc_0);
+      Instruction brfalse = Instruction.Create(OpCodes.Brfalse_S, start);
+      Instruction endFinally = Instruction.Create(OpCodes.Endfinally);
+      Instruction ret = Instruction.Create(OpCodes.Ret);
+
+      method.Body.Instructions.Add(start);
+      method.Body.Instructions.Add(ldarg0);
+      method.Body.Instructions.Add(ldfld);
+      method.Body.Instructions.Add(stloc0);
+      method.Body.Instructions.Add(ldloc0);
+      method.Body.Instructions.Add(brfalse);
+      method.Body.Instructions.Add(endFinally);
+      method.Body.Instructions.Add(ret);
+
+      method.Body.ExceptionHandlers.Add(new ExceptionHandler(ExceptionHandlerType.Finally)
+      {
+        TryStart = start,
+        TryEnd = endFinally,
+        HandlerStart = endFinally,
+        HandlerEnd = ret
+      });
+
+      return (method, method.Body.Instructions.ToList(), brfalse);
+    }
+
+    #endregion
   }
 }

--- a/test/coverlet.core.tests/Symbols/CecilSymbolHelperTests.cs
+++ b/test/coverlet.core.tests/Symbols/CecilSymbolHelperTests.cs
@@ -700,6 +700,23 @@ namespace Coverlet.Core.Tests.Symbols
       Assert.False(shouldSkip);
     }
 
+    [Fact]
+    public void SkipGeneratedBranchesForAsyncIterator_WhenStateSwitchPatternIsPresent_ReturnsTrue()
+    {
+      // arrange
+      MethodInfo method = typeof(CecilSymbolHelper).GetMethod("SkipGeneratedBranchesForAsyncIterator", BindingFlags.NonPublic | BindingFlags.Static);
+      Assert.NotNull(method);
+
+      (System.Collections.Generic.List<Instruction> instructions, Instruction switchInstruction) =
+        CreateAsyncIteratorStateSwitchPattern();
+
+      // act
+      bool shouldSkip = (bool)method.Invoke(null, [instructions, switchInstruction]);
+
+      // assert
+      Assert.True(shouldSkip);
+    }
+
     private static MethodDefinition CreateMethodWithAutoPropertyBackingFieldAssignment(bool isCompilerGeneratedBackingField, out Instruction firstInstruction)
     {
       var module = ModuleDefinition.CreateModule("AutoPropModule", ModuleKind.Dll);
@@ -843,6 +860,59 @@ namespace Coverlet.Core.Tests.Symbols
       MethodDefinition reloadedMethod = reloadedType.Methods.Single(x => x.Name == "MoveNext");
       Instruction reloadedBranchInstruction = reloadedMethod.Body.Instructions.Single(x => x.OpCode == OpCodes.Brfalse || x.OpCode == OpCodes.Brfalse_S);
       return (reloadedMethod, reloadedMethod.Body.Instructions.ToList(), reloadedBranchInstruction);
+    }
+
+    private static (System.Collections.Generic.List<Instruction> Instructions, Instruction SwitchInstruction) CreateAsyncIteratorStateSwitchPattern()
+    {
+      var module = ModuleDefinition.CreateModule("AsyncIteratorStateSwitch", ModuleKind.Dll);
+      var type = new TypeDefinition("Coverage", "AsyncIteratorStateMachineHost", Mono.Cecil.TypeAttributes.Class | Mono.Cecil.TypeAttributes.NotPublic, module.TypeSystem.Object);
+      module.Types.Add(type);
+
+      var compilerGeneratedCtor = typeof(System.Runtime.CompilerServices.CompilerGeneratedAttribute).GetConstructor(global::System.Type.EmptyTypes);
+      Assert.NotNull(compilerGeneratedCtor);
+      type.CustomAttributes.Add(new CustomAttribute(module.ImportReference(compilerGeneratedCtor)));
+
+      var stateField = new FieldDefinition("<>1__state", Mono.Cecil.FieldAttributes.Private, module.TypeSystem.Int32);
+      type.Fields.Add(stateField);
+
+      var method = new MethodDefinition("MoveNext", Mono.Cecil.MethodAttributes.Public, module.TypeSystem.Void);
+      method.Body.InitLocals = true;
+      method.Body.Variables.Add(new VariableDefinition(module.TypeSystem.Int32));
+      type.Methods.Add(method);
+
+      Instruction start = Instruction.Create(OpCodes.Nop);
+      Instruction ldarg0 = Instruction.Create(OpCodes.Ldarg_0);
+      Instruction ldfld = Instruction.Create(OpCodes.Ldfld, stateField);
+      Instruction stloc0 = Instruction.Create(OpCodes.Stloc_0);
+      Instruction ldloc0 = Instruction.Create(OpCodes.Ldloc_0);
+      Instruction ldcMinus4 = Instruction.Create(OpCodes.Ldc_I4_S, (sbyte)-4);
+      Instruction sub = Instruction.Create(OpCodes.Sub);
+      Instruction case0 = Instruction.Create(OpCodes.Nop);
+      Instruction case1 = Instruction.Create(OpCodes.Nop);
+      Instruction switchInstruction = Instruction.Create(OpCodes.Switch, new[] { case0, case1 });
+      Instruction ret = Instruction.Create(OpCodes.Ret);
+
+      method.Body.Instructions.Add(start);
+      method.Body.Instructions.Add(ldarg0);
+      method.Body.Instructions.Add(ldfld);
+      method.Body.Instructions.Add(stloc0);
+      method.Body.Instructions.Add(ldloc0);
+      method.Body.Instructions.Add(ldcMinus4);
+      method.Body.Instructions.Add(sub);
+      method.Body.Instructions.Add(switchInstruction);
+      method.Body.Instructions.Add(case0);
+      method.Body.Instructions.Add(case1);
+      method.Body.Instructions.Add(ret);
+
+      using var stream = new MemoryStream();
+      module.Write(stream);
+      stream.Position = 0;
+      ModuleDefinition reloadedModule = ModuleDefinition.ReadModule(stream);
+      TypeDefinition reloadedType = reloadedModule.Types.Single(x => x.Name == "AsyncIteratorStateMachineHost");
+      MethodDefinition reloadedMethod = reloadedType.Methods.Single(x => x.Name == "MoveNext");
+      Instruction reloadedSwitch = reloadedMethod.Body.Instructions.Single(x => x.OpCode == OpCodes.Switch);
+
+      return (reloadedMethod.Body.Instructions.ToList(), reloadedSwitch);
     }
 
     #endregion


### PR DESCRIPTION
Added comprehensive unit tests for previously untested internal/private methods in CollectorExtensionReportMethodsTests, CollectorExtensionTests, CoverageConfigurationTests, and CecilSymbolHelperTests. Updated test setup to use dependency injection for file system and source root translator mocks, enhancing test isolation. Clarified documentation to specify that tests should be run manually by the user.