### PR TITLE
Replace ConcurrentBag with List for unload handlers registry

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix When using "is" with "or" in pattern matching, branch coverage is lower than normal [#1979](https://github.com/coverlet-coverage/coverlet/pull/1979)
 - Fix silent zero coverage on .NET Framework since 8.0.0 [#1985](https://github.com/coverlet-coverage/coverlet/pull/1985)
 - Fix Race condition between ProcessExit hit-file write and out-of-proc coverage read causes EndOfStreamException [#1987](https://github.com/coverlet-coverage/coverlet/pull/1987) [#1988](https://github.com/coverlet-coverage/coverlet/pull/1988)
+- Fix Regression TypeInitializationException when targeting .NET Framework - Could not load type 'System.Collections.Concurrent.ConcurrentBag [#2010](https://github.com/coverlet-coverage/coverlet/pull/2010)
 
 ## Release date 2026-05-18
 

--- a/src/coverlet.MTP/InProcess/CoverletInProcessHandler.cs
+++ b/src/coverlet.MTP/InProcess/CoverletInProcessHandler.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Toni Solarin-Sodara
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Concurrent;
 using System.Diagnostics;
 using Coverlet.MTP.EnvironmentVariables;
 using Coverlet.Core.Instrumentation;
@@ -64,10 +63,10 @@ internal sealed class CoverletInProcessHandler : ITestSessionLifetimeHandler
     {
       _logger.LogDebug($"[Coverlet.MTP.InProcess] Test session starting: {testSessionContext.SessionUid}");
 
-      // Pre-create the registry bag before any instrumented assembly is loaded.
+      // Pre-create the registry list before any instrumented assembly is loaded.
       AppDomain.CurrentDomain.SetData(
           ModuleTrackerTemplate.ModuleTrackerRegistryKey,
-          new ConcurrentBag<EventHandler>());
+          new List<EventHandler>());
     }
     return Task.CompletedTask;
   }
@@ -98,11 +97,18 @@ internal sealed class CoverletInProcessHandler : ITestSessionLifetimeHandler
   {
     int flushedCount = 0;
 
-    var registeredHandlers = (ConcurrentBag<EventHandler>?)AppDomain.CurrentDomain.GetData(ModuleTrackerTemplate.ModuleTrackerRegistryKey);
-    if (registeredHandlers is null)
+    if (AppDomain.CurrentDomain.GetData(ModuleTrackerTemplate.ModuleTrackerRegistryKey) is not List<EventHandler> registeredHandlers)
+    {
       return;
+    }
 
-    foreach (EventHandler handler in registeredHandlers)
+    EventHandler[] handlersSnapshot;
+    lock (registeredHandlers)
+    {
+      handlersSnapshot = [.. registeredHandlers];
+    }
+
+    foreach (EventHandler handler in handlersSnapshot)
     {
       string assemblyName = handler.Method?.DeclaringType?.Assembly?.GetName().Name ?? "(unknown)";
       try

--- a/src/coverlet.core/Instrumentation/ModuleTrackerTemplate.cs
+++ b/src/coverlet.core/Instrumentation/ModuleTrackerTemplate.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
@@ -24,7 +24,7 @@ namespace Coverlet.Core.Instrumentation
   internal static class ModuleTrackerTemplate
   {
     /// <summary>
-    /// AppDomain data key under which a <see cref="ConcurrentBag{T}"/> of <see cref="EventHandler"/>
+    /// AppDomain data key under which a <see cref="List{T}"/> of <see cref="EventHandler"/>
     /// delegates, one per loaded instrumented module, is stored for use by the in-proc collector.
     /// </summary>
     internal const string ModuleTrackerRegistryKey = "Coverlet_RegisteredModuleTrackers";
@@ -52,8 +52,13 @@ namespace Coverlet.Core.Instrumentation
       // all fields before calling RegisterUnloadEvents). If no in-proc collector created the
       // registry (MSBuild / global-tool integration), GetData returns null and the Add is a
       // deliberate no-op; the ProcessExit handler covers the flush in those paths.
-      var registry = (ConcurrentBag<EventHandler>)AppDomain.CurrentDomain.GetData(ModuleTrackerRegistryKey);
-      registry?.Add(new EventHandler(UnloadModule));
+      if (AppDomain.CurrentDomain.GetData(ModuleTrackerRegistryKey) is List<EventHandler> registry)
+      {
+        lock (registry)
+        {
+          registry.Add(new EventHandler(UnloadModule));
+        }
+      }
 
       AppDomain.CurrentDomain.ProcessExit += new EventHandler(UnloadModule);
       AppDomain.CurrentDomain.DomainUnload += new EventHandler(UnloadModule);

--- a/src/legacy/coverlet.collector/InProcDataCollection/CoverletInProcDataCollector.cs
+++ b/src/legacy/coverlet.collector/InProcDataCollection/CoverletInProcDataCollector.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using Coverlet.Collector.Utilities;
 using Coverlet.Core.Instrumentation;
@@ -52,10 +52,10 @@ namespace Coverlet.Collector.DataCollection
       _eqtTrace = new TestPlatformEqtTrace();
       _eqtTrace.Verbose("Initialize CoverletInProcDataCollector");
 
-      // Pre-create the registry bag before any instrumented assembly is loaded.
+      // Pre-create the registry list before any instrumented assembly is loaded.
       AppDomain.CurrentDomain.SetData(
           ModuleTrackerTemplate.ModuleTrackerRegistryKey,
-          new ConcurrentBag<EventHandler>());
+          new List<EventHandler>());
     }
 
     public void TestCaseEnd(TestCaseEndArgs testCaseEndArgs)
@@ -75,11 +75,16 @@ namespace Coverlet.Collector.DataCollection
       }
 
       // Use the AppDomain registry populated by RegisterUnloadEvents at module-load time.
-      var registeredHandlers = (ConcurrentBag<EventHandler>)AppDomain.CurrentDomain.GetData(ModuleTrackerTemplate.ModuleTrackerRegistryKey);
-      if (registeredHandlers is null)
+      if (AppDomain.CurrentDomain.GetData(ModuleTrackerTemplate.ModuleTrackerRegistryKey) is not List<EventHandler> registeredHandlers)
         return;
 
-      foreach (EventHandler handler in registeredHandlers)
+      EventHandler[] handlersSnapshot;
+      lock (registeredHandlers)
+      {
+        handlersSnapshot = [.. registeredHandlers];
+      }
+
+      foreach (EventHandler handler in handlersSnapshot)
       {
         string assemblyName = handler.Method?.DeclaringType?.Assembly?.FullName ?? "(unknown)";
         try

--- a/test/coverlet.MTP.tests/InProcess/CoverletInProcessHandlerTests.cs
+++ b/test/coverlet.MTP.tests/InProcess/CoverletInProcessHandlerTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Toni Solarin-Sodara
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Concurrent;
 using Coverlet.Core.Instrumentation;
 using Coverlet.MTP.EnvironmentVariables;
 using Microsoft.Testing.Platform.Extensions.TestHost;
@@ -351,7 +350,7 @@ public class CoverletInProcessHandlerTests : IDisposable
     var handler = new CoverletInProcessHandler(_mockLoggerFactory.Object);
     var mockSessionContext = new Mock<ITestSessionContext>();
     mockSessionContext.Setup(x => x.SessionUid).Returns(new Microsoft.Testing.Platform.TestHost.SessionUid("test-session-789"));
-    AppDomain.CurrentDomain.SetData(ModuleTrackerTemplate.ModuleTrackerRegistryKey, new ConcurrentBag<EventHandler>());
+    AppDomain.CurrentDomain.SetData(ModuleTrackerTemplate.ModuleTrackerRegistryKey, new List<EventHandler>());
 
     try
     {
@@ -386,7 +385,7 @@ public class CoverletInProcessHandlerTests : IDisposable
     mockSessionContext.Setup(x => x.SessionUid).Returns(new Microsoft.Testing.Platform.TestHost.SessionUid("test-exception-session"));
 
     // Inject a failing handler into the registry
-    var registry = new ConcurrentBag<EventHandler>
+    var registry = new List<EventHandler>
     {
         (s, e) => throw new InvalidOperationException("Test exception")
     };
@@ -424,7 +423,7 @@ public class CoverletInProcessHandlerTests : IDisposable
     mockSessionContext.Setup(x => x.SessionUid).Returns(new Microsoft.Testing.Platform.TestHost.SessionUid("test-no-log-session"));
 
     // Inject a failing handler into the registry
-    var registry = new ConcurrentBag<EventHandler>
+    var registry = new List<EventHandler>
     {
         (s, e) => throw new InvalidOperationException("Test exception")
     };

--- a/test/coverlet.MTP.validation.tests/Issue2009NetFrameworkRegressionTests.cs
+++ b/test/coverlet.MTP.validation.tests/Issue2009NetFrameworkRegressionTests.cs
@@ -1,0 +1,205 @@
+﻿// Copyright (c) Toni Solarin-Sodara
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using Xunit;
+
+namespace Coverlet.MTP.validation.tests;
+
+/// <summary>
+/// Regression test for issue #2009 (.NET Framework tracker TypeLoadException).
+/// </summary>
+[Collection(nameof(MtpValidationTests))]
+public class Issue2009NetFrameworkRegressionTests : MtpValidationTestBase
+{
+  private const string CoverageJsonFileName = "coverage.json";
+  private const string NetFrameworkTfm = "net472";
+
+  [Fact]
+  public async Task Issue2009_NetFrameworkCoverage_DoesNotThrowTypeLoadException()
+  {
+    Assert.SkipUnless(OperatingSystem.IsWindows(), "Test requires Windows");
+
+    // Arrange
+    string testName = TestContext.Current.TestCase!.TestMethodName!;
+    using var testProject = CreateIssue2009ReproProject(testName);
+    await BuildProjectAsync(testProject.SolutionPath);
+
+    // Act
+    TestResult result = await RunNetFrameworkTestsWithCoverage(testProject, BuildConfiguration);
+    TestContext.Current?.AddAttachment("Test Output", result.CombinedOutput);
+
+    // Assert
+    Assert.True(result.ExitCode == 0,
+      $"Expected successful test run (exit code 0) but got {result.ExitCode}.\n\n{result.CombinedOutput}");
+    Assert.Contains("Passed!", result.StandardOutput);
+    Assert.DoesNotContain("TypeLoadException", result.CombinedOutput, StringComparison.Ordinal);
+    Assert.DoesNotContain("ConcurrentBag`1", result.CombinedOutput, StringComparison.Ordinal);
+
+    string[] coverageFiles = Directory.GetFiles(
+      testProject.SolutionDirectory,
+      CoverageJsonFileName.Insert(CoverageJsonFileName.LastIndexOf('.'), ".*"),
+      SearchOption.AllDirectories);
+
+    Assert.NotEmpty(coverageFiles);
+  }
+
+  private TestProjectInfo CreateIssue2009ReproProject(string testName)
+  {
+    string artifactsTemp = Path.Combine(RepoRoot, "artifacts", "tmp", BuildConfiguration.ToLowerInvariant());
+    Directory.CreateDirectory(artifactsTemp);
+
+    string solutionPath = CreateSolutionDirectory(artifactsTemp, "MTP_Issue2009_", SanitizePathName(testName));
+
+    string sutProjectPath = Path.Combine(solutionPath, SutProjectName);
+    string testProjectPath = Path.Combine(solutionPath, TestProjectName);
+    Directory.CreateDirectory(sutProjectPath);
+    Directory.CreateDirectory(testProjectPath);
+
+    CreateNugetConfig(solutionPath);
+
+    string coverletMtpVersion = GetCoverletMtpPackageVersion();
+
+    CreateIssue2009SutProject(sutProjectPath);
+    CreateIssue2009TestProject(testProjectPath, coverletMtpVersion);
+
+    string solutionFile = Path.Combine(solutionPath, "TestSolution.sln");
+    CreateSolutionFile(solutionFile);
+
+    return new TestProjectInfo(solutionFile, testProjectPath, testProjectPath, solutionPath);
+  }
+
+  private static void CreateIssue2009SutProject(string sutProjectPath)
+  {
+    string sutCsproj = Path.Combine(sutProjectPath, $"{SutProjectName}.csproj");
+    File.WriteAllText(sutCsproj, """
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+    <ArtifactsPath>$(MSBuildThisFileDirectory)..</ArtifactsPath>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>
+""");
+
+    File.WriteAllText(Path.Combine(sutProjectPath, "Class1.cs"), """
+// Copyright (c) Toni Solarin-Sodara
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace SampleLibrary;
+
+public class Class1
+{
+  public int Method()
+  {
+    return 1;
+  }
+}
+""");
+  }
+
+  private static void CreateIssue2009TestProject(string testProjectPath, string coverletMtpVersion)
+  {
+    string relativeSutPath = Path.Combine("..", SutProjectName, $"{SutProjectName}.csproj");
+
+    string testCsproj = Path.Combine(testProjectPath, $"{TestProjectName}.csproj");
+    File.WriteAllText(testCsproj, $$"""
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>{{NetFrameworkTfm}}</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <OutputType>Exe</OutputType>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+    <ArtifactsPath>$(MSBuildThisFileDirectory)..</ArtifactsPath>
+    <Deterministic>false</Deterministic>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="{{relativeSutPath}}" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit.v3.mtp-v2" Version="{{MtpPackageVersions.XunitV3}}" />
+    <PackageReference Include="Microsoft.Testing.Platform" Version="{{MtpPackageVersions.MicrosoftTestingPlatform}}" />
+    <PackageReference Include="coverlet.MTP" Version="{{coverletMtpVersion}}" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="{{MtpPackageVersions.MicrosoftTestingPlatform}}" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>
+""");
+
+    File.WriteAllText(Path.Combine(testProjectPath, "ReproTests.cs"), """
+// Copyright (c) Toni Solarin-Sodara
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using SampleLibrary;
+using Xunit;
+
+namespace TestProject;
+
+public class ReproTests
+{
+  [Fact]
+  public void DemoTest()
+  {
+    var sut = new Class1();
+    Assert.Equal(1, sut.Method());
+  }
+}
+""");
+  }
+
+  private static async Task<TestResult> RunNetFrameworkTestsWithCoverage(TestProjectInfo testProject, string buildConfiguration)
+  {
+    string testExecutablePath = Path.Combine(
+      testProject.SolutionDirectory,
+      "bin",
+      TestProjectName,
+      buildConfiguration.ToLowerInvariant(),
+      $"{TestProjectName}.exe");
+
+    if (!File.Exists(testExecutablePath))
+    {
+      throw new FileNotFoundException($"Test executable not found: {testExecutablePath}");
+    }
+
+    string workingDirectory = Path.GetDirectoryName(testExecutablePath)!;
+
+    var processStartInfo = new ProcessStartInfo
+    {
+      FileName = testExecutablePath,
+      Arguments = "--diagnostic --coverlet --results-directory ./results",
+      RedirectStandardOutput = true,
+      RedirectStandardError = true,
+      UseShellExecute = false,
+      CreateNoWindow = true,
+      WorkingDirectory = workingDirectory,
+    };
+
+    using var process = Process.Start(processStartInfo)!;
+
+    string output = await process.StandardOutput.ReadToEndAsync();
+    string error = await process.StandardError.ReadToEndAsync();
+
+    await process.WaitForExitAsync();
+
+    return new TestResult(
+      process.ExitCode,
+      output,
+      error);
+  }
+}

--- a/test/coverlet.MTP.validation.tests/Issue2009NetFrameworkRegressionTests.cs
+++ b/test/coverlet.MTP.validation.tests/Issue2009NetFrameworkRegressionTests.cs
@@ -66,7 +66,8 @@ public class Issue2009NetFrameworkRegressionTests : MtpValidationTestBase
     string solutionFile = Path.Combine(solutionPath, "TestSolution.sln");
     CreateSolutionFile(solutionFile);
 
-    return new TestProjectInfo(solutionFile, testProjectPath, testProjectPath, solutionPath);
+    string outputPath = Path.Combine(solutionPath, "bin", TestProjectName, BuildConfiguration.ToLowerInvariant());
+    return new TestProjectInfo(solutionFile, testProjectPath, outputPath, solutionPath);
   }
 
   private static void CreateIssue2009SutProject(string sutProjectPath)
@@ -192,10 +193,13 @@ public class ReproTests
 
     using var process = Process.Start(processStartInfo)!;
 
-    string output = await process.StandardOutput.ReadToEndAsync();
-    string error = await process.StandardError.ReadToEndAsync();
+    Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync();
+    Task<string> stderrTask = process.StandardError.ReadToEndAsync();
 
     await process.WaitForExitAsync();
+    await Task.WhenAll(stdoutTask, stderrTask, process.WaitForExitAsync());
+    string output = await stdoutTask;
+    string error = await stderrTask;
 
     return new TestResult(
       process.ExitCode,

--- a/test/coverlet.collector.tests/CoverletInProcDataCollectorTests.cs
+++ b/test/coverlet.collector.tests/CoverletInProcDataCollectorTests.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Concurrent;
+using System.Collections.Generic;
 using Coverlet.Collector.DataCollection;
 using Coverlet.Collector.Utilities;
 using Coverlet.Core.Instrumentation;
@@ -35,8 +35,13 @@ namespace Coverlet.Collector.Tests.DataCollection
       // Regression test for Fix 1 in issue #1983: TestSessionEnd must invoke handlers from the AppDomain registry.
       bool handlerCalled = false;
 
-      var bag = (ConcurrentBag<EventHandler>)AppDomain.CurrentDomain.GetData(ModuleTrackerTemplate.ModuleTrackerRegistryKey);
-      bag?.Add(new((_, _) => { handlerCalled = true; }));
+      if (AppDomain.CurrentDomain.GetData(ModuleTrackerTemplate.ModuleTrackerRegistryKey) is List<EventHandler> handlers)
+      {
+        lock (handlers)
+        {
+          handlers.Add(new((_, _) => { handlerCalled = true; }));
+        }
+      }
 
       _dataCollector.TestSessionEnd(new TestSessionEndArgs());
 
@@ -48,8 +53,13 @@ namespace Coverlet.Collector.Tests.DataCollection
     {
       // Regression test for Fix 4 in issue #1983: a failing handler must be logged but must not
       // propagate by default, so coverage failures do not abort the test run.
-      var bag = (ConcurrentBag<EventHandler>)AppDomain.CurrentDomain.GetData(ModuleTrackerTemplate.ModuleTrackerRegistryKey);
-      bag?.Add(new((_, _) => throw new InvalidOperationException("simulated flush failure")));
+      if (AppDomain.CurrentDomain.GetData(ModuleTrackerTemplate.ModuleTrackerRegistryKey) is List<EventHandler> handlers)
+      {
+        lock (handlers)
+        {
+          handlers.Add(new((_, _) => throw new InvalidOperationException("simulated flush failure")));
+        }
+      }
 
       _dataCollector.TestSessionEnd(new TestSessionEndArgs());
     }
@@ -66,8 +76,13 @@ namespace Coverlet.Collector.Tests.DataCollection
         collector.Initialize(new Mock<IDataCollectionSink>().Object);
 
         bool handlerCalled = false;
-        var bag = (ConcurrentBag<EventHandler>)AppDomain.CurrentDomain.GetData(ModuleTrackerTemplate.ModuleTrackerRegistryKey);
-        bag?.Add(new((_, _) => { handlerCalled = true; }));
+        if (AppDomain.CurrentDomain.GetData(ModuleTrackerTemplate.ModuleTrackerRegistryKey) is List<EventHandler> handlers)
+        {
+          lock (handlers)
+          {
+            handlers.Add(new((_, _) => { handlerCalled = true; }));
+          }
+        }
 
         collector.TestSessionEnd(new TestSessionEndArgs());
 
@@ -90,8 +105,13 @@ namespace Coverlet.Collector.Tests.DataCollection
         var collector = new CoverletInProcDataCollector();
         collector.Initialize(new Mock<IDataCollectionSink>().Object);
 
-        var bag = (ConcurrentBag<EventHandler>)AppDomain.CurrentDomain.GetData(ModuleTrackerTemplate.ModuleTrackerRegistryKey);
-        bag?.Add(new((_, _) => throw new InvalidOperationException("simulated flush failure")));
+        if (AppDomain.CurrentDomain.GetData(ModuleTrackerTemplate.ModuleTrackerRegistryKey) is List<EventHandler> handlers)
+        {
+          lock (handlers)
+          {
+            handlers.Add(new((_, _) => throw new InvalidOperationException("simulated flush failure")));
+          }
+        }
 
         Assert.Throws<CoverletDataCollectorException>(() => collector.TestSessionEnd(new TestSessionEndArgs()));
       }

--- a/test/coverlet.core.coverage.tests/Instrumentation/ModuleTrackerTemplateTests.cs
+++ b/test/coverlet.core.coverage.tests/Instrumentation/ModuleTrackerTemplateTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
@@ -150,12 +149,17 @@ namespace Coverlet.Core.Tests.Instrumentation
         using var ctx = new TrackerContext();
         ModuleTrackerTemplate.HitsArray = [3, 1, 4];
 
-        // Simulate Initialize pre-creating the bag, then module load calling RegisterUnloadEvents.
-        var bag = new ConcurrentBag<EventHandler>();
-        AppDomain.CurrentDomain.SetData(ModuleTrackerTemplate.ModuleTrackerRegistryKey, bag);
+        // Simulate Initialize pre-creating the registry, then module load calling RegisterUnloadEvents.
+        var handlers = new List<EventHandler>();
+        AppDomain.CurrentDomain.SetData(ModuleTrackerTemplate.ModuleTrackerRegistryKey, handlers);
         ModuleTrackerTemplate.RegisterUnloadEvents();
 
-        EventHandler handler = Assert.Single(bag);
+        EventHandler handler;
+        lock (handlers)
+        {
+          handler = Assert.Single(handlers);
+        }
+
         handler.Invoke(null, EventArgs.Empty);
         int[] expectedHitsArray = [3, 1, 4];
         Assert.Equal(expectedHitsArray, ReadHitsFile());


### PR DESCRIPTION
Replaces ConcurrentBag<EventHandler> with List<EventHandler> for module unload handler registry in Coverlet's in-process data collection. All registry accesses are now protected by locking for thread safety. Updates CoverletInProcessHandler, CoverletInProcDataCollector, ModuleTrackerTemplate, and related tests to use List. Adds Issue2009NetFrameworkRegressionTests to verify .NET Framework scenarios do not throw TypeLoadException for missing ConcurrentBag, resolving issue #2009.